### PR TITLE
Allow using another app to open user phrase files

### DIFF
--- a/po/en.po
+++ b/po/en.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: fcitx5-mcbopomofo v0.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-04-05 23:41-0700\n"
+"POT-Creation-Date: 2022-04-07 20:06-0700\n"
 "PO-Revision-Date: 2022-03-22 20:28-0700\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -17,35 +17,35 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: src/McBopomofo.cpp:109
+#: src/McBopomofo.cpp:110
 msgid "Cursor is between syllables {0} and {1}"
 msgstr ""
 
-#: src/McBopomofo.cpp:114
+#: src/McBopomofo.cpp:115
 msgid "{0} syllables required"
 msgstr ""
 
-#: src/McBopomofo.cpp:118
+#: src/McBopomofo.cpp:119
 msgid "{0} syllables maximum"
 msgstr ""
 
-#: src/McBopomofo.cpp:122
+#: src/McBopomofo.cpp:123
 msgid "phrase already exists"
 msgstr ""
 
-#: src/McBopomofo.cpp:126
+#: src/McBopomofo.cpp:127
 msgid "press Enter to add the phrase"
 msgstr ""
 
-#: src/McBopomofo.cpp:132
+#: src/McBopomofo.cpp:133
 msgid "Marked: {0}, syllables: {1}, {2}"
 msgstr ""
 
-#: src/McBopomofo.cpp:147
+#: src/McBopomofo.cpp:154
 msgid "Edit User Phrases"
 msgstr ""
 
-#: src/McBopomofo.cpp:156
+#: src/McBopomofo.cpp:164
 msgid "Edit Excluded Phrases"
 msgstr ""
 
@@ -101,28 +101,32 @@ msgstr "Directly Output Uppercase Letters"
 msgid "put_lowercase_to_buffer"
 msgstr "Put Lowercase Letters to Composing Buffer"
 
-#: src/McBopomofo.h:85
+#: src/McBopomofo.h:87
 msgid "Bopomofo Keyboard Layout"
 msgstr ""
 
-#: src/McBopomofo.h:90
+#: src/McBopomofo.h:92
 msgid "Selection Keys"
 msgstr ""
 
-#: src/McBopomofo.h:95
+#: src/McBopomofo.h:97
 msgid "Show Candidate Phrase"
 msgstr "Show Candidates"
 
-#: src/McBopomofo.h:100
+#: src/McBopomofo.h:102
 msgid "Move cursor after selection"
 msgstr ""
 
-#: src/McBopomofo.h:106
+#: src/McBopomofo.h:108
 msgid "ESC key clears entire composing buffer"
 msgstr ""
 
-#: src/McBopomofo.h:110
+#: src/McBopomofo.h:112
 msgid "Shift + Letter Keys"
+msgstr ""
+
+#: src/McBopomofo.h:116
+msgid "Open user phrase files with"
 msgstr ""
 
 #: src/mcbopomofo.conf.in.in:3 src/mcbopomofo-addon.conf.in.in:3

--- a/po/zh_TW.po
+++ b/po/zh_TW.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: fcitx5-mcbopomofo v0.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-04-05 23:41-0700\n"
+"POT-Creation-Date: 2022-04-07 20:06-0700\n"
 "PO-Revision-Date: 2022-03-22 20:28-0700\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -17,35 +17,35 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src/McBopomofo.cpp:109
+#: src/McBopomofo.cpp:110
 msgid "Cursor is between syllables {0} and {1}"
 msgstr "游標在「{0}」與「{1}」之間"
 
-#: src/McBopomofo.cpp:114
+#: src/McBopomofo.cpp:115
 msgid "{0} syllables required"
 msgstr "至少需要選取{0}個字"
 
-#: src/McBopomofo.cpp:118
+#: src/McBopomofo.cpp:119
 msgid "{0} syllables maximum"
 msgstr "最多只能選取{0}個字"
 
-#: src/McBopomofo.cpp:122
+#: src/McBopomofo.cpp:123
 msgid "phrase already exists"
 msgstr "詞庫已經有這個詞"
 
-#: src/McBopomofo.cpp:126
+#: src/McBopomofo.cpp:127
 msgid "press Enter to add the phrase"
 msgstr "請按 Enter 加入自訂詞庫"
 
-#: src/McBopomofo.cpp:132
+#: src/McBopomofo.cpp:133
 msgid "Marked: {0}, syllables: {1}, {2}"
 msgstr "選取了「{0}」，注音「{1}」：{2}"
 
-#: src/McBopomofo.cpp:147
+#: src/McBopomofo.cpp:154
 msgid "Edit User Phrases"
 msgstr "編輯使用者詞彙"
 
-#: src/McBopomofo.cpp:156
+#: src/McBopomofo.cpp:164
 msgid "Edit Excluded Phrases"
 msgstr "編輯排除的詞彙"
 
@@ -101,29 +101,33 @@ msgstr "直接輸入大寫字母"
 msgid "put_lowercase_to_buffer"
 msgstr "在輸入緩衝區中輸入小寫字母"
 
-#: src/McBopomofo.h:85
+#: src/McBopomofo.h:87
 msgid "Bopomofo Keyboard Layout"
 msgstr "注音鍵盤配置"
 
