### PR TITLE
Various features

### DIFF
--- a/po/en.po
+++ b/po/en.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: fcitx5-mcbopomofo v0.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-03-29 10:16-0700\n"
+"POT-Creation-Date: 2022-04-03 23:21+0800\n"
 "PO-Revision-Date: 2022-03-22 20:28-0700\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -17,11 +17,11 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: src/McBopomofo.cpp:175
+#: src/McBopomofo.cpp:76
 msgid "Edit User Phrases"
 msgstr ""
 
-#: src/McBopomofo.cpp:185
+#: src/McBopomofo.cpp:85
 msgid "Edit Excluded Phrases"
 msgstr ""
 
@@ -69,50 +69,62 @@ msgstr "Before the Cursor (Like Hanin)"
 msgid "after_cursor"
 msgstr "After the Cursor (Like MS IME)"
 
-#: src/McBopomofo.h:80
-msgid "Bopomofo Keyboard Layout"
+#: src/McBopomofo.h:76
+msgid "Directly Output Uppercased Letters"
+msgstr ""
+
+#: src/McBopomofo.h:77
+msgid "Put Lowercased Letters to Composing Buffer"
 msgstr ""
 
 #: src/McBopomofo.h:85
-msgid "Selection Keys"
+msgid "Bopomofo Keyboard Layout"
 msgstr ""
 
 #: src/McBopomofo.h:90
+msgid "Selection Keys"
+msgstr ""
+
+#: src/McBopomofo.h:95
 msgid "Show Candidate Phrase"
 msgstr "Show Candidates"
 
-#: src/McBopomofo.h:94
+#: src/McBopomofo.h:100
 msgid "Move cursor after selection"
 msgstr ""
 
-#: src/McBopomofo.h:102
-msgid "Map Dvorak to QWERTY"
+#: src/McBopomofo.h:105
+msgid "Shift + Letter Keys"
 msgstr ""
 
-#: src/KeyHandler.cpp:519
+#: src/KeyHandler.cpp:570
 msgid "Cursor is between syllables {0} and {1}"
 msgstr ""
 
-#: src/KeyHandler.cpp:611
+#: src/KeyHandler.cpp:662
 msgid "{0} syllables required"
 msgstr ""
 
-#: src/KeyHandler.cpp:614
+#: src/KeyHandler.cpp:665
 msgid "{0} syllables maximum"
 msgstr ""
 
-#: src/KeyHandler.cpp:617
+#: src/KeyHandler.cpp:668
 msgid "phrase already exists"
 msgstr ""
 
-#: src/KeyHandler.cpp:619
+#: src/KeyHandler.cpp:670
 msgid "press Enter to add the phrase"
 msgstr ""
 
-#: src/KeyHandler.cpp:623
+#: src/KeyHandler.cpp:674
 msgid "Marked: {0}, syllables: {1}, {2}"
 msgstr ""
 
 #: src/mcbopomofo.conf.in.in:3 src/mcbopomofo-addon.conf.in.in:3
 msgid "McBopomofo"
+msgstr ""
+
+#: src/mcbopomofo-addon.conf.in.in:4
+msgid "McBopomofo Wrapper For Fcitx"
 msgstr ""

--- a/po/en.po
+++ b/po/en.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: fcitx5-mcbopomofo v0.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-04-03 23:21+0800\n"
+"POT-Creation-Date: 2022-04-04 03:20+0800\n"
 "PO-Revision-Date: 2022-03-22 20:28-0700\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -93,31 +93,35 @@ msgstr "Show Candidates"
 msgid "Move cursor after selection"
 msgstr ""
 
-#: src/McBopomofo.h:105
+#: src/McBopomofo.h:106
+msgid "ESC key clears entire composing buffer"
+msgstr ""
+
+#: src/McBopomofo.h:110
 msgid "Shift + Letter Keys"
 msgstr ""
 
-#: src/KeyHandler.cpp:570
+#: src/KeyHandler.cpp:581
 msgid "Cursor is between syllables {0} and {1}"
 msgstr ""
 
-#: src/KeyHandler.cpp:662
+#: src/KeyHandler.cpp:673
 msgid "{0} syllables required"
 msgstr ""
 
-#: src/KeyHandler.cpp:665
+#: src/KeyHandler.cpp:676
 msgid "{0} syllables maximum"
 msgstr ""
 
