### PR TITLE
Uses tab key to choose next candidate without showing candidate panel.

### DIFF
--- a/src/Key.h
+++ b/src/Key.h
@@ -35,6 +35,7 @@ namespace McBopomofo {
 struct Key {
   enum class KeyName { ASCII, LEFT, RIGHT, HOME, END, UNKNOWN };
 
+  static constexpr char TAB = 9;
   static constexpr char BACKSPACE = 8;
   static constexpr char RETURN = 13;
   static constexpr char ESC = 27;

--- a/src/KeyHandler.cpp
+++ b/src/KeyHandler.cpp
@@ -490,19 +490,35 @@ bool KeyHandler::handleTabKey(McBopomofo::InputState* state,
   }
 
   size_t currentIndex = 0;
-  for (auto candidate : candidates) {
-    if (candidate == currentNode.node->currentKeyValue().value) {
-      currentIndex++;
-      break;
+  if (currentNode.node->score() < 99) {
+    // Once the user never select a candidate for the node, we start from the
+    // first candidate, so the user has a chance to use the unigram with two or
+    // more characters when type the tab key for the first time.
+    //
+    // In other words, if a user type two BPMF readings, but the score of seeing
+    // them as two unigrams is higher than a phrase with two characters, the
+    // user can just use the longer phrase by typing the tab key.
+    if (candidates[0] == currentNode.node->currentKeyValue().value) {
+      // If the first candidate is the value of the current node, we use next
+      // one.
+      currentIndex = 1;
     }
-    currentIndex++;
+  } else {
+    for (auto candidate : candidates) {
+      if (candidate == currentNode.node->currentKeyValue().value) {
+        currentIndex++;
+        break;
+      }
+      currentIndex++;
+    }
   }
 
   if (currentIndex >= candidates.size()) {
     currentIndex = 0;
   }
 
-  pinNode(candidates[currentIndex], false);
+  pinNode(candidates[currentIndex],
+          /*useMoveCursorAfterSelectionSetting=*/false);
   stateCallback(buildInputtingState());
   return true;
 }

--- a/src/KeyHandler.h
+++ b/src/KeyHandler.h
@@ -100,6 +100,9 @@ class KeyHandler {
 #pragma endregion Settings
 
  private:
+  bool handleTabKey(McBopomofo::InputState* state,
+                    const StateCallback& stateCallback,
+                    const ErrorCallback& errorCallback);
   bool handleCursorKeys(Key key, McBopomofo::InputState* state,
                         const StateCallback& stateCallback,
                         const ErrorCallback& errorCallback);
@@ -140,7 +143,8 @@ class KeyHandler {
   size_t actualCandidateCursorIndex();
 
   // Pin a node with a fixed unigram value, usually a candidate.
-  void pinNode(const std::string& candidate);
+  void pinNode(const std::string& candidate,
+               const bool useMoveCursorAfterSelectionSetting = true);
 
   void walk();
 

--- a/src/McBopomofo.cpp
+++ b/src/McBopomofo.cpp
@@ -95,6 +95,8 @@ static Key MapFcitxKey(const fcitx::Key& key) {
       return Key::asciiKey(Key::SPACE, shiftPressed, ctrlPressed);
     case FcitxKey_Delete:
       return Key::asciiKey(Key::DELETE, shiftPressed, ctrlPressed);
+    case FcitxKey_Tab:
+      return Key::asciiKey(Key::TAB, shiftPressed, ctrlPressed);
     case FcitxKey_Left:
       return Key::namedKey(Key::KeyName::LEFT, shiftPressed, ctrlPressed);
     case FcitxKey_Right:


### PR DESCRIPTION
This feature helps to save time in some cases. For example, when a user
wants to type "…", he or she has to input _ and then use space key
to show the candidate window and then select the second candidae. Using
the tab key feature can let the user just input _ and tab.