### PR TITLE
Define a McBopomofo-specific Key class

### DIFF
--- a/po/en.po
+++ b/po/en.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: fcitx5-mcbopomofo v0.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-04-04 03:20+0800\n"
+"POT-Creation-Date: 2022-04-05 00:08-0700\n"
 "PO-Revision-Date: 2022-03-22 20:28-0700\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -17,11 +17,35 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: src/McBopomofo.cpp:76
+#: src/McBopomofo.cpp:109
+msgid "Cursor is between syllables {0} and {1}"
+msgstr ""
+
+#: src/McBopomofo.cpp:114
+msgid "{0} syllables required"
+msgstr ""
+
+#: src/McBopomofo.cpp:118
+msgid "{0} syllables maximum"
+msgstr ""
+
+#: src/McBopomofo.cpp:122
+msgid "phrase already exists"
+msgstr ""
+
+#: src/McBopomofo.cpp:126
+msgid "press Enter to add the phrase"
+msgstr ""
+
+#: src/McBopomofo.cpp:132
+msgid "Marked: {0}, syllables: {1}, {2}"
+msgstr ""
+
+#: src/McBopomofo.cpp:147
 msgid "Edit User Phrases"
 msgstr ""
 
-#: src/McBopomofo.cpp:85
+#: src/McBopomofo.cpp:156
 msgid "Edit Excluded Phrases"
 msgstr ""
 
@@ -99,30 +123,6 @@ msgstr ""
 
 #: src/McBopomofo.h:110
 msgid "Shift + Letter Keys"
-msgstr ""
-
-#: src/KeyHandler.cpp:581
-msgid "Cursor is between syllables {0} and {1}"
-msgstr ""
-
-#: src/KeyHandler.cpp:673
-msgid "{0} syllables required"
-msgstr ""
-
-#: src/KeyHandler.cpp:676
-msgid "{0} syllables maximum"
-msgstr ""
-
-#: src/KeyHandler.cpp:679
-msgid "phrase already exists"
-msgstr ""
-
-#: src/KeyHandler.cpp:681
-msgid "press Enter to add the phrase"
-msgstr ""
-
-#: src/KeyHandler.cpp:685
-msgid "Marked: {0}, syllables: {1}, {2}"
 msgstr ""
 
 #: src/mcbopomofo.conf.in.in:3 src/mcbopomofo-addon.conf.in.in:3

--- a/po/en.po
+++ b/po/en.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: fcitx5-mcbopomofo v0.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-04-05 00:08-0700\n"
+"POT-Creation-Date: 2022-04-05 23:41-0700\n"
 "PO-Revision-Date: 2022-03-22 20:28-0700\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -94,12 +94,12 @@ msgid "after_cursor"
 msgstr "After the Cursor (Like MS IME)"
 
 #: src/McBopomofo.h:76
-msgid "Directly Output Uppercase Letters"
-msgstr ""
+msgid "directly_output_uppercase"
+msgstr "Directly Output Uppercase Letters"
 
 #: src/McBopomofo.h:77
-msgid "Put Lowercase Letters to Composing Buffer"
-msgstr ""
+msgid "put_lowercase_to_buffer"
+msgstr "Put Lowercase Letters to Composing Buffer"
 
 #: src/McBopomofo.h:85
 msgid "Bopomofo Keyboard Layout"

--- a/po/zh_TW.po
+++ b/po/zh_TW.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: fcitx5-mcbopomofo v0.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-04-05 00:08-0700\n"
+"POT-Creation-Date: 2022-04-05 23:41-0700\n"
 "PO-Revision-Date: 2022-03-22 20:28-0700\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -94,11 +94,11 @@ msgid "after_cursor"
 msgstr "游標後面（像微軟新注音）"
 
 #: src/McBopomofo.h:76
-msgid "Directly Output Uppercase Letters"
+msgid "directly_output_uppercase"
 msgstr "直接輸入大寫字母"
 
 #: src/McBopomofo.h:77
-msgid "Put Lowercase Letters to Composing Buffer"
+msgid "put_lowercase_to_buffer"
 msgstr "在輸入緩衝區中輸入小寫字母"
 
 #: src/McBopomofo.h:85

--- a/po/zh_TW.po
+++ b/po/zh_TW.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: fcitx5-mcbopomofo v0.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-04-04 03:20+0800\n"
+"POT-Creation-Date: 2022-04-05 00:08-0700\n"
 "PO-Revision-Date: 2022-03-22 20:28-0700\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -17,11 +17,35 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src/McBopomofo.cpp:76