-#: src/KeyHandler.cpp:668
+#: src/KeyHandler.cpp:679
 msgid "phrase already exists"
 msgstr ""
 
-#: src/KeyHandler.cpp:670
+#: src/KeyHandler.cpp:681
 msgid "press Enter to add the phrase"
 msgstr ""
 
-#: src/KeyHandler.cpp:674
+#: src/KeyHandler.cpp:685
 msgid "Marked: {0}, syllables: {1}, {2}"
 msgstr ""
 

--- a/po/en.po
+++ b/po/en.po
@@ -70,11 +70,11 @@ msgid "after_cursor"
 msgstr "After the Cursor (Like MS IME)"
 
 #: src/McBopomofo.h:76
-msgid "Directly Output Uppercased Letters"
+msgid "Directly Output Uppercase Letters"
 msgstr ""
 
 #: src/McBopomofo.h:77
-msgid "Put Lowercased Letters to Composing Buffer"
+msgid "Put Lowercase Letters to Composing Buffer"
 msgstr ""
 
 #: src/McBopomofo.h:85
@@ -130,5 +130,5 @@ msgid "McBopomofo"
 msgstr ""
 
 #: src/mcbopomofo-addon.conf.in.in:4
-msgid "McBopomofo Wrapper For Fcitx"
+msgid "McBopomofo Input Method For Fcitx"
 msgstr ""

--- a/po/zh_TW.po
+++ b/po/zh_TW.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: fcitx5-mcbopomofo v0.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-04-03 23:21+0800\n"
+"POT-Creation-Date: 2022-04-04 03:20+0800\n"
 "PO-Revision-Date: 2022-03-22 20:28-0700\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -93,31 +93,35 @@ msgstr "選字時，候選詞起算點"
 msgid "Move cursor after selection"
 msgstr "選字後自動移動游標"
 
-#: src/McBopomofo.h:105
+#: src/McBopomofo.h:106
+msgid "ESC key clears entire composing buffer"
+msgstr "ESC 按鍵清除輸入緩衝區的所有內容"
+
+#: src/McBopomofo.h:110
 msgid "Shift + Letter Keys"
 msgstr "Shift + 字母按鍵"
 
-#: src/KeyHandler.cpp:570
+#: src/KeyHandler.cpp:581
 msgid "Cursor is between syllables {0} and {1}"
 msgstr "游標在「{0}」與「{1}」之間"
 
-#: src/KeyHandler.cpp:662
+#: src/KeyHandler.cpp:673
 msgid "{0} syllables required"
 msgstr "至少需要選取{0}個字"
 
-#: src/KeyHandler.cpp:665
+#: src/KeyHandler.cpp:676
 msgid "{0} syllables maximum"
 msgstr "最多只能選取{0}個字"
 
-#: src/KeyHandler.cpp:668
+#: src/KeyHandler.cpp:679
 msgid "phrase already exists"
 msgstr "詞庫已經有這個詞"
 
-#: src/KeyHandler.cpp:670
+#: src/KeyHandler.cpp:681
 msgid "press Enter to add the phrase"
 msgstr "請按 Enter 加入自訂詞庫"
 
-#: src/KeyHandler.cpp:674
+#: src/KeyHandler.cpp:685
 msgid "Marked: {0}, syllables: {1}, {2}"
 msgstr "選取了「{0}」，注音「{1}」：{2}"
 
@@ -128,4 +132,3 @@ msgstr "小麥注音"
 #: src/mcbopomofo-addon.conf.in.in:4
 msgid "McBopomofo Wrapper For Fcitx"
 msgstr "Fctix 的小麥注音封裝"
-

--- a/po/zh_TW.po
+++ b/po/zh_TW.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: fcitx5-mcbopomofo v0.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-03-29 10:16-0700\n"
+"POT-Creation-Date: 2022-04-03 23:21+0800\n"
 "PO-Revision-Date: 2022-03-22 20:28-0700\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -17,11 +17,11 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src/McBopomofo.cpp:175
+#: src/McBopomofo.cpp:76
 msgid "Edit User Phrases"
 msgstr "編輯使用者詞彙"
 
-#: src/McBopomofo.cpp:185
+#: src/McBopomofo.cpp:85
 msgid "Edit Excluded Phrases"
 msgstr "編輯排除的詞彙"
 
