### PR TITLE
Allow disabling test target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,6 +10,8 @@ include(GNUInstallDirs)
 include(ECMSetupVersion)
 include(ECMUninstallTarget)
 
+option(ENABLE_TEST "Build Test" On)
+
 find_package(fmt REQUIRED)
 find_package(Gettext REQUIRED)
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -49,31 +49,33 @@ configure_file(mcbopomofo.conf.in.in mcbopomofo.conf.in)
 fcitx5_translate_desktop_file("${CMAKE_CURRENT_BINARY_DIR}/mcbopomofo.conf.in" mcbopomofo.conf)
 install(FILES "${CMAKE_CURRENT_BINARY_DIR}/mcbopomofo.conf" DESTINATION "${FCITX_INSTALL_PKGDATADIR}/inputmethod")
 
-# Let CMake fetch Google Test for us.
-# https://github.com/google/googletest/tree/main/googletest#incorporating-into-an-existing-cmake-project
-include(FetchContent)
+if (ENABLE_TEST)
+    # Let CMake fetch Google Test for us.
+    # https://github.com/google/googletest/tree/main/googletest#incorporating-into-an-existing-cmake-project
+    include(FetchContent)
 
-FetchContent_Declare(
-        googletest
-        # Specify the commit you depend on and update it regularly.
-        URL https://github.com/google/googletest/archive/609281088cfefc76f9d0ce82e1ff6c30cc3591e5.zip
-)
-# For Windows: Prevent overriding the parent project's compiler/linker settings
-set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
-FetchContent_MakeAvailable(googletest)
+    FetchContent_Declare(
+            googletest
+            # Specify the commit you depend on and update it regularly.
+            URL https://github.com/google/googletest/archive/609281088cfefc76f9d0ce82e1ff6c30cc3591e5.zip
+    )
+    # For Windows: Prevent overriding the parent project's compiler/linker settings
+    set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
+    FetchContent_MakeAvailable(googletest)
 
-include(GoogleTest)
+    include(GoogleTest)
 
-# Test target declarations.
-add_executable(McBopomofoTest
-        KeyHandlerTest.cpp)
-target_link_libraries(McBopomofoTest PRIVATE Fcitx5::Core gtest_main McBopomofoLib)
-target_include_directories(McBopomofoTest PRIVATE Fcitx5::Core GoogleTest)
+    # Test target declarations.
+    add_executable(McBopomofoTest
+            KeyHandlerTest.cpp)
+    target_link_libraries(McBopomofoTest PRIVATE Fcitx5::Core gtest_main McBopomofoLib)
+    target_include_directories(McBopomofoTest PRIVATE Fcitx5::Core GoogleTest)
 
-gtest_discover_tests(McBopomofoTest)
+    gtest_discover_tests(McBopomofoTest)
 
-add_custom_target(
-        runTest
-        COMMAND ${CMAKE_CURRENT_BINARY_DIR}/McBopomofoTest
-)
-add_dependencies(runTest McBopomofoTest)
+    add_custom_target(
+            runTest
+            COMMAND ${CMAKE_CURRENT_BINARY_DIR}/McBopomofoTest
+    )
+    add_dependencies(runTest McBopomofoTest)
+endif ()


### PR DESCRIPTION
FetchContent requires networking, which I don't have when building a Flatpak package, as disabling networking is a Flathub policy, so I suggest making the test target optional.