### PR TITLE
Fixes the flow to fix the nodes at front of the composing buffer.

### DIFF
--- a/src/Engine/Gramambular/Grid.h
+++ b/src/Engine/Gramambular/Grid.h
@@ -28,6 +28,7 @@
 #ifndef GRID_H_
 #define GRID_H_
 
+#include <iostream>
 #include <map>
 #include <string>
 #include <vector>
@@ -52,6 +53,7 @@ class Grid {
   size_t width() const;
   std::vector<NodeAnchor> nodesAt(size_t location);
   std::vector<NodeAnchor> nodesCrossingOrEndingAt(size_t location);
+  std::vector<NodeAnchor> nodesInRange(size_t begin, size_t end);
 
   // "Freeze" the node with the unigram that represents the selected candidate
   // value. After this, the node that contains the unigram will always be
@@ -182,46 +184,96 @@ inline std::vector<NodeAnchor> Grid::nodesCrossingOrEndingAt(size_t location) {
   return result;
 }
 
+inline std::vector<NodeAnchor> Grid::nodesInRange(size_t begin, size_t end) {
+  std::vector<NodeAnchor> result;
+
+  if (m_spans.size() && end <= m_spans.size()) {
+    for (size_t i = 0; i < end; i++) {
+      Span& span = m_spans[i];
+
+      if (i + span.maximumLength() > begin) {
+        for (size_t j = 1, m = span.maximumLength(); j <= m; j++) {
+          if (i + j <= begin) {
+            continue;
+          }
+
+          Node* np = span.nodeOfLength(j);
+          if (np) {
+            NodeAnchor na;
+            na.node = np;
+            na.location = i;
+            na.spanningLength = j;
+
+            result.push_back(na);
+          }
+        }
+      }
+    }
+  }
+
+  return result;
+}
+
 // For nodes found at the location, fix their currently-selected candidate
 // using the supplied string value.
 inline NodeAnchor Grid::fixNodeSelectedCandidate(size_t location,
                                                  const std::string& value) {
   std::vector<NodeAnchor> nodes = nodesCrossingOrEndingAt(location);
   NodeAnchor node;
+  size_t selectedIndex;
   for (auto nodeAnchor : nodes) {
     auto candidates = nodeAnchor.node->candidates();
 
-    // Reset the candidate-fixed state of every node at the location.
-    const_cast<Node*>(nodeAnchor.node)->resetCandidate();
-
     for (size_t i = 0, c = candidates.size(); i < c; ++i) {
       if (candidates[i].value == value) {
-        const_cast<Node*>(nodeAnchor.node)->selectCandidateAtIndex(i);
+        selectedIndex = i;
         node = nodeAnchor;
         break;
       }
     }
   }
+
+  if (node.node == nullptr) {
+    return node;
+  }
+
+  nodes = nodesInRange(location - node.spanningLength, location);
+  for (auto nodeAnchor : nodes) {
+    const_cast<Node*>(nodeAnchor.node)->resetCandidate();
+  }
+
+  const_cast<Node*>(node.node)->selectCandidateAtIndex(selectedIndex);
   return node;
 }
 
 inline void Grid::overrideNodeScoreForSelectedCandidate(
     size_t location, const std::string& value, float overridingScore) {
   std::vector<NodeAnchor> nodes = nodesCrossingOrEndingAt(location);
+  NodeAnchor node;
+  size_t selectedIndex;
   for (auto nodeAnchor : nodes) {
     auto candidates = nodeAnchor.node->candidates();
 
-    // Reset the candidate-fixed state of every node at the location.
-    const_cast<Node*>(nodeAnchor.node)->resetCandidate();
-
     for (size_t i = 0, c = candidates.size(); i < c; ++i) {
       if (candidates[i].value == value) {
-        const_cast<Node*>(nodeAnchor.node)
-            ->selectFloatingCandidateAtIndex(i, overridingScore);
+        selectedIndex = i;
+        node = nodeAnchor;
         break;
       }
     }
   }
+
+  if (node.node == nullptr) {
+    return;
+  }
+
+  nodes = nodesInRange(location - node.spanningLength, location);
+  for (auto nodeAnchor : nodes) {
+    const_cast<Node*>(nodeAnchor.node)->resetCandidate();
+  }
+
+  const_cast<Node*>(node.node)->selectFloatingCandidateAtIndex(selectedIndex,
+                                                               overridingScore);
 }
 
 }  // namespace Gramambular

--- a/src/Engine/Gramambular/Grid.h
+++ b/src/Engine/Gramambular/Grid.h
@@ -28,7 +28,6 @@
 #ifndef GRID_H_
 #define GRID_H_
 
-#include <iostream>
 #include <map>
 #include <string>
 #include <vector>

--- a/src/KeyHandler.cpp
+++ b/src/KeyHandler.cpp
@@ -163,7 +163,6 @@ bool KeyHandler::handle(Key key, McBopomofo::InputState* state,
 
     builder_->insertReadingAtCursor(syllable);
     std::string evictedText = popEvictedTextAndWalk();
-    fixNodesIfRequired();
 
     std::string overrideValue = userOverrideModel_.suggest(
         walkedNodes_, builder_->cursorIndex(), GetEpochNowInSeconds());
@@ -175,6 +174,8 @@ bool KeyHandler::handle(Key key, McBopomofo::InputState* state,
       builder_->grid().overrideNodeScoreForSelectedCandidate(
           cursorIndex, overrideValue, static_cast<float>(highestScore));
     }
+
+    fixNodesIfRequired();
 
     auto inputtingState = buildInputtingState();
     inputtingState->evictedText = evictedText;
@@ -924,7 +925,8 @@ void KeyHandler::fixNodesIfRequired() {
       }
       if (node.node->score() < Formosa::Gramambular::kSelectedCandidateScore) {
         auto candidate = node.node->currentKeyValue().value;
-        builder_->grid().fixNodeSelectedCandidate(index + 1, candidate);
+        builder_->grid().fixNodeSelectedCandidate(index + node.spanningLength,
+                                                  candidate);
       }
       index += node.spanningLength;
     }


### PR DESCRIPTION
In the previous PR I put the code before user override models suggestion. It causes the fixes node to be set to another score. Fixed.

I used a workaround yesterday to fix the nodes at front by code like "fixNode(offset + 1)", but it was buggy, and sometimes causes crashes.

Once we change the order to walk through the tree, we cannot just reset the score of the nodes crossing or ending at a given location, but the nodes in the range of the spanning length.

In a range of 台灣人 may contain nodes like 台灣 and 人, once we only reset the nodes crossing or ends at the end index 3, it won't effect the node 台灣, but if we handle only the index, it won't apply to 人. We have to change the way to find effect nodes to reset both 台灣 and 人. Merely using (index + 1) looks right but it is actually wrong.