@@ -69,50 +69,63 @@ msgstr "游標前面（像漢音輸入法）"
 msgid "after_cursor"
 msgstr "游標後面（像微軟新注音）"
 
-#: src/McBopomofo.h:80
+#: src/McBopomofo.h:76
+msgid "Directly Output Uppercased Letters"
+msgstr "直接輸入大寫字母"
+
+#: src/McBopomofo.h:77
+msgid "Put Lowercased Letters to Composing Buffer"
+msgstr "在輸入緩衝區中輸入小寫字母"
+
+#: src/McBopomofo.h:85
 msgid "Bopomofo Keyboard Layout"
 msgstr "注音鍵盤配置"
 
-#: src/McBopomofo.h:85
+#: src/McBopomofo.h:90
 msgid "Selection Keys"
 msgstr "選字鍵"
 
-#: src/McBopomofo.h:90
+#: src/McBopomofo.h:95
 msgid "Show Candidate Phrase"
 msgstr "選字時，候選詞起算點"
 
-#: src/McBopomofo.h:94
+#: src/McBopomofo.h:100
 msgid "Move cursor after selection"
 msgstr "選字後自動移動游標"
 
-#: src/McBopomofo.h:102
-msgid "Map Dvorak to QWERTY"
-msgstr "將 Dvorak 鍵盤字元對應回 QWERTY"
+#: src/McBopomofo.h:105
+msgid "Shift + Letter Keys"
+msgstr "Shift + 字母按鍵"
 
-#: src/KeyHandler.cpp:519
+#: src/KeyHandler.cpp:570
 msgid "Cursor is between syllables {0} and {1}"
 msgstr "游標在「{0}」與「{1}」之間"
 
-#: src/KeyHandler.cpp:611
+#: src/KeyHandler.cpp:662
 msgid "{0} syllables required"
 msgstr "至少需要選取{0}個字"
 
-#: src/KeyHandler.cpp:614
+#: src/KeyHandler.cpp:665
 msgid "{0} syllables maximum"
 msgstr "最多只能選取{0}個字"
 
-#: src/KeyHandler.cpp:617
+#: src/KeyHandler.cpp:668
 msgid "phrase already exists"
 msgstr "詞庫已經有這個詞"
 
-#: src/KeyHandler.cpp:619
+#: src/KeyHandler.cpp:670
 msgid "press Enter to add the phrase"
 msgstr "請按 Enter 加入自訂詞庫"
 
-#: src/KeyHandler.cpp:623
+#: src/KeyHandler.cpp:674
 msgid "Marked: {0}, syllables: {1}, {2}"
 msgstr "選取了「{0}」，注音「{1}」：{2}"
 
 #: src/mcbopomofo.conf.in.in:3 src/mcbopomofo-addon.conf.in.in:3
 msgid "McBopomofo"
 msgstr "小麥注音"
+
+#: src/mcbopomofo-addon.conf.in.in:4
+msgid "McBopomofo Wrapper For Fcitx"
+msgstr "Fctix 的小麥注音封裝"
+

--- a/po/zh_TW.po
+++ b/po/zh_TW.po
@@ -70,11 +70,11 @@ msgid "after_cursor"
 msgstr "游標後面（像微軟新注音）"
 
 #: src/McBopomofo.h:76
-msgid "Directly Output Uppercased Letters"
+msgid "Directly Output Uppercase Letters"
 msgstr "直接輸入大寫字母"
 
 #: src/McBopomofo.h:77
-msgid "Put Lowercased Letters to Composing Buffer"
+msgid "Put Lowercase Letters to Composing Buffer"
 msgstr "在輸入緩衝區中輸入小寫字母"
 
 #: src/McBopomofo.h:85
@@ -130,5 +130,5 @@ msgid "McBopomofo"
 msgstr "小麥注音"
 
 #: src/mcbopomofo-addon.conf.in.in:4
-msgid "McBopomofo Wrapper For Fcitx"
-msgstr "Fctix 的小麥注音封裝"
+msgid "McBopomofo Input Method For Fcitx"
+msgstr "Fctix 的小麥注音輸入法"

--- a/src/KeyHandler.cpp
+++ b/src/KeyHandler.cpp
@@ -207,6 +207,12 @@ bool KeyHandler::handle(fcitx::Key key, McBopomofo::InputState* state,
       return false;
     }
 
