### PR TITLE
Optimizes the reverse walker

### DIFF
--- a/po/en.po
+++ b/po/en.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: fcitx5-mcbopomofo v0.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-05-07 16:12+0800\n"
+"POT-Creation-Date: 2022-05-29 13:28+0800\n"
 "PO-Revision-Date: 2022-03-22 20:28-0700\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -17,35 +17,35 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: src/McBopomofo.cpp:131
+#: src/McBopomofo.cpp:133
 msgid "Cursor is between syllables {0} and {1}"
 msgstr ""
 
-#: src/McBopomofo.cpp:136
+#: src/McBopomofo.cpp:138
 msgid "{0} syllables required"
 msgstr ""
 
-#: src/McBopomofo.cpp:140
+#: src/McBopomofo.cpp:142
 msgid "{0} syllables maximum"
 msgstr ""
 
-#: src/McBopomofo.cpp:144
+#: src/McBopomofo.cpp:146
 msgid "phrase already exists"
 msgstr ""
 
-#: src/McBopomofo.cpp:148
+#: src/McBopomofo.cpp:150
 msgid "press Enter to add the phrase"
 msgstr ""
 
-#: src/McBopomofo.cpp:154
+#: src/McBopomofo.cpp:156
 msgid "Marked: {0}, syllables: {1}, {2}"
 msgstr ""
 
-#: src/McBopomofo.cpp:190
+#: src/McBopomofo.cpp:192
 msgid "Edit User Phrases"
 msgstr ""
 
-#: src/McBopomofo.cpp:200
+#: src/McBopomofo.cpp:202
 msgid "Edit Excluded Phrases"
 msgstr ""
 
@@ -86,70 +86,90 @@ msgid "asdfzxcvb"
 msgstr ""
 
 #: src/McBopomofo.h:71
+msgid "Not Set"
+msgstr ""
+
+#: src/McBopomofo.h:72
+msgid "Vertical"
+msgstr ""
+
+#: src/McBopomofo.h:72
+msgid "Horizontal"
+msgstr ""
+
+#: src/McBopomofo.h:75
 msgid "before_cursor"
 msgstr "Before the Cursor (Like Hanin)"
 
-#: src/McBopomofo.h:72
+#: src/McBopomofo.h:76
 msgid "after_cursor"
 msgstr "After the Cursor (Like MS IME)"
 
-#: src/McBopomofo.h:76
+#: src/McBopomofo.h:80
 msgid "directly_output_uppercase"
 msgstr "Directly Output Uppercase Letters"
 
-#: src/McBopomofo.h:77
+#: src/McBopomofo.h:81
 msgid "put_lowercase_to_buffer"
 msgstr "Put Lowercase Letters to Composing Buffer"
 
-#: src/McBopomofo.h:83
+#: src/McBopomofo.h:87
 msgid "disabled"
 msgstr "Disabled"
 
-#: src/McBopomofo.h:84
+#: src/McBopomofo.h:88
 msgid "output_bpmf_reading"
 msgstr "Input Bofomofo Readings"
 
-#: src/McBopomofo.h:85
+#: src/McBopomofo.h:89
 msgid "output_html_ruby_text"
 msgstr "Input HTML Ruby Text"
 
-#: src/McBopomofo.h:93
+#: src/McBopomofo.h:97
 msgid "Bopomofo Keyboard Layout"
 msgstr ""
 
-#: src/McBopomofo.h:98
+#: src/McBopomofo.h:103
+msgid "Candidate List Layout"
+msgstr ""
+
+#: src/McBopomofo.h:108
 msgid "Selection Keys"
 msgstr ""
 
-#: src/McBopomofo.h:103
+#: src/McBopomofo.h:113
 msgid "Show Candidate Phrase"
 msgstr "Show Candidates"
 
-#: src/McBopomofo.h:108
+#: src/McBopomofo.h:118
 msgid "Move cursor after selection"
 msgstr ""
 
-#: src/McBopomofo.h:114
+#: src/McBopomofo.h:124
 msgid "ESC key clears entire composing buffer"
 msgstr ""
 
