### PR TITLE
Populate localized custom phrase file headers

### DIFF
--- a/po/en.po
+++ b/po/en.po
@@ -7,13 +7,13 @@ msgid ""
 msgstr ""
 "Project-Id-Version: fcitx5-mcbopomofo v0.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-05-29 13:28+0800\n"
+"POT-Creation-Date: 2022-06-12 13:02-0700\n"
 "PO-Revision-Date: 2022-03-22 20:28-0700\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
 "Language: en\n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=ASCII\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
@@ -41,11 +41,56 @@ msgstr ""
 msgid "Marked: {0}, syllables: {1}, {2}"
 msgstr ""
 
-#: src/McBopomofo.cpp:192
+#: src/McBopomofo.cpp:168
+msgid "# Custom Phrases or Characters."
+msgstr ""
+
+#: src/McBopomofo.cpp:170
+msgid ""
+"# See https://github.com/openvanilla/McBopomofo/wiki/使用手冊#手動加詞 for "
+"usage."
+msgstr ""
+
+#: src/McBopomofo.cpp:172
+msgid ""
+"# Add your phrases and their respective Bopomofo reading below. Use hyphen "
+"(\"-\")"
+msgstr ""
+
+#: src/McBopomofo.cpp:173
+msgid "# to connect the Bopomofo syllables."
+msgstr ""
+
+#: src/McBopomofo.cpp:177 src/McBopomofo.cpp:196
+msgid "# Any line that starts with \"#\" is treated as comment."
+msgstr ""
+
+#: src/McBopomofo.cpp:186
+msgid "# Custom Excluded Phrases or Characters."
+msgstr ""
+
+#: src/McBopomofo.cpp:188
+msgid ""
+"# See https://github.com/openvanilla/McBopomofo/wiki/使用手冊#手動刪詞 for "
+"usage."
+msgstr ""
+
+#: src/McBopomofo.cpp:190
+msgid ""
+"# For example, the line below will prevent the phrase \"家祠\" from showing "
+"up anywhere:"
+msgstr ""
+
+#: src/McBopomofo.cpp:194
+msgid ""
+"# Note that you need to use a hyphen (\"-\") between Bopomofo syllables."
+msgstr ""
+
+#: src/McBopomofo.cpp:235
 msgid "Edit User Phrases"
 msgstr ""
 
-#: src/McBopomofo.cpp:202
+#: src/McBopomofo.cpp:245
 msgid "Edit Excluded Phrases"
 msgstr ""
 

--- a/po/zh_TW.po
+++ b/po/zh_TW.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: fcitx5-mcbopomofo v0.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-05-29 13:28+0800\n"
+"POT-Creation-Date: 2022-06-12 13:03-0700\n"
 "PO-Revision-Date: 2022-03-22 20:28-0700\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -41,11 +41,47 @@ msgstr "請按 Enter 加入自訂詞庫"
 msgid "Marked: {0}, syllables: {1}, {2}"
 msgstr "選取了「{0}」，注音「{1}」：{2}"
 