-#: src/McBopomofo.h:90
+#: src/McBopomofo.h:92
 msgid "Selection Keys"
 msgstr "選字鍵"
 
-#: src/McBopomofo.h:95
+#: src/McBopomofo.h:97
 msgid "Show Candidate Phrase"
 msgstr "選字時，候選詞起算點"
 
-#: src/McBopomofo.h:100
+#: src/McBopomofo.h:102
 msgid "Move cursor after selection"
 msgstr "選字後自動移動游標"
 
-#: src/McBopomofo.h:106
+#: src/McBopomofo.h:108
 msgid "ESC key clears entire composing buffer"
 msgstr "ESC 按鍵清除輸入緩衝區的所有內容"
 
-#: src/McBopomofo.h:110
+#: src/McBopomofo.h:112
 msgid "Shift + Letter Keys"
 msgstr "Shift + 字母按鍵"
+
+#: src/McBopomofo.h:116
+msgid "Open user phrase files with"
+msgstr "開啟自訂詞庫檔案要用"
 
 #: src/mcbopomofo.conf.in.in:3 src/mcbopomofo-addon.conf.in.in:3
 msgid "McBopomofo"

--- a/src/McBopomofo.cpp
+++ b/src/McBopomofo.cpp
@@ -135,6 +135,12 @@ class KeyHandlerLocalizedString : public KeyHandler::LocalizedStrings {
   }
 };
 
+static std::string GetOpenFileWith(const McBopomofoConfig& config) {
+  return config.openUserPhraseFilesWith.value().length() > 0
+             ? config.openUserPhraseFilesWith.value()
+             : kDefaultOpenFileWith;
+}
+
 McBopomofoEngine::McBopomofoEngine(fcitx::Instance* instance)
     : instance_(instance) {
   languageModelLoader_ = std::make_shared<LanguageModelLoader>();
@@ -146,10 +152,11 @@ McBopomofoEngine::McBopomofoEngine(fcitx::Instance* instance)
 
   editUserPhreasesAction_ = std::make_unique<fcitx::SimpleAction>();
   editUserPhreasesAction_->setShortText(_("Edit User Phrases"));
-  editUserPhreasesAction_->connect<
-      fcitx::SimpleAction::Activated>([this](fcitx::InputContext*) {
-    fcitx::startProcess({"xdg-open", languageModelLoader_->userPhrasesPath()});
-  });
+  editUserPhreasesAction_->connect<fcitx::SimpleAction::Activated>(
+      [this](fcitx::InputContext*) {
+        fcitx::startProcess({GetOpenFileWith(config_),
+                             languageModelLoader_->userPhrasesPath()});
+      });
   instance_->userInterfaceManager().registerAction(
       "mcbopomofo-user-phrases-edit", editUserPhreasesAction_.get());
 
@@ -157,8 +164,8 @@ McBopomofoEngine::McBopomofoEngine(fcitx::Instance* instance)
   excludedPhreasesAction_->setShortText(_("Edit Excluded Phrases"));
   excludedPhreasesAction_->connect<fcitx::SimpleAction::Activated>(
       [this](fcitx::InputContext*) {
-        fcitx::startProcess(
-            {"xdg-open", languageModelLoader_->excludedPhrasesPath()});
+        fcitx::startProcess({GetOpenFileWith(config_),
+                             languageModelLoader_->excludedPhrasesPath()});
       });
   instance_->userInterfaceManager().registerAction(
       "mcbopomofo-user-excluded-phrases-edit", excludedPhreasesAction_.get());

--- a/src/McBopomofo.h
+++ b/src/McBopomofo.h
@@ -76,6 +76,8 @@ FCITX_CONFIG_ENUM_NAME_WITH_I18N(ShiftLetterKeys,
                                  N_("directly_output_uppercase"),
                                  N_("put_lowercase_to_buffer"));
 
+constexpr char kDefaultOpenFileWith[] = "xdg-open";
+
 FCITX_CONFIGURATION(
     McBopomofoConfig,
     // Keyboard layout: standard, eten, etc.
@@ -110,7 +112,9 @@ FCITX_CONFIGURATION(
         shiftLetterKeys{this, "ShiftLetterKeys", _("Shift + Letter Keys"),
                         ShiftLetterKeys::DirectlyOutputUppercase};
 
-);
+    fcitx::Option<std::string> openUserPhraseFilesWith{
+        this, "OpenUserPhraseFilesWith", _("Open user phrase files with"),
+        kDefaultOpenFileWith};);
 
 class McBopomofoEngine : public fcitx::InputMethodEngine {
  public:


### PR DESCRIPTION
I thought about the options listed [here](https://github.com/openvanilla/fcitx5-mcbopomofo/issues/30#issuecomment-1086548334) in #30 , and found Option 2 (giving users a way to customize how they want to edit the files) the easiest and simplest.

We no longer use `system()` to launch processes as of 19d21d09b4803204f30198accc4205529117b443, so I think at least McBopomofo won't misbehave even when the default `xdg-open` doesn't work.

Probing things like `XDG_CURRENT_DESKTOP` or showing warnings depending on such a probe seems a bit complex and prone to all kinds of edge cases. So this appears the most cost-effective solution.