-#: src/McBopomofo.h:118
+#: src/McBopomofo.h:128
+msgid "Composing Buffer Size"
+msgstr ""
+
+#: src/McBopomofo.h:133
 msgid "Shift + Letter Keys"
 msgstr ""
 
-#: src/McBopomofo.h:123
+#: src/McBopomofo.h:139
 msgid "Control + Enter Key"
 msgstr ""
 
-#: src/McBopomofo.h:127
+#: src/McBopomofo.h:144
 msgid "Open User Phrase Files With"
 msgstr ""
 
-#: src/McBopomofo.h:131
+#: src/McBopomofo.h:149
 msgid "Add Phrase Hook Path"
 msgstr ""
 
-#: src/McBopomofo.h:136
+#: src/McBopomofo.h:154
 msgid "Run the hook script after adding a phrase"
 msgstr ""
 

--- a/po/zh_TW.po
+++ b/po/zh_TW.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: fcitx5-mcbopomofo v0.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-05-07 16:12+0800\n"
+"POT-Creation-Date: 2022-05-29 13:28+0800\n"
 "PO-Revision-Date: 2022-03-22 20:28-0700\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -17,35 +17,35 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src/McBopomofo.cpp:131
+#: src/McBopomofo.cpp:133
 msgid "Cursor is between syllables {0} and {1}"
 msgstr "游標在「{0}」與「{1}」之間"
 
-#: src/McBopomofo.cpp:136
+#: src/McBopomofo.cpp:138
 msgid "{0} syllables required"
 msgstr "至少需要選取{0}個字"
 
-#: src/McBopomofo.cpp:140
+#: src/McBopomofo.cpp:142
 msgid "{0} syllables maximum"
 msgstr "最多只能選取{0}個字"
 
-#: src/McBopomofo.cpp:144
+#: src/McBopomofo.cpp:146
 msgid "phrase already exists"
 msgstr "詞庫已經有這個詞"
 
-#: src/McBopomofo.cpp:148
+#: src/McBopomofo.cpp:150
 msgid "press Enter to add the phrase"
 msgstr "請按 Enter 加入自訂詞庫"
 
-#: src/McBopomofo.cpp:154
+#: src/McBopomofo.cpp:156
 msgid "Marked: {0}, syllables: {1}, {2}"
 msgstr "選取了「{0}」，注音「{1}」：{2}"
 
-#: src/McBopomofo.cpp:190
+#: src/McBopomofo.cpp:192
 msgid "Edit User Phrases"
 msgstr "編輯使用者詞彙"
 
-#: src/McBopomofo.cpp:200
+#: src/McBopomofo.cpp:202
 msgid "Edit Excluded Phrases"
 msgstr "編輯排除的詞彙"
 
@@ -86,70 +86,90 @@ msgid "asdfzxcvb"
 msgstr ""
 
 #: src/McBopomofo.h:71
+msgid "Not Set"
+msgstr "尚未設置"
+
+#: src/McBopomofo.h:72
+msgid "Vertical"
+msgstr "垂直選字窗"
+
+#: src/McBopomofo.h:72
+msgid "Horizontal"
+msgstr "水平選字窗"
+
+#: src/McBopomofo.h:75
 msgid "before_cursor"
 msgstr "游標前面（像漢音輸入法）"
 
-#: src/McBopomofo.h:72
+#: src/McBopomofo.h:76
 msgid "after_cursor"
 msgstr "游標後面（像微軟新注音）"
 
-#: src/McBopomofo.h:76
+#: src/McBopomofo.h:80
 msgid "directly_output_uppercase"
 msgstr "直接輸入大寫字母"
 
-#: src/McBopomofo.h:77
+#: src/McBopomofo.h:81
 msgid "put_lowercase_to_buffer"
 msgstr "在輸入緩衝區中輸入小寫字母"
 
-#: src/McBopomofo.h:83
+#: src/McBopomofo.h:87
 msgid "disabled"
 msgstr "無作用"
 
-#: src/McBopomofo.h:84
+#: src/McBopomofo.h:88
 msgid "output_bpmf_reading"
 msgstr "輸出整個句子的注音符號"
 