+#: src/McBopomofo.cpp:109
+msgid "Cursor is between syllables {0} and {1}"
+msgstr "游標在「{0}」與「{1}」之間"
+
+#: src/McBopomofo.cpp:114
+msgid "{0} syllables required"
+msgstr "至少需要選取{0}個字"
+
+#: src/McBopomofo.cpp:118
+msgid "{0} syllables maximum"
+msgstr "最多只能選取{0}個字"
+
+#: src/McBopomofo.cpp:122
+msgid "phrase already exists"
+msgstr "詞庫已經有這個詞"
+
+#: src/McBopomofo.cpp:126
+msgid "press Enter to add the phrase"
+msgstr "請按 Enter 加入自訂詞庫"
+
+#: src/McBopomofo.cpp:132
+msgid "Marked: {0}, syllables: {1}, {2}"
+msgstr "選取了「{0}」，注音「{1}」：{2}"
+
+#: src/McBopomofo.cpp:147
 msgid "Edit User Phrases"
 msgstr "編輯使用者詞彙"
 
-#: src/McBopomofo.cpp:85
+#: src/McBopomofo.cpp:156
 msgid "Edit Excluded Phrases"
 msgstr "編輯排除的詞彙"
 
@@ -100,30 +124,6 @@ msgstr "ESC 按鍵清除輸入緩衝區的所有內容"
 #: src/McBopomofo.h:110
 msgid "Shift + Letter Keys"
 msgstr "Shift + 字母按鍵"
-
-#: src/KeyHandler.cpp:581
-msgid "Cursor is between syllables {0} and {1}"
-msgstr "游標在「{0}」與「{1}」之間"
-
-#: src/KeyHandler.cpp:673
-msgid "{0} syllables required"
-msgstr "至少需要選取{0}個字"
-
-#: src/KeyHandler.cpp:676
-msgid "{0} syllables maximum"
-msgstr "最多只能選取{0}個字"
-
-#: src/KeyHandler.cpp:679
-msgid "phrase already exists"
-msgstr "詞庫已經有這個詞"
-
-#: src/KeyHandler.cpp:681
-msgid "press Enter to add the phrase"
-msgstr "請按 Enter 加入自訂詞庫"
-
-#: src/KeyHandler.cpp:685
-msgid "Marked: {0}, syllables: {1}, {2}"
-msgstr "選取了「{0}」，注音「{1}」：{2}"
 
 #: src/mcbopomofo.conf.in.in:3 src/mcbopomofo-addon.conf.in.in:3
 msgid "McBopomofo"

--- a/run-xgettext.sh
+++ b/run-xgettext.sh
@@ -6,7 +6,7 @@ xgettext \
 	-k_ \
 	-kN_ \
 	-o po/fcitx5-mcbopomofo.pot \