+    if (escKeyClearsEntireComposingBuffer_) {
+      reset();
+      stateCallback(std::make_unique<InputStates::EmptyIgnoringPrevious>());
+      return true;
+    }
+
     if (!reading_.isEmpty()) {
       reading_.clear();
       if (!builder_->length()) {
@@ -375,6 +381,10 @@ void KeyHandler::setMoveCursorAfterSelection(bool flag) {
 
 void KeyHandler::setPutLowercasedLettersToComposingBuffer(bool flag) {
   putLowercasedLettersToComposingBuffer_ = flag;
+}
+
+void KeyHandler::setEscKeyClearsEntireComposingBuffer(bool flag) {
+  escKeyClearsEntireComposingBuffer_ = flag;
 }
 
 bool KeyHandler::handleCursorKeys(fcitx::Key key, McBopomofo::InputState* state,

--- a/src/KeyHandler.cpp
+++ b/src/KeyHandler.cpp
@@ -172,7 +172,7 @@ bool KeyHandler::handle(fcitx::Key key, McBopomofo::InputState* state,
 
   // Shift + Space
   if (key.check(FcitxKey_space, fcitx::KeyState::Shift)) {
-    if (putLowercasedLettersToComposingBuffer_) {
+    if (putLowercaseLettersToComposingBuffer_) {
       builder_->insertReadingAtCursor(" ");
       std::string evictedText = popEvictedTextAndWalk();
       auto inputtingState = buildInputtingState();
@@ -318,7 +318,7 @@ bool KeyHandler::handle(fcitx::Key key, McBopomofo::InputState* state,
 
     // Upper case letters.
     if (asciiChar >= 'A' && asciiChar <= 'Z') {
-      if (putLowercasedLettersToComposingBuffer_) {
+      if (putLowercaseLettersToComposingBuffer_) {
         unigram = std::string(kLetterPrefix) + chrStr;
         if (handlePunctuation(unigram, stateCallback, errorCallback)) {
           return true;
@@ -379,8 +379,8 @@ void KeyHandler::setMoveCursorAfterSelection(bool flag) {
   moveCursorAfterSelection_ = flag;
 }
 
-void KeyHandler::setPutLowercasedLettersToComposingBuffer(bool flag) {
-  putLowercasedLettersToComposingBuffer_ = flag;
+void KeyHandler::setPutLowercaseLettersToComposingBuffer(bool flag) {
+  putLowercaseLettersToComposingBuffer_ = flag;
 }
 
 void KeyHandler::setEscKeyClearsEntireComposingBuffer(bool flag) {

--- a/src/KeyHandler.cpp
+++ b/src/KeyHandler.cpp
@@ -37,6 +37,7 @@ namespace McBopomofo {
 constexpr char kJoinSeparator[] = "-";
 constexpr char kPunctuationListKey[] = "_punctuation_list";
 constexpr char kPunctuationKeyPrefix[] = "_punctuation_";
+constexpr char kLetterPrefix[] = "_letter_";
 constexpr size_t kMinValidMarkingReadingCount = 2;
 constexpr size_t kMaxValidMarkingReadingCount = 6;
 
@@ -169,6 +170,29 @@ bool KeyHandler::handle(fcitx::Key key, McBopomofo::InputState* state,
     return true;
   }
 
+  // Shift + Space
+  if (key.check(FcitxKey_space, fcitx::KeyState::Shift)) {
+    if (putLowercasedLettersToComposingBuffer_) {
+      builder_->insertReadingAtCursor(" ");
+      std::string evictedText = popEvictedTextAndWalk();
+      auto inputtingState = buildInputtingState();
+      inputtingState->evictedText = evictedText;
+      stateCallback(std::move(inputtingState));
+    } else {
+      if (builder_->length()) {
+        auto inputtingState = buildInputtingState();
+        // Steal the composingBuffer built by the inputting state.
+        auto committingState = std::make_unique<InputStates::Committing>(
+            inputtingState->composingBuffer);
+        stateCallback(std::move(committingState));
+      }
+      auto committingState = std::make_unique<InputStates::Committing>(" ");
+      stateCallback(std::move(committingState));
+      reset();
+    }
+    return true;
+  }
+
   // Space hit: see if we should enter the candidate choosing state.
   auto maybeNotEmptyState = dynamic_cast<InputStates::NotEmpty*>(state);
   if (key.check(FcitxKey_space) && maybeNotEmptyState != nullptr &&
@@ -285,6 +309,29 @@ bool KeyHandler::handle(fcitx::Key key, McBopomofo::InputState* state,
     if (handlePunctuation(unigram, stateCallback, errorCallback)) {
       return true;
     }
+
+    // Upper case letters.
+    if (asciiChar >= 'A' && asciiChar <= 'Z') {
+      if (putLowercasedLettersToComposingBuffer_) {
+        unigram = std::string(kLetterPrefix) + chrStr;
+        if (handlePunctuation(unigram, stateCallback, errorCallback)) {
+          return true;
+        }
+      } else {
+        if (builder_->length()) {
+          auto inputtingState = buildInputtingState();
+          // Steal the composingBuffer built by the inputting state.
+          auto committingState = std::make_unique<InputStates::Committing>(
+              inputtingState->composingBuffer);
+          stateCallback(std::move(committingState));
+        }
+        auto committingState =
+            std::make_unique<InputStates::Committing>(chrStr);
+        stateCallback(std::move(committingState));
+        reset();
+      }
+      return true;
+    }
   }
 
   // No key is handled. Refresh and consume the key.
@@ -324,6 +371,10 @@ void KeyHandler::setSelectPhraseAfterCursorAsCandidate(bool flag) {
 
 void KeyHandler::setMoveCursorAfterSelection(bool flag) {
   moveCursorAfterSelection_ = flag;
+}
+
+void KeyHandler::setPutLowercasedLettersToComposingBuffer(bool flag) {
+  putLowercasedLettersToComposingBuffer_ = flag;
 }
 
 bool KeyHandler::handleCursorKeys(fcitx::Key key, McBopomofo::InputState* state,

--- a/src/KeyHandler.h
+++ b/src/KeyHandler.h
@@ -77,7 +77,7 @@ class KeyHandler {
   void setMoveCursorAfterSelection(bool flag);
 
   // Sets if we should put lowercasesd letters into the composing buffer.
-  void setPutLowercasedLettersToComposingBuffer(bool flag);
+  void setPutLowercaseLettersToComposingBuffer(bool flag);
 
   /// Sets if the ESC key clears enture composing buffer.
   void setEscKeyClearsEntireComposingBuffer(bool flag);
@@ -138,7 +138,7 @@ class KeyHandler {
 
   bool selectPhraseAfterCursorAsCandidate_;
   bool moveCursorAfterSelection_;
-  bool putLowercasedLettersToComposingBuffer_;
+  bool putLowercaseLettersToComposingBuffer_;
   bool escKeyClearsEntireComposingBuffer_;
 };
 

--- a/src/KeyHandler.h
+++ b/src/KeyHandler.h
@@ -70,11 +70,14 @@ class KeyHandler {
   void setKeyboardLayout(
       const Formosa::Mandarin::BopomofoKeyboardLayout* layout);
 
-  // Sets select phrase after cursor as candidate.
+  // Sets if we should select phrase after cursor as candidate.
   void setSelectPhraseAfterCursorAsCandidate(bool flag);
 
-  // Sets move cursor after selection.
+  // Sets if we should move cursor after selection.
   void setMoveCursorAfterSelection(bool flag);
+
+  // Sets if we should put lowercasesd letters into the composing buffer.
+  void setPutLowercasedLettersToComposingBuffer(bool flag);
 
  private:
   bool handleCursorKeys(fcitx::Key key, McBopomofo::InputState* state,
@@ -132,6 +135,7 @@ class KeyHandler {
 
   bool selectPhraseAfterCursorAsCandidate_;
   bool moveCursorAfterSelection_;
+  bool putLowercasedLettersToComposingBuffer_;
 };
 
 }  // namespace McBopomofo

--- a/src/KeyHandler.h
+++ b/src/KeyHandler.h
@@ -79,6 +79,9 @@ class KeyHandler {
   // Sets if we should put lowercasesd letters into the composing buffer.
   void setPutLowercasedLettersToComposingBuffer(bool flag);
 
+  /// Sets if the ESC key clears enture composing buffer.
+  void setEscKeyClearsEntireComposingBuffer(bool flag);
+
  private:
   bool handleCursorKeys(fcitx::Key key, McBopomofo::InputState* state,
                         const StateCallback& stateCallback,
@@ -136,6 +139,7 @@ class KeyHandler {
   bool selectPhraseAfterCursorAsCandidate_;
   bool moveCursorAfterSelection_;
   bool putLowercasedLettersToComposingBuffer_;
+  bool escKeyClearsEntireComposingBuffer_;
 };
 
 }  // namespace McBopomofo

--- a/src/McBopomofo.cpp
+++ b/src/McBopomofo.cpp
@@ -153,6 +153,10 @@ void McBopomofoEngine::activate(const fcitx::InputMethodEntry&,
   keyHandler_->setMoveCursorAfterSelection(
       config_.moveCursorAfterSelection.value());
 
+  keyHandler_->setPutLowercasedLettersToComposingBuffer(
+      config_.shiftLetterKeys.value() ==
+      ShiftLetterKeys::PutLowercasedToBuffer);
+
   languageModelLoader_->reloadUserModelsIfNeeded();
 }
 

--- a/src/McBopomofo.cpp
+++ b/src/McBopomofo.cpp
@@ -153,6 +153,9 @@ void McBopomofoEngine::activate(const fcitx::InputMethodEntry&,
   keyHandler_->setMoveCursorAfterSelection(
       config_.moveCursorAfterSelection.value());
 
+  keyHandler_->setEscKeyClearsEntireComposingBuffer(
+      config_.escKeyClearsEntireComposingBuffer.value());
+
   keyHandler_->setPutLowercasedLettersToComposingBuffer(
       config_.shiftLetterKeys.value() ==
       ShiftLetterKeys::PutLowercasedToBuffer);

--- a/src/McBopomofo.cpp
+++ b/src/McBopomofo.cpp
@@ -253,7 +253,7 @@ void McBopomofoEngine::handleCandidateKeyEvent(
     }
   }
 
-  if (key.check(FcitxKey_Escape)) {
+  if (key.check(FcitxKey_Escape) || key.check(FcitxKey_BackSpace)) {
     keyHandler_->candidatePanelCancelled(
         [this, context](std::unique_ptr<InputState> next) {
           enterNewState(context, std::move(next));
@@ -279,13 +279,17 @@ void McBopomofoEngine::handleCandidateKeyEvent(
                                             fcitx::Key(FcitxKey_Left),
                                             fcitx::Key(FcitxKey_Up)};
 
-  if (key.checkKeyList(nextKeys) && candidateList->hasNext()) {
+  if ((key.checkKeyList(nextKeys) ||
+       key.checkKeyList(instance_->globalConfig().defaultNextPage())) &&
+      candidateList->hasNext()) {
     candidateList->next();
     context->updateUserInterface(fcitx::UserInterfaceComponent::InputPanel);
     return;
   }
 
-  if (key.checkKeyList(prevKeys) && candidateList->hasPrev()) {
+  if ((key.checkKeyList(prevKeys) ||
+       key.checkKeyList(instance_->globalConfig().defaultPrevPage())) &&
+      candidateList->hasPrev()) {
     candidateList->prev();
     context->updateUserInterface(fcitx::UserInterfaceComponent::InputPanel);
     return;

--- a/src/McBopomofo.cpp
+++ b/src/McBopomofo.cpp
@@ -162,9 +162,8 @@ void McBopomofoEngine::activate(const fcitx::InputMethodEntry&,
   keyHandler_->setEscKeyClearsEntireComposingBuffer(
       config_.escKeyClearsEntireComposingBuffer.value());
 
-  keyHandler_->setPutLowercasedLettersToComposingBuffer(
-      config_.shiftLetterKeys.value() ==
-      ShiftLetterKeys::PutLowercasedToBuffer);
+  keyHandler_->setPutLowercaseLettersToComposingBuffer(
+      config_.shiftLetterKeys.value() == ShiftLetterKeys::PutLowercaseToBuffer);
 
   languageModelLoader_->reloadUserModelsIfNeeded();
 }

--- a/src/McBopomofo.cpp
+++ b/src/McBopomofo.cpp
@@ -204,6 +204,13 @@ void McBopomofoEngine::keyEvent(const fcitx::InputMethodEntry&,
   fcitx::InputContext* context = keyEvent.inputContext();
   fcitx::Key key = keyEvent.key();
 
+  if (key.states() & fcitx::KeyState::Ctrl ||
+      key.states() & fcitx::KeyState::Alt ||
+      key.states() & fcitx::KeyState::Super ||
+      key.states() & fcitx::KeyState::CapsLock) {
+    return;
+  }
+
   if (dynamic_cast<InputStates::ChoosingCandidate*>(state_.get()) != nullptr) {
     // Absorb all keys when the candidate panel is on.
     keyEvent.filterAndAccept();
@@ -454,14 +461,14 @@ void McBopomofoEngine::handleMarkingState(fcitx::InputContext* context,
 
 void McBopomofoEngine::updatePreedit(fcitx::InputContext* context,
                                      InputStates::NotEmpty* state) {
-  bool use_client_preedit =
+  bool useClientPreedit =
       context->capabilityFlags().test(fcitx::CapabilityFlag::Preedit);
 #ifdef USE_LEGACY_FCITX5_API
-  fcitx::TextFormatFlags normalFormat{use_client_preedit
+  fcitx::TextFormatFlags normalFormat{useClientPreedit
                                           ? fcitx::TextFormatFlag::Underline
                                           : fcitx::TextFormatFlag::None};
 #else
-  fcitx::TextFormatFlags normalFormat{use_client_preedit
+  fcitx::TextFormatFlags normalFormat{useClientPreedit
                                           ? fcitx::TextFormatFlag::Underline
                                           : fcitx::TextFormatFlag::NoFlag};
 #endif
@@ -475,7 +482,7 @@ void McBopomofoEngine::updatePreedit(fcitx::InputContext* context,
   }
   preedit.setCursor(state->cursorIndex);
 
-  if (use_client_preedit) {
+  if (useClientPreedit) {
     context->inputPanel().setClientPreedit(preedit);
   } else {
     context->inputPanel().setPreedit(preedit);

--- a/src/McBopomofo.cpp
+++ b/src/McBopomofo.cpp
@@ -74,11 +74,10 @@ McBopomofoEngine::McBopomofoEngine(fcitx::Instance* instance)
 
   editUserPhreasesAction_ = std::make_unique<fcitx::SimpleAction>();
   editUserPhreasesAction_->setShortText(_("Edit User Phrases"));
-  editUserPhreasesAction_->connect<fcitx::SimpleAction::Activated>(
-      [this](fcitx::InputContext*) {
-        auto command = "xdg-open " + languageModelLoader_->userPhrasesPath();
-        system(command.c_str());
-      });
+  editUserPhreasesAction_->connect<
+      fcitx::SimpleAction::Activated>([this](fcitx::InputContext*) {
+    fcitx::startProcess({"xdg-open", languageModelLoader_->userPhrasesPath()});
+  });
   instance_->userInterfaceManager().registerAction(
       "mcbopomofo-user-phrases-edit", editUserPhreasesAction_.get());
 
@@ -86,9 +85,8 @@ McBopomofoEngine::McBopomofoEngine(fcitx::Instance* instance)
   excludedPhreasesAction_->setShortText(_("Edit Excluded Phrases"));
   excludedPhreasesAction_->connect<fcitx::SimpleAction::Activated>(
       [this](fcitx::InputContext*) {
-        auto command =
-            "xdg-open " + languageModelLoader_->excludedPhrasesPath();
-        system(command.c_str());
+        fcitx::startProcess(
+            {"xdg-open", languageModelLoader_->excludedPhrasesPath()});
       });
   instance_->userInterfaceManager().registerAction(
       "mcbopomofo-user-excluded-phrases-edit", excludedPhreasesAction_.get());

--- a/src/McBopomofo.h
+++ b/src/McBopomofo.h
@@ -100,6 +100,11 @@ FCITX_CONFIGURATION(
         this, "MoveCursorAfterSelection", _("Move cursor after selection"),
         false};
 
+    // ESC key clears entire composing buffer.
+    fcitx::Option<bool> escKeyClearsEntireComposingBuffer{
+        this, "EscKeyClearsEntireComposingBuffer",
+        _("ESC key clears entire composing buffer"), false};
+
     /// Shift + letter keys.
     fcitx::OptionWithAnnotation<ShiftLetterKeys, ShiftLetterKeysI18NAnnotation>
         shiftLetterKeys{this, "ShiftLetterKeys", _("Shift + Letter Keys"),

--- a/src/McBopomofo.h
+++ b/src/McBopomofo.h
@@ -71,10 +71,10 @@ enum class SelectPhrase { BeforeCursor, AfterCursor };
 FCITX_CONFIG_ENUM_NAME_WITH_I18N(SelectPhrase, N_("before_cursor"),
                                  N_("after_cursor"));
 
-enum class ShiftLetterKeys { DirectlytOutputUppercased, PutLowercasedToBuffer };
+enum class ShiftLetterKeys { DirectlytOutputUppercase, PutLowercaseToBuffer };
 FCITX_CONFIG_ENUM_NAME_WITH_I18N(
-    ShiftLetterKeys, N_("Directly Output Uppercased Letters"),
-    N_("Put Lowercased Letters to Composing Buffer"));
+    ShiftLetterKeys, N_("Directly Output Uppercase Letters"),
+    N_("Put Lowercase Letters to Composing Buffer"));
 
 FCITX_CONFIGURATION(
     McBopomofoConfig,
@@ -108,7 +108,7 @@ FCITX_CONFIGURATION(
     /// Shift + letter keys.
     fcitx::OptionWithAnnotation<ShiftLetterKeys, ShiftLetterKeysI18NAnnotation>
         shiftLetterKeys{this, "ShiftLetterKeys", _("Shift + Letter Keys"),
-                        ShiftLetterKeys::DirectlytOutputUppercased};
+                        ShiftLetterKeys::DirectlytOutputUppercase};
 
 );
 

--- a/src/McBopomofo.h
+++ b/src/McBopomofo.h
@@ -71,6 +71,11 @@ enum class SelectPhrase { BeforeCursor, AfterCursor };
 FCITX_CONFIG_ENUM_NAME_WITH_I18N(SelectPhrase, N_("before_cursor"),
                                  N_("after_cursor"));
 
+enum class ShiftLetterKeys { DirectlytOutputUppercased, PutLowercasedToBuffer };
+FCITX_CONFIG_ENUM_NAME_WITH_I18N(
+    ShiftLetterKeys, N_("Directly Output Uppercased Letters"),
+    N_("Put Lowercased Letters to Composing Buffer"));
+
 FCITX_CONFIGURATION(
     McBopomofoConfig,
     // Keyboard layout: standard, eten, etc.
@@ -92,8 +97,15 @@ FCITX_CONFIGURATION(
 
     // Move the cursor at the end of the selected candidate phrase.
     fcitx::Option<bool> moveCursorAfterSelection{
-        this, "moveCursorAfterSelection", _("Move cursor after selection"),
-        false};);
+        this, "MoveCursorAfterSelection", _("Move cursor after selection"),
+        false};
+
+    /// Shift + letter keys.
+    fcitx::OptionWithAnnotation<ShiftLetterKeys, ShiftLetterKeysI18NAnnotation>
+        shiftLetterKeys{this, "ShiftLetterKeys", _("Shift + Letter Keys"),
+                        ShiftLetterKeys::DirectlytOutputUppercased};
+
+);
 
 class McBopomofoEngine : public fcitx::InputMethodEngine {
  public:

--- a/src/mcbopomofo-addon.conf.in.in
+++ b/src/mcbopomofo-addon.conf.in.in
@@ -1,5 +1,6 @@
 [Addon]
 Name=McBopomofo
+Comment=McBopomofo Wrapper For Fcitx
 Category=InputMethod
 Version=@PROJECT_VERSION@
 Library=mcbopomofo

--- a/src/mcbopomofo-addon.conf.in.in
+++ b/src/mcbopomofo-addon.conf.in.in
@@ -1,6 +1,6 @@
 [Addon]
 Name=McBopomofo
-Comment=McBopomofo Wrapper For Fcitx
+Comment=McBopomofo Input Method For Fcitx
 Category=InputMethod
 Version=@PROJECT_VERSION@
 Library=mcbopomofo


### PR DESCRIPTION
- Adds `McBopomofoCandidateWord` and now we can use mouse to select candidates
- Adds the option to use ESC key to clear the entire composing buffer
- Adds the support for shift + letter keys
- Uses fcitx's own API to start process to edit user phrases
- Adopts fcitx's own config for previous/next candidate page