-#: src/McBopomofo.h:85
+#: src/McBopomofo.h:89
 msgid "output_html_ruby_text"
 msgstr "輸出加上注音標示的 HTML (Ruby Text)"
 
-#: src/McBopomofo.h:93
+#: src/McBopomofo.h:97
 msgid "Bopomofo Keyboard Layout"
 msgstr "注音鍵盤配置"
 
-#: src/McBopomofo.h:98
+#: src/McBopomofo.h:103
+msgid "Candidate List Layout"
+msgstr "選字窗樣式"
+
+#: src/McBopomofo.h:108
 msgid "Selection Keys"
 msgstr "選字鍵"
 
-#: src/McBopomofo.h:103
+#: src/McBopomofo.h:113
 msgid "Show Candidate Phrase"
 msgstr "選字時，候選詞起算點"
 
-#: src/McBopomofo.h:108
+#: src/McBopomofo.h:118
 msgid "Move cursor after selection"
 msgstr "選字後自動移動游標"
 
-#: src/McBopomofo.h:114
+#: src/McBopomofo.h:124
 msgid "ESC key clears entire composing buffer"
 msgstr "ESC 按鍵清除輸入緩衝區的所有內容"
 
-#: src/McBopomofo.h:118
+#: src/McBopomofo.h:128
+msgid "Composing Buffer Size"
+msgstr "輸入緩衝區大小"
+
+#: src/McBopomofo.h:133
 msgid "Shift + Letter Keys"
 msgstr "Shift + 字母按鍵"
 
-#: src/McBopomofo.h:123
+#: src/McBopomofo.h:139
 msgid "Control + Enter Key"
 msgstr "Control + Enter 按鍵"
 
-#: src/McBopomofo.h:127
+#: src/McBopomofo.h:144
 msgid "Open User Phrase Files With"
 msgstr "開啟自訂詞庫檔案要用"
 
-#: src/McBopomofo.h:131
+#: src/McBopomofo.h:149
 msgid "Add Phrase Hook Path"
 msgstr "加詞腳本路徑"
 
-#: src/McBopomofo.h:136
+#: src/McBopomofo.h:154
 msgid "Run the hook script after adding a phrase"
 msgstr "在加入新詞之後執行加詞腳本"
 