-#: src/McBopomofo.cpp:192
+#: src/McBopomofo.cpp:168
+msgid "# Custom Phrases or Characters."
+msgstr "# 手動加詞資料檔"
+
+#: src/McBopomofo.cpp:170
+msgid "# See https://github.com/openvanilla/McBopomofo/wiki/使用手冊#手動加詞 for usage."
+msgstr "# 使用方式請參考 https://github.com/openvanilla/McBopomofo/wiki/使用手冊#手動加詞"
+
+#: src/McBopomofo.cpp:172
+msgid "# Add your phrases and their respective Bopomofo reading below. Use hyphen (\"-\")"
+msgstr "# 請在下方加入用戶自訂字詞。每個詞後面要有字詞的讀音。注音音節之間要用減"
+
+#: src/McBopomofo.cpp:173
+msgid "# to connect the Bopomofo syllables."
+msgstr "# 號 (\"-\") 分隔。例如，以下範例加入「小麥注音」一詞："
+
+#: src/McBopomofo.cpp:177 src/McBopomofo.cpp:196
+msgid "# Any line that starts with \"#\" is treated as comment."
+msgstr "# 如果任何一行以 \"#\" 開頭，該行將被當作註解忽略。"
+
+#: src/McBopomofo.cpp:186
+msgid "# Custom Excluded Phrases or Characters."
+msgstr "# 手動刪詞資料檔"
+
+#: src/McBopomofo.cpp:188
+msgid "# See https://github.com/openvanilla/McBopomofo/wiki/使用手冊#手動刪詞 for usage."
+msgstr "# 使用方式請參考 https://github.com/openvanilla/McBopomofo/wiki/使用手冊#手動刪詞"
+
+#: src/McBopomofo.cpp:190
+msgid "# For example, the line below will prevent the phrase \"家祠\" from showing up anywhere:"
+msgstr "# 如果將下面這行範例加入資料檔中，輸入 \"ㄐㄧㄚ ㄘˊ\" 時不會再看到「家祠」一詞："
+
+#: src/McBopomofo.cpp:194
+msgid "# Note that you need to use a hyphen (\"-\") between Bopomofo syllables."
+msgstr "# 請注意，注音音節之間要用減號 (\"-\") 分隔。"
+
+#: src/McBopomofo.cpp:235
 msgid "Edit User Phrases"
 msgstr "編輯使用者詞彙"
 
-#: src/McBopomofo.cpp:202
+#: src/McBopomofo.cpp:245
 msgid "Edit Excluded Phrases"
 msgstr "編輯排除的詞彙"
 

--- a/run-xgettext.sh
+++ b/run-xgettext.sh
@@ -3,6 +3,7 @@ xgettext \
 	--package-version=v0.1 \
 	--copyright-holder=OpenVanilla \
 	--c++ \
+	--from-code=UTF-8 \
 	-k_ \
 	-kN_ \
 	-o po/fcitx5-mcbopomofo.pot \

--- a/src/LanguageModelLoader.cpp
+++ b/src/LanguageModelLoader.cpp
@@ -37,8 +37,10 @@ constexpr char kDataPath[] = "data/mcbopomofo-data.txt";
 constexpr char kUserPhraseFilename[] = "data.txt";  // same as macOS version
 constexpr char kExcludedPhraseFilename[] = "exclude-phrases.txt";  // ditto
 
