### PR TITLE
Use heuristics for when to ignore FocusOut events

### DIFF
--- a/src/KeyHandler.cpp
+++ b/src/KeyHandler.cpp
@@ -82,7 +82,7 @@ static bool MarkedPhraseExists(Formosa::Gramambular::LanguageModel* lm,
                      });
 }
 
-static double GetNow() {
+static double GetEpochNowInSeconds() {
   auto now = std::chrono::system_clock::now();
   int64_t timestamp = std::chrono::time_point_cast<std::chrono::seconds>(now)
                           .time_since_epoch()
@@ -153,7 +153,7 @@ bool KeyHandler::handle(fcitx::Key key, McBopomofo::InputState* state,
     std::string evictedText = popEvictedTextAndWalk();
 
     std::string overrideValue = userOverrideModel_.suggest(
-        walkedNodes_, builder_->cursorIndex(), GetNow());
+        walkedNodes_, builder_->cursorIndex(), GetEpochNowInSeconds());
     if (!overrideValue.empty()) {
       size_t cursorIndex = actualCandidateCursorIndex();
       std::vector<Formosa::Gramambular::NodeAnchor> nodes =
@@ -671,7 +671,8 @@ void KeyHandler::pinNode(const std::string& candidate) {
       builder_->grid().fixNodeSelectedCandidate(cursorIndex, candidate);
   double score = selectedNode.node->scoreForCandidate(candidate);
   if (score > kNoOverrideThreshold) {
-    userOverrideModel_.observe(walkedNodes_, cursorIndex, candidate, GetNow());
+    userOverrideModel_.observe(walkedNodes_, cursorIndex, candidate,
+                               GetEpochNowInSeconds());
   }
 
   walk();

--- a/src/McBopomofo.h
+++ b/src/McBopomofo.h
@@ -155,6 +155,7 @@ class McBopomofoEngine : public fcitx::InputMethodEngine {
   std::shared_ptr<LanguageModelLoader> languageModelLoader_;
   std::unique_ptr<KeyHandler> keyHandler_;
   std::unique_ptr<InputState> state_;
+  int64_t stateCommittedTimestampMicroseconds_;
   McBopomofoConfig config_;
   fcitx::KeyList selectionKeys_;
 


### PR DESCRIPTION
Experiments showed that manually triggered context switch
(activate->reset) actually takes ~200 ms to complete (which is a bit
surprising, by the way). Anything below that latency can only be due to
non-manual triggers like FocusOut. We therefore use heuristics and a
lower threshold (90 ms, or 90,000 microsecnds) to determine when
FocusOut should be ignored if the current state is Inputting and it has
recently evicted (so committed) some overflow text.

Fixes #24.