--- a/src/Engine/Gramambular/Node.h
+++ b/src/Engine/Gramambular/Node.h
@@ -39,6 +39,8 @@
 namespace Formosa {
 namespace Gramambular {
 
+constexpr int kSelectedCandidateScore = 99;
+
 class Node {
  public:
   Node() {}
@@ -110,7 +112,7 @@ inline void Node::selectCandidateAtIndex(size_t index) {
     m_selectedUnigramIndex = index;
   }
 
-  m_score = 99;
+  m_score = kSelectedCandidateScore;
 }
 
 inline void Node::resetCandidate() {

--- a/src/Engine/Gramambular/Walker.h
+++ b/src/Engine/Gramambular/Walker.h
@@ -80,6 +80,8 @@ inline const std::vector<NodeAnchor> Walker::reverseWalk(
     path.insert(path.begin(), node);
     paths.push_back(path);
   } else if (longPhrases.size() > 0) {
+    std::vector<NodeAnchor> path;
+
     for (std::vector<NodeAnchor>::iterator ni = nodes.begin();
          ni != nodes.end(); ++ni) {
       if (!ni->node) {
@@ -96,15 +98,13 @@ inline const std::vector<NodeAnchor> Walker::reverseWalk(
       // "我/這/樣/覺/得" are excatly the same for the users.
       if (std::find(longPhrases.begin(), longPhrases.end(), joinedValue) !=
           longPhrases.end()) {
-        std::vector<NodeAnchor> path;
         ni->accumulatedScore = kDroppedPathScore;
         path.insert(path.begin(), *ni);
         paths.push_back(path);
         continue;
       }
 
-      ni->accumulatedScore = accumulatedScore + (*ni).node->score();
-      std::vector<NodeAnchor> path;
+      ni->accumulatedScore = accumulatedScore + ni->node->score();
 
       if (joinedValue.size() >= longPhrases[0].size()) {
         path = reverseWalk(location - ni->spanningLength, ni->accumulatedScore,
@@ -121,7 +121,7 @@ inline const std::vector<NodeAnchor> Walker::reverseWalk(
     std::vector<std::string> longPhrases;
     for (std::vector<NodeAnchor>::iterator ni = nodes.begin();
          ni != nodes.end(); ++ni) {
-      if (!(*ni).node) {
+      if (!ni->node) {
         continue;
       }
       if (ni->spanningLength > 1) {
@@ -139,7 +139,7 @@ inline const std::vector<NodeAnchor> Walker::reverseWalk(
         continue;
       }
 
-      (*ni).accumulatedScore = accumulatedScore + (*ni).node->score();
+      ni->accumulatedScore = accumulatedScore + ni->node->score();
       std::vector<NodeAnchor> path;
       if (ni->spanningLength > 1) {
         path = reverseWalk(location - ni->spanningLength, ni->accumulatedScore,

--- a/src/Engine/Gramambular/Walker.h
+++ b/src/Engine/Gramambular/Walker.h
@@ -36,11 +36,15 @@
 namespace Formosa {
 namespace Gramambular {
 
+constexpr int kDroppedPathScore = -999;
+
 class Walker {
  public:
   explicit Walker(Grid* inGrid);
-  const std::vector<NodeAnchor> reverseWalk(size_t location,
-                                            double accumulatedScore = 0.0);
+  const std::vector<NodeAnchor> reverseWalk(
+      size_t location, double accumulatedScore = 0.0,
+      std::string joinedPhrase = "",
+      std::vector<std::string> longPhrases = std::vector<std::string>());
 
  protected:
   Grid* m_grid;
@@ -49,7 +53,8 @@ class Walker {
 inline Walker::Walker(Grid* inGrid) : m_grid(inGrid) {}
 
 inline const std::vector<NodeAnchor> Walker::reverseWalk(
-    size_t location, double accumulatedScore) {
+    size_t location, double accumulatedScore, std::string joinedPhrase,
+    std::vector<std::string> longPhrases) {
   if (!location || location > m_grid->width()) {
     return std::vector<NodeAnchor>();
   }
@@ -58,19 +63,94 @@ inline const std::vector<NodeAnchor> Walker::reverseWalk(
 
   std::vector<NodeAnchor> nodes = m_grid->nodesEndingAt(location);
 
-  for (std::vector<NodeAnchor>::iterator ni = nodes.begin(); ni != nodes.end();
-       ++ni) {
-    if (!(*ni).node) {
-      continue;
+  stable_sort(nodes.begin(), nodes.end(),
+              [](const Formosa::Gramambular::NodeAnchor& a,
+                 const Formosa::Gramambular::NodeAnchor& b) {
+                return a.node->score() > b.node->score();
+              });
+
+  if (nodes[0].node->score() >= kSelectedCandidateScore) {
+    // If the user ever choosed a candidate on a node, we should only use the
+    // path based on the selected candidate and ignore other paths.
+    auto node = nodes[0];
+
+    node.accumulatedScore = accumulatedScore + node.node->score();
+    std::vector<NodeAnchor> path =
+        reverseWalk(location - node.spanningLength, (node).accumulatedScore);
+    path.insert(path.begin(), node);
+    paths.push_back(path);
+  } else if (longPhrases.size() > 0) {
+    for (std::vector<NodeAnchor>::iterator ni = nodes.begin();
+         ni != nodes.end(); ++ni) {
+      if (!ni->node) {
+        continue;
+      }
+      std::string joinedValue = joinedPhrase;
+      joinedValue.insert(0, ni->node->currentKeyValue().value);
+      // If some nodes with only a character composed a result as a long phease,
+      // we just give up the path and give it a really low score.
+      //
+      // For example, in a sentense "我這樣覺得", we have a longer phrase
+      // 覺得, and we found there is another path may ends with "覺" and
+      // "得", we just ignore the path since finally "我/這樣/覺得" and
+      // "我/這/樣/覺/得" are excatly the same for the users.
+      if (std::find(longPhrases.begin(), longPhrases.end(), joinedValue) !=
+          longPhrases.end()) {
+        std::vector<NodeAnchor> path;
+        ni->accumulatedScore = kDroppedPathScore;
+        path.insert(path.begin(), *ni);
+        paths.push_back(path);
+        continue;
+      }
+
+      ni->accumulatedScore = accumulatedScore + (*ni).node->score();
+      std::vector<NodeAnchor> path;
+
+      if (joinedValue.size() >= longPhrases[0].size()) {
+        path = reverseWalk(location - ni->spanningLength, ni->accumulatedScore,
+                           "", std::vector<std::string>());
+      } else {
+        path = reverseWalk(location - ni->spanningLength, ni->accumulatedScore,
+                           joinedValue, longPhrases);
+      }
+      path.insert(path.begin(), *ni);
+      paths.push_back(path);
+    }
+  } else {
+    // Let's see if we have longer phrases in the position in the grid.
+    std::vector<std::string> longPhrases;
+    for (std::vector<NodeAnchor>::iterator ni = nodes.begin();
+         ni != nodes.end(); ++ni) {
+      if (!(*ni).node) {
+        continue;
+      }
+      if (ni->spanningLength > 1) {
+        longPhrases.push_back(ni->node->currentKeyValue().value);
+      }
     }
 
-    (*ni).accumulatedScore = accumulatedScore + (*ni).node->score();
+    stable_sort(
+        longPhrases.begin(), longPhrases.end(),
+        [](std::string a, std::string b) { return a.size() > b.size(); });
 
-    std::vector<NodeAnchor> path =
-        reverseWalk(location - (*ni).spanningLength, (*ni).accumulatedScore);
-    path.insert(path.begin(), *ni);
+    for (std::vector<NodeAnchor>::iterator ni = nodes.begin();
+         ni != nodes.end(); ++ni) {
+      if (!ni->node) {
+        continue;
+      }
 
-    paths.push_back(path);
+      (*ni).accumulatedScore = accumulatedScore + (*ni).node->score();
+      std::vector<NodeAnchor> path;
+      if (ni->spanningLength > 1) {
+        path = reverseWalk(location - ni->spanningLength, ni->accumulatedScore,
+                           "", std::vector<std::string>());
+      } else {
+        path = reverseWalk(location - ni->spanningLength, ni->accumulatedScore,
+                           ni->node->currentKeyValue().value, longPhrases);
+      }
+      path.insert(path.begin(), *ni);
+      paths.push_back(path);
+    }
   }
 
   if (!paths.size()) {
@@ -80,7 +160,7 @@ inline const std::vector<NodeAnchor> Walker::reverseWalk(
   std::vector<NodeAnchor>* result = &*(paths.begin());
   for (std::vector<std::vector<NodeAnchor> >::iterator pi = paths.begin();
        pi != paths.end(); ++pi) {
-    if ((*pi).back().accumulatedScore > result->back().accumulatedScore) {
+    if (pi->back().accumulatedScore > result->back().accumulatedScore) {
       result = &*pi;
     }
   }

--- a/src/Engine/Gramambular/Walker.h
+++ b/src/Engine/Gramambular/Walker.h
@@ -89,13 +89,13 @@ inline const std::vector<NodeAnchor> Walker::reverseWalk(
       }
       std::string joinedValue = joinedPhrase;
       joinedValue.insert(0, ni->node->currentKeyValue().value);
-      // If some nodes with only a character composed a result as a long phease,
+      // If some nodes with only a character composed a result as a long phrase,
       // we just give up the path and give it a really low score.
       //
-      // For example, in a sentense "我這樣覺得", we have a longer phrase
+      // For example, in a sentence "我這樣覺得", we have a longer phrase
       // 覺得, and we found there is another path may ends with "覺" and
       // "得", we just ignore the path since finally "我/這樣/覺得" and
-      // "我/這/樣/覺/得" are excatly the same for the users.
+      // "我/這/樣/覺/得" are exactly the same for the users.
       if (std::find(longPhrases.begin(), longPhrases.end(), joinedValue) !=
           longPhrases.end()) {
         ni->accumulatedScore = kDroppedPathScore;

--- a/src/KeyHandler.cpp
+++ b/src/KeyHandler.cpp
@@ -49,7 +49,7 @@ constexpr double kEpsilon = 0.000001;
 
 // Maximum composing buffer size, roughly in codepoints.
 // TODO(unassigned): maybe make this configurable.
-constexpr size_t kComposingBufferSize = 10;
+constexpr size_t kComposingBufferSize = 40;
 
 static const char* GetKeyboardLayoutName(
     const Formosa::Mandarin::BopomofoKeyboardLayout* layout) {

--- a/src/KeyHandler.h
+++ b/src/KeyHandler.h
@@ -100,7 +100,7 @@ class KeyHandler {
 #pragma endregion Settings
 
  private:
-  bool handleTabKey(McBopomofo::InputState* state,
+  bool handleTabKey(Key key, McBopomofo::InputState* state,
                     const StateCallback& stateCallback,
                     const ErrorCallback& errorCallback);
   bool handleCursorKeys(Key key, McBopomofo::InputState* state,

--- a/src/KeyHandler.h
+++ b/src/KeyHandler.h
@@ -92,6 +92,9 @@ class KeyHandler {
   /// Sets if the ESC key clears entire composing buffer.
   void setEscKeyClearsEntireComposingBuffer(bool flag);
 
+  // Sets composing buffer size.
+  void setComposingBufferSize(size_t size);
+
   void setCtrlEnterKeyBehavior(KeyHandlerCtrlEnter behavior);
 
   void setOnAddNewPhrase(
@@ -165,6 +168,7 @@ class KeyHandler {
   bool moveCursorAfterSelection_;
   bool putLowercaseLettersToComposingBuffer_;
   bool escKeyClearsEntireComposingBuffer_;
+  size_t composingBufferSize_;
   KeyHandlerCtrlEnter ctrlEnterKey_ = KeyHandlerCtrlEnter::Disabled;
   std::function<void(const std::string&)> onAddNewPhrase_;
 

--- a/src/McBopomofo.cpp
+++ b/src/McBopomofo.cpp
@@ -278,6 +278,8 @@ void McBopomofoEngine::activate(const fcitx::InputMethodEntry&,
 
   keyHandler_->setCtrlEnterKeyBehavior(config_.ctrlEnterKeys.value());
 
+  keyHandler_->setComposingBufferSize(config_.composingBufferSize.value());
+
   languageModelLoader_->reloadUserModelsIfNeeded();
 }
 
@@ -421,7 +423,22 @@ void McBopomofoEngine::handleCandidateKeyEvent(
     return;
   }
 
-  fcitx::CandidateLayoutHint layoutHint = candidateList->layoutHint();
+  fcitx::CandidateLayoutHint layoutHint;
+  switch (config_.candidateLayout.value()) {
+    case McBopomofo::CandidateLayoutHint::Vertical:
+      layoutHint = fcitx::CandidateLayoutHint::Vertical;
+      break;
+    case McBopomofo::CandidateLayoutHint::Horizontal:
+      layoutHint = fcitx::CandidateLayoutHint::Horizontal;
+      break;
+    case McBopomofo::CandidateLayoutHint::NotSet:
+      layoutHint = fcitx::CandidateLayoutHint::NotSet;
+      break;
+    default:
+      break;
+  }
+
+  candidateList->setLayoutHint(layoutHint);
   bool isVertical = (layoutHint == fcitx::CandidateLayoutHint::Vertical);
 
   if (isVertical) {

--- a/src/McBopomofo.h
+++ b/src/McBopomofo.h
@@ -67,6 +67,10 @@ enum class SelectionKeys {
 FCITX_CONFIG_ENUM_NAME_WITH_I18N(SelectionKeys, N_("123456789"),
                                  N_("asdfghjkl"), N_("asdfzxcvb"));
 
+enum class CandidateLayoutHint { NotSet, Vertical, Horizontal };
+FCITX_CONFIG_ENUM_NAME_WITH_I18N(CandidateLayoutHint, N_("Not Set"),
+                                 N_("Vertical"), N_("Horizontal"));
+
 enum class SelectPhrase { BeforeCursor, AfterCursor };
 FCITX_CONFIG_ENUM_NAME_WITH_I18N(SelectPhrase, N_("before_cursor"),
                                  N_("after_cursor"));
@@ -93,6 +97,12 @@ FCITX_CONFIGURATION(
                                _("Bopomofo Keyboard Layout"),
                                BopomofoKeyboardLayout::Standard};
 
+    // Candidate layout.
+    fcitx::OptionWithAnnotation<CandidateLayoutHint,
+                                CandidateLayoutHintI18NAnnotation>
+        candidateLayout{this, "CandidateLayout", _("Candidate List Layout"),
+                        CandidateLayoutHint::NotSet};
+
     // Select selection keys.
     fcitx::OptionWithAnnotation<SelectionKeys, SelectionKeysI18NAnnotation>
         selectionKeys{this, "SelectionKeys", _("Selection Keys"),
@@ -113,20 +123,28 @@ FCITX_CONFIGURATION(
         this, "EscKeyClearsEntireComposingBuffer",
         _("ESC key clears entire composing buffer"), false};
 
+    // Composing buffer size.
+    fcitx::Option<int, fcitx::IntConstrain> composingBufferSize{
+        this, "ComposingBufferSize", _("Composing Buffer Size"), 10,
+        fcitx::IntConstrain(4, 40)};
+
     // Shift + letter keys.
     fcitx::OptionWithAnnotation<ShiftLetterKeys, ShiftLetterKeysI18NAnnotation>
         shiftLetterKeys{this, "ShiftLetterKeys", _("Shift + Letter Keys"),
                         ShiftLetterKeys::DirectlyOutputUppercase};
 
+    // Ctrl + enter keys.
     fcitx::OptionWithAnnotation<KeyHandlerCtrlEnter,
                                 KeyHandlerCtrlEnterI18NAnnotation>
         ctrlEnterKeys{this, "KeyHandlerCtrlEnter", _("Control + Enter Key"),
                       KeyHandlerCtrlEnter::Disabled};
 
+    // The app to open custom phrase text files.
     fcitx::Option<std::string> openUserPhraseFilesWith{
         this, "OpenUserPhraseFilesWith", _("Open User Phrase Files With"),
         kDefaultOpenFileWith};
 
+    // The path of the hook-script to add a phrase.
     fcitx::Option<std::string> addScriptHookPath{this, "AddScriptHookPath",
                                                  _("Add Phrase Hook Path"),
                                                  kDefaultAddPhraseHookPath};


### PR DESCRIPTION
We use reverse walker to get the path with the highest score composed by anchor nodes. The walker finds all paths but some of them are not really required, and finding them increases time complexity.

For example, when a user types "我這樣覺得", the walker has to find the following four routes and then choose the one with highest score:

```
[-8.68873387] 我(-2.27257609) -> 這樣(-3.14860584) -> 覺得(-3.26755194)
[-10.834656139999998] 我(-2.27257609) -> 這(-2.35405571) -> 樣(-2.9404724) -> 覺得(-3.26755194)
[-11.35937573] 我(-2.27257609) -> 這樣(-3.14860584) -> 覺(-3.20706759) -> 得(-2.73112621)
[-13.505298000000002] 我(-2.27257609) -> 這(-2.35405571) -> 樣(-2.9404724) -> 覺(-3.20706759) -> 得(-2.73112621)
```

However, from a user's aspect, the final product produced by these four paths are all the same - they all compose "我這樣覺得". A single node "覺得" and two nodes "覺" and "得" produce the same product. So, once we have a path ends with "覺得", when we are walking at the path ends with "覺", we should stop when we find the next node is "得" and it helps to save half of the time.

The PR also enlarges the size of the composing buffer to 40. Previously McBopomofo could be very slow when there are 20 readings in the composing buffer, but now it works fine with about 40. Some edge cases can still make it become very slow such as repeatedly typing "嗯嗯嗯嗯嗯嗯嗯嗯嗯嗯嗯嗯嗯嗯嗯嗯嗯嗯....". 

These are also included in the PR:

- Users can use shift + tab to reverse fast iterate the candidate 
- Makes composing buffer configurable 
- Makes candidate list style configurable