-LanguageModelLoader::LanguageModelLoader()
-    : lm_(std::make_shared<McBopomofoLM>()) {
+LanguageModelLoader::LanguageModelLoader(
+    std::unique_ptr<LocalizedStrings> localizedStrings)
+    : localizedStrings_(std::move(localizedStrings)),
+      lm_(std::make_shared<McBopomofoLM>()) {
   std::string buildInLMPath = fcitx::StandardPath::global().locate(
       fcitx::StandardPath::Type::PkgData, kDataPath);
   FCITX_MCBOPOMOFO_INFO() << "Built-in LM: " << buildInLMPath;
@@ -132,9 +134,7 @@ void LanguageModelLoader::populateUserDataFilesIfNeeded() {
     std::ofstream ofs(userPhrasesPath_);
     if (ofs) {
       FCITX_MCBOPOMOFO_INFO() << "Creating: " << userPhrasesPath_;
-
-      // TODO(unassigned): Populate date here
-      ofs << "# user phrases file\n";
+      ofs << localizedStrings_->userPhraseFileHeader();
       ofs.close();
     }
   }
@@ -144,9 +144,7 @@ void LanguageModelLoader::populateUserDataFilesIfNeeded() {
     std::ofstream ofs(excludedPhrasesPath_);
     if (ofs) {
       FCITX_MCBOPOMOFO_INFO() << "Creating: " << excludedPhrasesPath_;
-
-      // TODO(unassigned): Populate date here
-      ofs << "# excluded phrases file\n";
+      ofs << localizedStrings_->excludedPhraseFileHeader();
       ofs.close();
     }
   }

--- a/src/LanguageModelLoader.h
+++ b/src/LanguageModelLoader.h
@@ -42,7 +42,10 @@ class UserPhraseAdder {
 
 class LanguageModelLoader : public UserPhraseAdder {
  public:
-  LanguageModelLoader();
+  class LocalizedStrings;
+
+  explicit LanguageModelLoader(
+      std::unique_ptr<LocalizedStrings> localizedStrings);
 
   std::shared_ptr<McBopomofoLM> getLM() { return lm_; }
 
@@ -60,6 +63,8 @@ class LanguageModelLoader : public UserPhraseAdder {
  private:
   void populateUserDataFilesIfNeeded();
 
+  std::unique_ptr<LocalizedStrings> localizedStrings_;
+
   std::shared_ptr<McBopomofoLM> lm_;
 
   std::string userDataPath_;
@@ -67,6 +72,13 @@ class LanguageModelLoader : public UserPhraseAdder {
   std::filesystem::file_time_type userPhrasesTimestamp_;
   std::string excludedPhrasesPath_;
   std::filesystem::file_time_type excludedPhrasesTimestamp_;
+
+ public:
+  class LocalizedStrings {
+   public:
+    virtual std::string userPhraseFileHeader() = 0;
+    virtual std::string excludedPhraseFileHeader() = 0;
+  };
 };
 
 }  // namespace McBopomofo

--- a/src/McBopomofo.cpp
+++ b/src/McBopomofo.cpp
@@ -158,6 +158,48 @@ class KeyHandlerLocalizedString : public KeyHandler::LocalizedStrings {
   }
 };
 
+class LanguageModelLoaderLocalizedStrings
+    : public LanguageModelLoader::LocalizedStrings {
+ public:
+  virtual std::string userPhraseFileHeader() {
+    std::stringstream sst;
+    // clang-format off
+    sst
+      << _("# Custom Phrases or Characters.") << "\n"
+      << "#\n"
+      << _("# See https://github.com/openvanilla/McBopomofo/wiki/使用手冊#手動加詞 for usage.") << "\n"
+      << "#\n"
+      << _("# Add your phrases and their respective Bopomofo reading below. Use hyphen (\"-\")") << "\n"
+      << _("# to connect the Bopomofo syllables.") << "\n"
+      << "#\n"
+      << "#   小麥注音 ㄒㄧㄠˇ-ㄇㄞˋ-ㄓㄨˋ-ㄧㄣ" << "\n"
+      << "#\n"
+      << _("# Any line that starts with \"#\" is treated as comment.") << "\n"
+      << "\n";
+    // clang-format on
+    return sst.str();
+  }
+  virtual std::string excludedPhraseFileHeader() {
+    std::stringstream sst;
+    // clang-format off
+    sst
+      << _("# Custom Excluded Phrases or Characters.") << "\n"
+      << "#\n"
+      << _("# See https://github.com/openvanilla/McBopomofo/wiki/使用手冊#手動刪詞 for usage.") << "\n"
+      << "#\n"
+      << _("# For example, the line below will prevent the phrase \"家祠\" from showing up anywhere:") << "\n"
+      << "#\n"
+      << "#   家祠 ㄐㄧㄚ-ㄘˊ" << "\n"
+      << "#\n"
+      << _("# Note that you need to use a hyphen (\"-\") between Bopomofo syllables.") << "\n"
+      << "#\n"
+      << _("# Any line that starts with \"#\" is treated as comment.") << "\n"
+      << "\n";
+    // clang-format on
+    return sst.str();
+  }
+};
+
 static std::string GetOpenFileWith(const McBopomofoConfig& config) {
   return config.openUserPhraseFilesWith.value().length() > 0
              ? config.openUserPhraseFilesWith.value()
@@ -166,7 +208,8 @@ static std::string GetOpenFileWith(const McBopomofoConfig& config) {
 
 McBopomofoEngine::McBopomofoEngine(fcitx::Instance* instance)
     : instance_(instance) {
-  languageModelLoader_ = std::make_shared<LanguageModelLoader>();
+  languageModelLoader_ = std::make_shared<LanguageModelLoader>(
+      std::make_unique<LanguageModelLoaderLocalizedStrings>());
   keyHandler_ = std::make_unique<KeyHandler>(
       languageModelLoader_->getLM(), languageModelLoader_,
       std::make_unique<KeyHandlerLocalizedString>());


### PR DESCRIPTION
This makes sure that the intially populated user phrases and excluded phrases files have the localized headers, just like how the macOS version populates them.
