### PR TITLE
build: add PKGBUILD for Arch linux

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -26,3 +26,26 @@ jobs:
         run: |
           cd build
           make runTest
+
+  build_archlinux:
+    runs-on: ubuntu-latest
+    container: ghcr.io/xatier/arch-dev:latest
+
+    steps:
+      - name: Checkout
+        run: |
+          export HOME=/home/xatier
+          cd /home/xatier
+          echo "cloning $GITHUB_SERVER_URL/$GITHUB_REPOSITORY into $PWD $GITHUB_SHA"
+          git clone "$GITHUB_SERVER_URL/$GITHUB_REPOSITORY"
+
+          cd /home/xatier/fcitx5-mcbopomofo
+          git fetch origin "$GITHUB_REF" ||:
+          git checkout "$GITHUB_SHA"
+
+      - name: Build
+        run: |
+          export HOME=/home/xatier
+          cd /home/xatier/fcitx5-mcbopomofo/distro/archlinux/
+          sudo pacman -Syy
+          makepkg -s --noconfirm

--- a/distro/archlinux/PKGBUILD
+++ b/distro/archlinux/PKGBUILD
@@ -1,0 +1,38 @@
+# Contributor: xatier
+_pkgname=fcitx5-mcbopomofo
+pkgname=fcitx5-mcbopomofo-git
+pkgver=97.f08da14
+pkgrel=1
+pkgdesc="McBopomofo for fcitx5"
+arch=('x86_64')
+url="https://github.com/openvanilla/fcitx5-mcbopomofo"
+license=('MIT')
+depends=('fcitx5')
+makedepends=('cmake' 'extra-cmake-modules')
+optdepends=()
+conflicts=('fcitx5-mcbopomofo')
+provides=('fcitx5-mcbopomofo')
+source=("${_pkgname}::git+https://github.com/openvanilla/fcitx5-mcbopomofo.git")
+sha512sums=('SKIP')
+
+pkgver() {
+    cd "${srcdir}/${_pkgname}"
+    echo "$(git rev-list --count HEAD).$(git rev-parse --short HEAD)"
+}
+
+build() {
+    cd "${srcdir}/${_pkgname}"
+    mkdir -p build
+    cd build
+    cmake ../ -DCMAKE_INSTALL_PREFIX=/usr
+    make
+}
+
+package() {
+    cd "${srcdir}/${_pkgname}/build"
+    make DESTDIR="${pkgdir}" install
+
+    # install licence files
+    install -dm755 "${pkgdir}/usr/share/licenses/${_pkgname}/"
+    install -Dm644 "${srcdir}/${_pkgname}/LICENSE.txt" "${pkgdir}/usr/share/licenses/${_pkgname}/"
+}


### PR DESCRIPTION
It seems like `actions/checkout@v3` is not quite workig with Arch containers though :- 