### PR TITLE
Prevent sole tone markers from being composed

### DIFF
--- a/src/Engine/Mandarin/Mandarin.h
+++ b/src/Engine/Mandarin/Mandarin.h
@@ -407,6 +407,17 @@ class BopomofoReadingBuffer {
     return false;
   }
 
+  bool isToneMarkerKey(char k) {
+    // Use another reading buffer to check if k is a tone marker key. This
+    // ensures that the function is layout-agnostic.
+    BopomofoReadingBuffer buf(layout_);
+    if (!buf.isValidKey(k)) {
+      return false;
+    }
+    buf.combineKey(k);
+    return buf.hasToneMarker();
+  }
+
   bool combineKey(char k) {
     if (!isValidKey(k)) return false;
 
@@ -465,6 +476,12 @@ class BopomofoReadingBuffer {
   }
 
   bool hasToneMarker() const { return syllable_.hasToneMarker(); }
+
+  bool hasToneMarkerOnly() const {
+    return syllable_.hasToneMarker() &&
+           !(syllable_.hasConsonant() || syllable_.hasMiddleVowel() ||
+             syllable_.hasVowel());
+  }
 
  protected:
   const BopomofoKeyboardLayout* layout_;


### PR DESCRIPTION
Previously we allow sole tone markers to be composed on their own. This
created an suboptimal user experience as tone markers might be
inadvertently placed into the composing buffer. Now we require an extra
Space if the intent is really to compose the markers. New test cases are
introduced for this improvement.

Also, independently, this commit fixes a crashing bug: If the composing
buffer starts empty and a non-viable syllable is composed, the state
machine should enter Empty state. Instead, Inputting state was used.
This caused the next Space key to attempt to enter the ChoosingCandidate
state when the builder had nothing to offer, resulting in crash.
Regression tests are added as a result.