### PR TITLE
Tunes the behavior of sole tone mark.

### DIFF
--- a/src/Engine/Mandarin/Mandarin.h
+++ b/src/Engine/Mandarin/Mandarin.h
@@ -407,17 +407,6 @@ class BopomofoReadingBuffer {
     return false;
   }
 
-  bool isToneMarkerKey(char k) {
-    // Use another reading buffer to check if k is a tone marker key. This
-    // ensures that the function is layout-agnostic.
-    BopomofoReadingBuffer buf(layout_);
-    if (!buf.isValidKey(k)) {
-      return false;
-    }
-    buf.combineKey(k);
-    return buf.hasToneMarker();
-  }
-
   bool combineKey(char k) {
     if (!isValidKey(k)) return false;
 

--- a/src/KeyHandler.cpp
+++ b/src/KeyHandler.cpp
@@ -231,7 +231,7 @@ bool KeyHandler::handle(Key key, McBopomofo::InputState* state,
       return true;
     }
 
-    if (!reading_.isEmpty() || reading_.hasToneMarkerOnly()) {
+    if (!reading_.isEmpty()) {
       reading_.clear();
       if (!builder_->length()) {
         stateCallback(std::make_unique<InputStates::EmptyIgnoringPrevious>());

--- a/src/KeyHandler.cpp
+++ b/src/KeyHandler.cpp
@@ -136,21 +136,12 @@ bool KeyHandler::handle(Key key, McBopomofo::InputState* state,
       stateCallback(buildInputtingState());
       return true;
     }
-
-    // Check if reading *only* has the tone component. If so, stay in the
-    // current state. This is to prevent tone marks from being accidentally
-    // placed into the composing buffer. If you intend to place a tone marker
-    // to the composing buffer, type an extra space.
-    if (reading_.hasToneMarkerOnly()) {
-      stateCallback(buildInputtingState());
-      return true;
-    }
   }
 
   // Compose the reading if either there's a tone marker, or if the reading is
   // not empty, and space is pressed.
   bool shouldComposeReading =
-      reading_.isToneMarkerKey(simpleAscii) ||
+      (reading_.hasToneMarker() && !reading_.hasToneMarkerOnly()) ||
       (!reading_.isEmpty() && simpleAscii == Key::SPACE);
 
   if (shouldComposeReading) {
@@ -240,7 +231,7 @@ bool KeyHandler::handle(Key key, McBopomofo::InputState* state,
       return true;
     }
 
-    if (!reading_.isEmpty()) {
+    if (!reading_.isEmpty() || reading_.hasToneMarkerOnly()) {
       reading_.clear();
       if (!builder_->length()) {
         stateCallback(std::make_unique<InputStates::EmptyIgnoringPrevious>());
@@ -519,7 +510,9 @@ bool KeyHandler::handleDeleteKeys(Key key, McBopomofo::InputState* state,
     return false;
   }
 
-  if (reading_.isEmpty()) {
+  if (reading_.hasToneMarkerOnly()) {
+    reading_.clear();
+  } else if (reading_.isEmpty()) {
     bool isValidDelete = false;
 
     if (key.ascii == Key::BACKSPACE && builder_->cursorIndex() > 0) {

--- a/src/KeyHandlerTest.cpp
+++ b/src/KeyHandlerTest.cpp
@@ -300,7 +300,7 @@ TEST_F(KeyHandlerTest, ToneMarkOnlyRequiresExtraSpaceToCompose) {
 }
 
 TEST_F(KeyHandlerTest,
-       ToneMarkThenNonToneComponentCombinesReadingButDoesNotCompose) {
+       ToneMarkThenNonToneComponentResultingInCompositionCase1) {
   auto keys = asciiKeys("6u");
   auto endState = handleKeySequence(keys);
   auto inputtingState = dynamic_cast<InputStates::Inputting*>(endState.get());
@@ -310,7 +310,7 @@ TEST_F(KeyHandlerTest,
 }
 
 TEST_F(KeyHandlerTest,
-       ToneMarkThenNonToneComponentOnlyComposesWithAnotherTone) {
+       ToneMarkThenNonToneComponentResultingInCompositionCase2) {
   auto keys = asciiKeys("6u3");
   auto endState = handleKeySequence(keys);
   auto inputtingState = dynamic_cast<InputStates::Inputting*>(endState.get());
@@ -319,7 +319,8 @@ TEST_F(KeyHandlerTest,
   ASSERT_EQ(inputtingState->cursorIndex, strlen("一ˇ"));
 }
 
-TEST_F(KeyHandlerTest, ToneMarkThenNonToneComponentOnlyComposesWithSameTone) {
+TEST_F(KeyHandlerTest,
+       ToneMarkThenNonToneComponentResultingInCompositionCase3) {
   auto keys = asciiKeys("3u3");
   auto endState = handleKeySequence(keys);
   auto inputtingState = dynamic_cast<InputStates::Inputting*>(endState.get());

--- a/src/KeyHandlerTest.cpp
+++ b/src/KeyHandlerTest.cpp
@@ -329,7 +329,9 @@ TEST_F(KeyHandlerTest,
   ASSERT_EQ(inputtingState->cursorIndex, strlen("以ˇ"));
 }
 
-TEST_F(KeyHandlerTest, ToneMarkThenNonToneComponentOnlyComposesWithSpace) {
+TEST_F(KeyHandlerTest,
+       ToneMarkThenNonToneComponentResultingInCompositionCase4) {
+  // The last space key composes a ChoosingCandidate.
   auto keys = asciiKeys("3u ");
   auto endState = handleKeySequence(keys);
   auto inputtingState =

--- a/src/KeyHandlerTest.cpp
+++ b/src/KeyHandlerTest.cpp
@@ -354,7 +354,9 @@ TEST_F(
     KeyHandlerTest,
     NonViableCompositionShouldRevertToEmptyStateIfComposingBufferEndsUpEmptyCase2) {
   auto keys = asciiKeys("313");
-  // ㄅˇ is not a viable composition.
+  // "ˇㄅ" is not valid in McBopomofo. We are tolerant for some cases, such as
+  // we accpet "ˇ一"  to be "以" since it is usually a user just want to type
+  // "一ˇ". However, typing "ˇㄅ" does not make sense.
   auto endState = handleKeySequence(keys, /*expectHandled=*/true,
                                     /*expectErrorCallbackAtEnd=*/false);
   auto inputtingState = dynamic_cast<InputStates::Inputting*>(endState.get());
@@ -366,7 +368,9 @@ TEST_F(
     KeyHandlerTest,
     NonViableCompositionShouldRevertToEmptyStateIfComposingBufferEndsUpEmptyCase3) {
   auto keys = asciiKeys("31 ");
-  // ㄅˇ is not a viable composition.
+  // "ˇㄅ" is not valid in McBopomofo. We are tolerant for some cases, such as
+  // we accpet "ˇ一"  to be "以" since it is usually a user just want to type
+  // "一ˇ". However, typing "ˇㄅ" does not make sense.
   auto endState = handleKeySequence(keys, /*expectHandled=*/false,
                                     /*expectErrorCallbackAtEnd=*/false);
   auto emptyState = dynamic_cast<InputStates::Empty*>(endState.get());

--- a/src/KeyHandlerTest.cpp
+++ b/src/KeyHandlerTest.cpp
@@ -359,8 +359,7 @@ TEST_F(
   // "ˇㄅ" is not valid in McBopomofo. We are tolerant for some cases, such as
   // we accpet "ˇ一"  to be "以" since it is usually a user just want to type
   // "一ˇ". However, typing "ˇㄅ" does not make sense.
-  auto endState = handleKeySequence(keys, /*expectHandled=*/true,
-                                    /*expectErrorCallbackAtEnd=*/false);
+  auto endState = handleKeySequence(keys);
   auto inputtingState = dynamic_cast<InputStates::Inputting*>(endState.get());
   ASSERT_TRUE(inputtingState != nullptr);
   ASSERT_EQ(inputtingState->composingBuffer, "ˇ");

--- a/src/KeyHandlerTest.cpp
+++ b/src/KeyHandlerTest.cpp
@@ -305,8 +305,8 @@ TEST_F(KeyHandlerTest,
   auto endState = handleKeySequence(keys);
   auto inputtingState = dynamic_cast<InputStates::Inputting*>(endState.get());
   ASSERT_TRUE(inputtingState != nullptr);
-  ASSERT_EQ(inputtingState->composingBuffer, "ㄧˊ");
-  ASSERT_EQ(inputtingState->cursorIndex, strlen("ㄧˊ"));
+  ASSERT_EQ(inputtingState->composingBuffer, "一");
+  ASSERT_EQ(inputtingState->cursorIndex, strlen("一"));
 }
 
 TEST_F(KeyHandlerTest,
@@ -315,8 +315,8 @@ TEST_F(KeyHandlerTest,
   auto endState = handleKeySequence(keys);
   auto inputtingState = dynamic_cast<InputStates::Inputting*>(endState.get());
   ASSERT_TRUE(inputtingState != nullptr);
-  ASSERT_EQ(inputtingState->composingBuffer, "以");
-  ASSERT_EQ(inputtingState->cursorIndex, strlen("以"));
+  ASSERT_EQ(inputtingState->composingBuffer, "一ˇ");
+  ASSERT_EQ(inputtingState->cursorIndex, strlen("一ˇ"));
 }
 
 TEST_F(KeyHandlerTest, ToneMarkThenNonToneComponentOnlyComposesWithSameTone) {
@@ -324,14 +324,15 @@ TEST_F(KeyHandlerTest, ToneMarkThenNonToneComponentOnlyComposesWithSameTone) {
   auto endState = handleKeySequence(keys);
   auto inputtingState = dynamic_cast<InputStates::Inputting*>(endState.get());
   ASSERT_TRUE(inputtingState != nullptr);
-  ASSERT_EQ(inputtingState->composingBuffer, "以");
-  ASSERT_EQ(inputtingState->cursorIndex, strlen("以"));
+  ASSERT_EQ(inputtingState->composingBuffer, "以ˇ");
+  ASSERT_EQ(inputtingState->cursorIndex, strlen("以ˇ"));
 }
 
 TEST_F(KeyHandlerTest, ToneMarkThenNonToneComponentOnlyComposesWithSpace) {
   auto keys = asciiKeys("3u ");
   auto endState = handleKeySequence(keys);
-  auto inputtingState = dynamic_cast<InputStates::Inputting*>(endState.get());
+  auto inputtingState =
+      dynamic_cast<InputStates::ChoosingCandidate*>(endState.get());
   ASSERT_TRUE(inputtingState != nullptr);
   ASSERT_EQ(inputtingState->composingBuffer, "以");
   ASSERT_EQ(inputtingState->cursorIndex, strlen("以"));
@@ -354,9 +355,10 @@ TEST_F(
   auto keys = asciiKeys("313");
   // ㄅˇ is not a viable composition.
   auto endState = handleKeySequence(keys, /*expectHandled=*/true,
-                                    /*expectErrorCallbackAtEnd=*/true);
-  auto emptyState = dynamic_cast<InputStates::Empty*>(endState.get());
-  ASSERT_TRUE(emptyState != nullptr);
+                                    /*expectErrorCallbackAtEnd=*/false);
+  auto inputtingState = dynamic_cast<InputStates::Inputting*>(endState.get());
+  ASSERT_TRUE(inputtingState != nullptr);
+  ASSERT_EQ(inputtingState->composingBuffer, "ˇ");
 }
 
 TEST_F(
@@ -364,8 +366,8 @@ TEST_F(
     NonViableCompositionShouldRevertToEmptyStateIfComposingBufferEndsUpEmptyCase3) {
   auto keys = asciiKeys("31 ");
   // ㄅˇ is not a viable composition.
-  auto endState = handleKeySequence(keys, /*expectHandled=*/true,
-                                    /*expectErrorCallbackAtEnd=*/true);
+  auto endState = handleKeySequence(keys, /*expectHandled=*/false,
+                                    /*expectErrorCallbackAtEnd=*/false);
   auto emptyState = dynamic_cast<InputStates::Empty*>(endState.get());
   ASSERT_TRUE(emptyState != nullptr);
 }


### PR DESCRIPTION
PR #40 left some weird behaviors

- We cannot use ESC and backspace key to erase the reading if there is only the tone mark in the reading. The PR now allows user to erase the sole tone mark..
- We allow the users to iuput BPMF after inputting only a tone mark, however, when a user sees the reading like "ˇㄧ", he or she may not know how to end current input.

My idea is, we should accept only a single BPMF that can compose a character or phrase with the tone mark. When a user wants to input "以", it is possible he wrongly uses "3u" instead of "u3", so, we should just compose "以" in this case anyway. However, if a user input "31" like "ˋㄅ", it should be an error since I think it does not make sense.
