### PR TITLE
Allows to use arrow key to choose candidates but not to go to another page

### DIFF
--- a/src/McBopomofo.cpp
+++ b/src/McBopomofo.cpp
@@ -348,7 +348,11 @@ void McBopomofoEngine::handleCandidateKeyEvent(
   if (key.check(FcitxKey_Return)) {
     idx = candidateList->cursorIndex();
     if (idx < candidateList->size()) {
+#ifdef USE_LEGACY_FCITX5_API
+      candidateList->candidate(idx)->select(context);
+#else
       candidateList->candidate(idx).select(context);
+#endif
     }
     return;
   }

--- a/src/McBopomofo.cpp
+++ b/src/McBopomofo.cpp
@@ -304,10 +304,14 @@ void McBopomofoEngine::keyEvent(const fcitx::InputMethodEntry&,
       // TODO(unassigned): Just assert this.
       FCITX_MCBOPOMOFO_WARN() << "inconsistent state";
       enterNewState(context, std::make_unique<InputStates::Empty>());
+      context->updateUserInterface(fcitx::UserInterfaceComponent::InputPanel);
+      context->updatePreedit();
       return;
     }
 
     handleCandidateKeyEvent(context, key, maybeCandidateList);
+    context->updateUserInterface(fcitx::UserInterfaceComponent::InputPanel);
+    context->updatePreedit();
     return;
   }
 


### PR DESCRIPTION
Before the PR, the users can use the arrow keys to go to another page but not to choose a candidate The PR makes the FCITX5 port more like the macOS version.