-    src/McBopomofo.cpp src/McBopomofo.h src/KeyHandler.cpp src/KeyHandler.h
+    src/McBopomofo.cpp src/McBopomofo.h
 
 xgettext \
 	--package-name=fcitx5-mcbopomofo \

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -7,7 +7,7 @@ set(MCBOPOMOFO_LIB_SOURCES
  KeyHandler.cpp
  LanguageModelLoader.cpp
  UTF8Helper.cpp
- Log.cpp
+ Log.cpp  # Log is part of McBopomofoLib to facilitate debugging via logging.
  Engine/KeyValueBlobReader.cpp 
  Engine/McBopomofoLM.cpp
  Engine/ParselessLM.cpp
@@ -24,9 +24,8 @@ set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC")
 include("${FCITX_INSTALL_CMAKECONFIG_DIR}/Fcitx5Utils/Fcitx5CompilerSettings.cmake")
 
 add_library(McBopomofoLib STATIC ${MCBOPOMOFO_LIB_SOURCES})
-target_include_directories(McBopomofoLib PRIVATE BEFORE Fcitx5::Core fmt::fmt)
-target_link_libraries(McBopomofoLib PRIVATE Fcitx5::Core fmt::fmt)
-set_target_properties(McBopomofoLib PROPERTIES PREFIX "")
+target_link_libraries(McBopomofoLib PRIVATE Fcitx5::Utils)
+target_include_directories(McBopomofoLib PRIVATE Fcitx5::Utils)
 target_compile_definitions(McBopomofoLib PRIVATE FCITX_GETTEXT_DOMAIN=\"fcitx5-mcbopomofo\")
 
 include_directories(Engine)
@@ -40,8 +39,8 @@ if (USE_LEGACY_FCITX5_API)
     add_compile_definitions(mcbopomofo USE_LEGACY_FCITX5_API=1)
 endif()
 # target_compile_options(mcbopomofo PRIVATE -Wall -Wextra)
-target_link_libraries(mcbopomofo PRIVATE Fcitx5::Core McBopomofoLib)
-target_include_directories(mcbopomofo PRIVATE Fcitx5::Core)
+target_link_libraries(mcbopomofo PRIVATE Fcitx5::Core McBopomofoLib fmt::fmt)
+target_include_directories(mcbopomofo PRIVATE Fcitx5::Core fmt::fmt)
 set_target_properties(mcbopomofo PROPERTIES PREFIX "")
 target_compile_definitions(mcbopomofo PRIVATE FCITX_GETTEXT_DOMAIN=\"fcitx5-mcbopomofo\")
 install(TARGETS mcbopomofo DESTINATION "${FCITX_INSTALL_LIBDIR}/fcitx5")

--- a/src/Key.h
+++ b/src/Key.h
@@ -1,0 +1,75 @@
+// Copyright (c) 2022 and onwards The McBopomofo Authors.
+//
+// Permission is hereby granted, free of charge, to any person
+// obtaining a copy of this software and associated documentation
+// files (the "Software"), to deal in the Software without
+// restriction, including without limitation the rights to use,
+// copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following
+// conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+// OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+// HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+// OTHER DEALINGS IN THE SOFTWARE.
+
+#ifndef SRC_KEY_H_
+#define SRC_KEY_H_
+
+namespace McBopomofo {
+
+// Encapsulates the keys accepted by KeyHandler. This class never attempts to
+// represent all key states that a generic input method framework desires to
+// handle. Instead, this class only reflects the keys KeyHandler will handle.
+//
+// This is not always a perfect representation (for example, shift muddles the
+// picture), but is sufficient for KeyHandler's needs.
+struct Key {
+  enum class KeyName { ASCII, LEFT, RIGHT, HOME, END, UNKNOWN };
+
+  static constexpr char BACKSPACE = 8;
+  static constexpr char RETURN = 13;
+  static constexpr char ESC = 27;
+  static constexpr char SPACE = 32;
+  static constexpr char DELETE = 127;
+
+  char ascii = 0;
+  KeyName name = KeyName::UNKNOWN;
+
+  // Note that `ascii` takes precedence. If `ascii` is an uppercase letter or a
+  // punctuation symbol produced via a shift combination, ascii is set to a
+  // non-zero value and `shiftPressed` is always false. On the other hand,
+  // "complex" keys such as Shift-Space will see both `ascii` and `shiftPressed`
+  // set, since `ascii` alone is not sufficient to represent the key.
+  bool shiftPressed = false;
+
+  static Key asciiKey(char c, bool shiftPressed = false) {
+    return Key{
+        .ascii = c, .name = KeyName::ASCII, .shiftPressed = shiftPressed};
+  }
+
+  static Key namedKey(KeyName name, bool shiftPressed = false) {
+    return Key{.ascii = 0, .name = name, shiftPressed = shiftPressed};
+  }
+
+  // Regardless of the shift state.
+  bool isCursorKeys() {
+    return name == KeyName::LEFT || name == KeyName::RIGHT ||
+           name == KeyName::HOME || name == KeyName::END;
+  }
+
+  // Regardless of the shift state.
+  bool isDeleteKeys() { return ascii == BACKSPACE || ascii == DELETE; }
+};
+
+}  // namespace McBopomofo
+
+#endif  // SRC_KEY_H_

--- a/src/KeyHandler.h
+++ b/src/KeyHandler.h
@@ -33,6 +33,7 @@
 
 #include "Gramambular.h"
 #include "InputState.h"
+#include "Key.h"
 #include "LanguageModelLoader.h"
 #include "Mandarin.h"
 #include "McBopomofoLM.h"
@@ -54,7 +55,7 @@ class KeyHandler {
   // a new state is entered, or errorCallback will be invoked. Returns true if
   // the key should be absorbed, signaling that the key is accepted and handled,
   // or false if the event should be let pass through.
-  bool handle(fcitx::Key key, McBopomofo::InputState* state,
+  bool handle(Key key, McBopomofo::InputState* state,
               const StateCallback& stateCallback,
               const ErrorCallback& errorCallback);
 
@@ -83,10 +84,10 @@ class KeyHandler {
   void setEscKeyClearsEntireComposingBuffer(bool flag);
 
  private:
-  bool handleCursorKeys(fcitx::Key key, McBopomofo::InputState* state,
+  bool handleCursorKeys(Key key, McBopomofo::InputState* state,
                         const StateCallback& stateCallback,
                         const ErrorCallback& errorCallback);
-  bool handleDeleteKeys(fcitx::Key key, McBopomofo::InputState* state,
+  bool handleDeleteKeys(Key key, McBopomofo::InputState* state,
                         const StateCallback& stateCallback,
                         const ErrorCallback& errorCallback);
   bool handlePunctuation(const std::string& punctuationUnigramKey,

--- a/src/KeyHandlerTest.cpp
+++ b/src/KeyHandlerTest.cpp
@@ -37,6 +37,35 @@ class MockUserPhraseAdder : public UserPhraseAdder {
                      const std::string_view&) override {}
 };
 
+class MockLocalizedString : public KeyHandler::LocalizedStrings {
+ public:
+  std::string cursorIsBetweenSyllables(
+      const std::string& prevReading, const std::string& nextReading) override {
+    return std::string("between ") + prevReading + " and " + nextReading;
+  }
+
+  std::string syllablesRequired(size_t syllables) override {
+    return std::to_string(syllables) + " syllables required";
+  }
+
+  std::string syllablesMaximum(size_t syllables) override {
+    return std::to_string(syllables) + " syllables maximum";
+  }
+
+  std::string phraseAlreadyExists() override { return "phrase already exists"; }
+
+  std::string pressEnterToAddThePhrase() override {
+    return "press Enter to add the phrase";
+  }
+
+  std::string markedWithSyllablesAndStatus(const std::string& marked,
+                                           const std::string& readingUiText,
+                                           const std::string& status) override {
+    return std::string("Marked: ") + marked + ", syllables: " + readingUiText +
+           ", " + status;
+  }
+};
+
 class KeyHandlerTest : public ::testing::Test {
  protected:
   void SetUp() override {
@@ -46,7 +75,8 @@ class KeyHandlerTest : public ::testing::Test {
     userPhraseAdder_ = std::make_shared<MockUserPhraseAdder>();
 
     keyHandler_ =
-        std::make_unique<KeyHandler>(languageModel_, userPhraseAdder_);
+        std::make_unique<KeyHandler>(languageModel_, userPhraseAdder_,
+                                     std::make_unique<MockLocalizedString>());
   }
 
   std::vector<Key> asciiKeys(const std::string& keyString) {

--- a/src/KeyHandlerTest.cpp
+++ b/src/KeyHandlerTest.cpp
@@ -49,24 +49,24 @@ class KeyHandlerTest : public ::testing::Test {
         std::make_unique<KeyHandler>(languageModel_, userPhraseAdder_);
   }
 
-  std::vector<fcitx::Key> asciiKeys(const std::string& keyString) {
-    std::vector<fcitx::Key> keys;
+  std::vector<Key> asciiKeys(const std::string& keyString) {
+    std::vector<Key> keys;
     for (const char chr : keyString) {
-      keys.emplace_back(fcitx::Key(static_cast<fcitx::KeySym>(chr)));
+      keys.emplace_back(Key::asciiKey(chr));
     }
     return keys;
   }
 
   // Given a sequence of keys, return the last state.
   std::unique_ptr<InputState> handleKeySequence(
-      std::vector<fcitx::Key> keys, bool expectHandled = true,
+      std::vector<Key> keys, bool expectHandled = true,
       bool expectErrorCallbackAtEnd = false) {
     std::unique_ptr<InputState> state = std::make_unique<InputStates::Empty>();
 
     bool handled = false;
     bool errorCallbackInvoked = false;
 
-    for (const fcitx::Key& key : keys) {
+    for (const Key& key : keys) {
       errorCallbackInvoked = false;
       handled = keyHandler_->handle(
           key, state.get(),
@@ -97,7 +97,7 @@ TEST_F(KeyHandlerTest, EmptyKey_NothingHandled) {
   bool errorCallbackInvoked = false;
   auto emptyState = std::make_unique<InputStates::Empty>();
   bool handled = keyHandler_->handle(
-      fcitx::Key(), emptyState.get(),
+      Key(), emptyState.get(),
       [&stateCallbackInvoked](std::unique_ptr<McBopomofo::InputState>) {
         stateCallbackInvoked = true;
       },
@@ -123,7 +123,7 @@ TEST_F(KeyHandlerTest, SimpleReading) {
 
 TEST_F(KeyHandlerTest, SimpleReadingPlusUnhandledKey) {
   auto keys = asciiKeys("1");
-  keys.emplace_back(fcitx::Key(FcitxKey_Up));
+  keys.emplace_back(Key::namedKey(Key::KeyName::LEFT));
   auto endState = handleKeySequence(keys, /*expectHandled=*/true,
                                     /*expectErrorCallbackAtEnd=*/true);
   auto inputtingState = dynamic_cast<InputStates::Inputting*>(endState.get());
@@ -160,7 +160,7 @@ TEST_F(KeyHandlerTest, EnterCandidateState) {
 
 TEST_F(KeyHandlerTest, CursorMovementLeft) {
   auto keys = asciiKeys("5j/ jp6");
-  keys.emplace_back(fcitx::Key(FcitxKey_Left));
+  keys.emplace_back(Key::namedKey(Key::KeyName::LEFT));
   auto endState = handleKeySequence(keys);
   auto inputtingState = dynamic_cast<InputStates::Inputting*>(endState.get());
   ASSERT_TRUE(inputtingState != nullptr);
@@ -170,7 +170,7 @@ TEST_F(KeyHandlerTest, CursorMovementLeft) {
 
 TEST_F(KeyHandlerTest, CursorMovementHome) {
   auto keys = asciiKeys("5j/ jp6");
-  keys.emplace_back(fcitx::Key(FcitxKey_Home));
+  keys.emplace_back(Key::namedKey(Key::KeyName::HOME));
   auto endState = handleKeySequence(keys);
   auto inputtingState = dynamic_cast<InputStates::Inputting*>(endState.get());
   ASSERT_TRUE(inputtingState != nullptr);
@@ -180,8 +180,8 @@ TEST_F(KeyHandlerTest, CursorMovementHome) {
 
 TEST_F(KeyHandlerTest, SelectCandidatesBeforeCursor) {
   auto keys = asciiKeys("5j/ jp6");
-  keys.emplace_back(fcitx::Key(FcitxKey_Left));
-  keys.emplace_back(fcitx::Key(FcitxKey_space));
+  keys.emplace_back(Key::namedKey(Key::KeyName::LEFT));
+  keys.emplace_back(Key::asciiKey(Key::SPACE));
   auto endState = handleKeySequence(keys);
   auto choosingCandidateState =
       dynamic_cast<InputStates::ChoosingCandidate*>(endState.get());
@@ -195,8 +195,8 @@ TEST_F(KeyHandlerTest, SelectCandidatesAfterCursor) {
   keyHandler_->setSelectPhraseAfterCursorAsCandidate(true);
 
   auto keys = asciiKeys("5j/ jp6");
-  keys.emplace_back(fcitx::Key(FcitxKey_Left));
-  keys.emplace_back(fcitx::Key(FcitxKey_space));
+  keys.emplace_back(Key::namedKey(Key::KeyName::LEFT));
+  keys.emplace_back(Key::asciiKey(Key::SPACE));
   auto endState = handleKeySequence(keys);
   auto choosingCandidateState =
       dynamic_cast<InputStates::ChoosingCandidate*>(endState.get());

--- a/src/McBopomofo.h
+++ b/src/McBopomofo.h
@@ -71,10 +71,10 @@ enum class SelectPhrase { BeforeCursor, AfterCursor };
 FCITX_CONFIG_ENUM_NAME_WITH_I18N(SelectPhrase, N_("before_cursor"),
                                  N_("after_cursor"));
 
-enum class ShiftLetterKeys { DirectlytOutputUppercase, PutLowercaseToBuffer };
-FCITX_CONFIG_ENUM_NAME_WITH_I18N(
-    ShiftLetterKeys, N_("Directly Output Uppercase Letters"),
-    N_("Put Lowercase Letters to Composing Buffer"));
+enum class ShiftLetterKeys { DirectlyOutputUppercase, PutLowercaseToBuffer };
+FCITX_CONFIG_ENUM_NAME_WITH_I18N(ShiftLetterKeys,
+                                 N_("directly_output_uppercase"),
+                                 N_("put_lowercase_to_buffer"));
 
 FCITX_CONFIGURATION(
     McBopomofoConfig,
@@ -105,10 +105,10 @@ FCITX_CONFIGURATION(
         this, "EscKeyClearsEntireComposingBuffer",
         _("ESC key clears entire composing buffer"), false};
 
-    /// Shift + letter keys.
+    // Shift + letter keys.
     fcitx::OptionWithAnnotation<ShiftLetterKeys, ShiftLetterKeysI18NAnnotation>
         shiftLetterKeys{this, "ShiftLetterKeys", _("Shift + Letter Keys"),
-                        ShiftLetterKeys::DirectlytOutputUppercase};
+                        ShiftLetterKeys::DirectlyOutputUppercase};
 
 );
 


### PR DESCRIPTION
The net result of this PR is that KeyHandler is now totally framework-independent, and our own Key class defines a much narrower interface that only describes what McBopomofo can handle.

Also adds relevant test cases to make sure that one of the most complicated set of code paths (uppercase letter handling) are correct after those changes.
