### PR TITLE
Import tests from the macOS version

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -22,10 +22,17 @@ jobs:
           cd build
           cmake ../ -DCMAKE_INSTALL_PREFIX=/usr
           make -j
+          cd ../
+          mkdir -p src/Engine/build
+          cd src/Engine/build
+          cmake ../
+          make -j
       - name: Test
         run: |
           cd build
           make runTest
+          cd ../src/Engine/build
+          make runMcBopomofoLMLibTest
 
   build_ubuntu_20:
     runs-on: ubuntu-latest

--- a/src/Engine/CMakeLists.txt
+++ b/src/Engine/CMakeLists.txt
@@ -1,0 +1,54 @@
+cmake_minimum_required(VERSION 3.17)
+project(McBopomofoLMLib)
+
+set(CMAKE_CXX_STANDARD 17)
+
+include_directories("Gramambular")
+add_library(McBopomofoLMLib
+        KeyValueBlobReader.cpp
+        KeyValueBlobReader.h
+        ParselessPhraseDB.cpp
+        ParselessPhraseDB.h
+        ParselessLM.cpp
+        ParselessLM.h
+        PhraseReplacementMap.h
+        PhraseReplacementMap.cpp
+        UserPhrasesLM.h
+        UserPhrasesLM.cpp)
+
+# Let CMake fetch Google Test for us.
+# https://github.com/google/googletest/tree/main/googletest#incorporating-into-an-existing-cmake-project
+include(FetchContent)
+
+FetchContent_Declare(
+        googletest
+        # Specify the commit you depend on and update it regularly.
+        URL https://github.com/google/googletest/archive/609281088cfefc76f9d0ce82e1ff6c30cc3591e5.zip
+)
+# For Windows: Prevent overriding the parent project's compiler/linker settings
+set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
+FetchContent_MakeAvailable(googletest)
+
+# Test target declarations.
+add_executable(McBopomofoLMLibTest
+        KeyValueBlobReaderTest.cpp
+        ParselessLMTest.cpp
+        ParselessPhraseDBTest.cpp
+        PhraseReplacementMapTest.cpp
+        UserPhrasesLMTest.cpp)
+target_link_libraries(McBopomofoLMLibTest gtest_main McBopomofoLMLib)
+include(GoogleTest)
+gtest_discover_tests(McBopomofoLMLibTest)
+
+add_custom_target(
+        runMcBopomofoLMLibTest
+        COMMAND ${CMAKE_CURRENT_BINARY_DIR}/McBopomofoLMLibTest
+)
+add_dependencies(runMcBopomofoLMLibTest McBopomofoLMLibTest)
+
+# Benchmark target; to run, manually uncomment the lines below.
+#
+# find_package(benchmark)
+# add_executable(ParselessLMBenchmark
+#         ParselessLMBenchmark.cpp)
+# target_link_libraries(ParselessLMBenchmark McBopomofoLMLib benchmark::benchmark)

--- a/src/Engine/Gramambular/CMakeLists.txt
+++ b/src/Engine/Gramambular/CMakeLists.txt
@@ -1,0 +1,31 @@
+cmake_minimum_required(VERSION 3.17)
+project(Gramambular)
+
+set(CMAKE_CXX_STANDARD 17)
+
+add_library(GramambularLib BlockReadingBuilder.h Gramambular.h Grid.h Grid.cpp KeyValuePair.h LanguageModel.h Node.h NodeAnchor.h Span.h Unigram.h Walker.h)
+
+# Let CMake fetch Google Test for us.
+# https://github.com/google/googletest/tree/main/googletest#incorporating-into-an-existing-cmake-project
+include(FetchContent)
+
+FetchContent_Declare(
+        googletest
+        # Specify the commit you depend on and update it regularly.
+        URL https://github.com/google/googletest/archive/609281088cfefc76f9d0ce82e1ff6c30cc3591e5.zip
+)
+# For Windows: Prevent overriding the parent project's compiler/linker settings
+set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
+FetchContent_MakeAvailable(googletest)
+
+# Test target declarations.
+add_executable(GramambularTest GramambularTest.cpp)
+target_link_libraries(GramambularTest gtest_main GramambularLib)
+include(GoogleTest)
+gtest_discover_tests(GramambularTest)
+
+add_custom_target(
+        runGramambularTest
+        COMMAND ${CMAKE_CURRENT_BINARY_DIR}/GramambularTest
+)
+add_dependencies(runGramambularTest GramambularTest)

--- a/src/Engine/Gramambular/GramambularTest.cpp
+++ b/src/Engine/Gramambular/GramambularTest.cpp
@@ -1,0 +1,238 @@
+// Copyright (c) 2022 and onwards Lukhnos Liu
+//
+// Permission is hereby granted, free of charge, to any person
+// obtaining a copy of this software and associated documentation
+// files (the "Software"), to deal in the Software without
+// restriction, including without limitation the rights to use,
+// copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following
+// conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+// OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+// HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+// OTHER DEALINGS IN THE SOFTWARE.
+
+#include <algorithm>
+#include <cstdlib>
+#include <iostream>
+#include <map>
+#include <sstream>
+#include <vector>
+
+#include "Gramambular.h"
+#include "gtest/gtest.h"
+
+namespace Formosa {
+namespace Gramambular {
+
+const char* SampleData = R"(
+#
+# The sample is from libtabe (http://sourceforge.net/projects/libtabe/)
+# last updated in 2002. The project was originally initiated by
+# Pai-Hsiang Hsiao in 1999.
+#
+# Libtabe is a frequency table of Taiwanese Mandarin words. The database
+# itself is, according to the tar file, released under the BSD License.
+#
+
+ㄙ 絲 -9.495858
+ㄙ 思 -9.006414
+ㄙ 私 -99.000000
+ㄙ 斯 -8.091803
+ㄙ 司 -99.000000
+ㄙ 嘶 -13.513987
+ㄙ 撕 -12.259095
+ㄍㄠ 高 -7.171551
+ㄎㄜ 顆 -10.574273
+ㄎㄜ 棵 -11.504072
+ㄎㄜ 刻 -10.450457
+ㄎㄜ 科 -7.171052
+ㄎㄜ 柯 -99.000000
+ㄍㄠ 膏 -11.928720
+ㄍㄠ 篙 -13.624335
+ㄍㄠ 糕 -12.390804
+ㄉㄜ˙ 的 -3.516024
+ㄉㄧˊ 的 -3.516024
+ㄉㄧˋ 的 -3.516024
+ㄓㄨㄥ 中 -5.809297
+ㄉㄜ˙ 得 -7.427179
+ㄍㄨㄥ 共 -8.381971
+ㄍㄨㄥ 供 -8.501463
+ㄐㄧˋ 既 -99.000000
+ㄐㄧㄣ 今 -8.034095
+ㄍㄨㄥ 紅 -8.858181
+ㄐㄧˋ 際 -7.608341
+ㄐㄧˋ 季 -99.000000
+ㄐㄧㄣ 金 -7.290109
+ㄐㄧˋ 騎 -10.939895
+ㄓㄨㄥ 終 -99.000000
+ㄐㄧˋ 記 -99.000000
+ㄐㄧˋ 寄 -99.000000
+ㄐㄧㄣ 斤 -99.000000
+ㄐㄧˋ 繼 -9.715317
+ㄐㄧˋ 計 -7.926683
+ㄐㄧˋ 暨 -8.373022
+ㄓㄨㄥ 鐘 -9.877580
+ㄐㄧㄣ 禁 -10.711079
+ㄍㄨㄥ 公 -7.877973
+ㄍㄨㄥ 工 -7.822167
+ㄍㄨㄥ 攻 -99.000000
+ㄍㄨㄥ 功 -99.000000
+ㄍㄨㄥ 宮 -99.000000
+ㄓㄨㄥ 鍾 -9.685671
+ㄐㄧˋ 繫 -10.425662
+ㄍㄨㄥ 弓 -99.000000
+ㄍㄨㄥ 恭 -99.000000
+ㄐㄧˋ 劑 -8.888722
+ㄐㄧˋ 祭 -10.204425
+ㄐㄧㄣ 浸 -11.378321
+ㄓㄨㄥ 盅 -99.000000
+ㄐㄧˋ 忌 -99.000000
+ㄐㄧˋ 技 -8.450826
+ㄐㄧㄣ 筋 -11.074890
+ㄍㄨㄥ 躬 -99.000000
+ㄐㄧˋ 冀 -12.045357
+ㄓㄨㄥ 忠 -99.000000
+ㄐㄧˋ 妓 -99.000000
+ㄐㄧˋ 濟 -9.517568
+ㄐㄧˋ 薊 -12.021587
+ㄐㄧㄣ 巾 -99.000000
+ㄐㄧㄣ 襟 -12.784206
+ㄋㄧㄢˊ 年 -6.086515
+ㄐㄧㄤˇ 講 -9.164384
+ㄐㄧㄤˇ 獎 -8.690941
+ㄐㄧㄤˇ 蔣 -10.127828
+ㄋㄧㄢˊ 黏 -11.336864
+ㄋㄧㄢˊ 粘 -11.285740
+ㄐㄧㄤˇ 槳 -12.492933
+ㄍㄨㄥㄙ 公司 -6.299461
+ㄎㄜㄐㄧˋ 科技 -6.736613
+ㄐㄧˋㄍㄨㄥ 濟公 -13.336653
+ㄐㄧㄤˇㄐㄧㄣ 獎金 -10.344678
+ㄋㄧㄢˊㄓㄨㄥ 年終 -11.668947
+ㄋㄧㄢˊㄓㄨㄥ 年中 -11.373044
+ㄍㄠㄎㄜㄐㄧˋ 高科技 -9.842421
+)";
+
+class SimpleLM : public LanguageModel {
+ public:
+  SimpleLM(const char* input, bool swapKeyValue = false) {
+    std::stringstream sstream(input);
+    while (sstream.good()) {
+      std::string line;
+      getline(sstream, line);
+
+      if (!line.size() || (line.size() && line[0] == '#')) {
+        continue;
+      }
+
+      std::stringstream linestream(line);
+      std::string col0;
+      std::string col1;
+      std::string col2;
+      linestream >> col0;
+      linestream >> col1;
+      linestream >> col2;
+
+      Unigram u;
+
+      if (swapKeyValue) {
+        u.keyValue.key = col1;
+        u.keyValue.value = col0;
+      } else {
+        u.keyValue.key = col0;
+        u.keyValue.value = col1;
+      }
+
+      u.score = atof(col2.c_str());
+
+      m_db[u.keyValue.key].push_back(u);
+    }
+  }
+
+  const std::vector<Unigram> unigramsForKey(const std::string& key) override {
+    std::map<std::string, std::vector<Unigram>>::const_iterator f =
+        m_db.find(key);
+    return f == m_db.end() ? std::vector<Unigram>() : (*f).second;
+  }
+
+  bool hasUnigramsForKey(const std::string& key) override {
+    std::map<std::string, std::vector<Unigram>>::const_iterator f =
+        m_db.find(key);
+    return f != m_db.end();
+  }
+
+ protected:
+  std::map<std::string, std::vector<Unigram>> m_db;
+};
+
+TEST(GramambularTest, InputTest) {
+  SimpleLM lm(SampleData);
+
+  BlockReadingBuilder builder(&lm);
+  builder.insertReadingAtCursor("ㄍㄠ");
+  builder.insertReadingAtCursor("ㄐㄧˋ");
+  builder.setCursorIndex(1);
+  builder.insertReadingAtCursor("ㄎㄜ");
+  builder.setCursorIndex(0);
+  builder.deleteReadingAfterCursor();
+  builder.insertReadingAtCursor("ㄍㄠ");
+  builder.setCursorIndex(builder.length());
+  builder.insertReadingAtCursor("ㄍㄨㄥ");
+  builder.insertReadingAtCursor("ㄙ");
+  builder.insertReadingAtCursor("ㄉㄜ˙");
+  builder.insertReadingAtCursor("ㄋㄧㄢˊ");
+  builder.insertReadingAtCursor("ㄓㄨㄥ");
+  builder.insertReadingAtCursor("ㄐㄧㄤˇ");
+  builder.insertReadingAtCursor("ㄐㄧㄣ");
+
+  Walker walker(&builder.grid());
+
+  std::vector<NodeAnchor> walked = walker.walk(0, 0.0);
+
+  std::vector<std::string> composed;
+  for (std::vector<NodeAnchor>::iterator wi = walked.begin();
+       wi != walked.end(); ++wi) {
+    composed.push_back((*wi).node->currentKeyValue().value);
+  }
+  ASSERT_EQ(composed,
+            (std::vector<std::string>{"高科技", "公司", "的", "年中", "獎金"}));
+}
+
+TEST(GramambularTest, WordSegmentationTest) {
+  SimpleLM lm2(SampleData, true);
+  BlockReadingBuilder builder2(&lm2);
+  builder2.insertReadingAtCursor("高");
+  builder2.insertReadingAtCursor("科");
+  builder2.insertReadingAtCursor("技");
+  builder2.insertReadingAtCursor("公");
+  builder2.insertReadingAtCursor("司");
+  builder2.insertReadingAtCursor("的");
+  builder2.insertReadingAtCursor("年");
+  builder2.insertReadingAtCursor("終");
+  builder2.insertReadingAtCursor("獎");
+  builder2.insertReadingAtCursor("金");
+  Walker walker2(&builder2.grid());
+
+  std::vector<NodeAnchor> walked = walker2.walk(0, 0.0);
+
+  std::vector<std::string> segmented;
+  for (std::vector<NodeAnchor>::iterator wi = walked.begin();
+       wi != walked.end(); ++wi) {
+    segmented.push_back((*wi).node->currentKeyValue().key);
+  }
+  ASSERT_EQ(segmented,
+            (std::vector<std::string>{"高科技", "公司", "的", "年終", "獎金"}));
+}
+
+}  // namespace Gramambular
+}  // namespace Formosa

--- a/src/Engine/KeyValueBlobReaderTest.cpp
+++ b/src/Engine/KeyValueBlobReaderTest.cpp
@@ -1,0 +1,255 @@
+// Copyright (c) 2022 and onwards The McBopomofo Authors.
+//
+// Permission is hereby granted, free of charge, to any person
+// obtaining a copy of this software and associated documentation
+// files (the "Software"), to deal in the Software without
+// restriction, including without limitation the rights to use,
+// copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following
+// conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+// OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+// HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+// OTHER DEALINGS IN THE SOFTWARE.
+
+#include <string>
+
+#include "KeyValueBlobReader.h"
+#include "gtest/gtest.h"
+
+namespace McBopomofo {
+
+using State = KeyValueBlobReader::State;
+using KeyValue = KeyValueBlobReader::KeyValue;
+
+TEST(KeyValueBlobReaderTest, EmptyBlob)
+{
+    std::string empty;
+    KeyValueBlobReader reader(empty.c_str(), empty.length());
+    EXPECT_EQ(reader.Next(), State::END);
+}
+
+TEST(KeyValueBlobReaderTest, EmptyBlobIdempotency)
+{
+    char empty[0];
+    KeyValueBlobReader reader(empty, 0);
+    EXPECT_EQ(reader.Next(), State::END);
+    EXPECT_EQ(reader.Next(), State::END);
+}
+
+TEST(KeyValueBlobReaderTest, BlankBlob)
+{
+    std::string blank = " ";
+    KeyValueBlobReader reader(blank.c_str(), blank.length());
+    EXPECT_EQ(reader.Next(), State::END);
+}
+
+TEST(KeyValueBlobReaderTest, KeyWithoutValueIsInvalid)
+{
+    std::string empty = "hello";
+    KeyValueBlobReader reader(empty.c_str(), empty.length());
+    EXPECT_EQ(reader.Next(), State::ERROR);
+}
+
+TEST(KeyValueBlobReaderTest, ErrorStateMakesNoMoreProgress)
+{
+    std::string empty = "hello";
+    KeyValueBlobReader reader(empty.c_str(), empty.length());
+    EXPECT_EQ(reader.Next(), State::ERROR);
+    EXPECT_EQ(reader.Next(), State::ERROR);
+}
+
+TEST(KeyValueBlobReaderTest, KeyValueSeparatedByNullCharIsInvalid)
+{
+    char bad[] = { 'h', 0, 'w' };
+    KeyValueBlobReader reader(bad, sizeof(bad));
+    EXPECT_EQ(reader.Next(), State::ERROR);
+}
+
+TEST(KeyValueBlobReaderTest, SingleKeyValuePair)
+{
+    std::string empty = "hello world\n";
+    KeyValueBlobReader reader(empty.c_str(), empty.length());
+    KeyValue keyValue;
+    EXPECT_EQ(reader.Next(&keyValue), State::HAS_PAIR);
+    EXPECT_EQ(keyValue, (KeyValue { "hello", "world" }));
+    EXPECT_EQ(reader.Next(), State::END);
+}
+
+TEST(KeyValueBlobReaderTest, SingleKeyValuePairFromButterWithoutNullEnding)
+{
+    char small[] = { 'p', ' ', 'q' };
+    KeyValueBlobReader reader(small, sizeof(small));
+    KeyValue keyValue;
+    EXPECT_EQ(reader.Next(&keyValue), State::HAS_PAIR);
+    EXPECT_EQ(keyValue, (KeyValue { "p", "q" }));
+    EXPECT_EQ(reader.Next(), State::END);
+}
+
+TEST(KeyValueBlobReaderTest, NullCharInTheMiddleTerminatesParsing)
+{
+    char small[] = { 'p', ' ', 'q', ' ', 0, '\n', 'r', ' ', 's' };
+    KeyValueBlobReader reader(small, sizeof(small));
+    KeyValue keyValue;
+    EXPECT_EQ(reader.Next(&keyValue), State::HAS_PAIR);
+    EXPECT_EQ(keyValue, (KeyValue { "p", "q" }));
+    EXPECT_EQ(reader.Next(), State::END);
+}
+
+TEST(KeyValueBlobReaderTest, SingleKeyValuePairWithoutLFAtEnd)
+{
+    std::string simple = "hello world";
+    KeyValueBlobReader reader(simple.c_str(), simple.length());
+    KeyValue keyValue;
+    EXPECT_EQ(reader.Next(&keyValue), State::HAS_PAIR);
+    EXPECT_EQ(keyValue, (KeyValue { "hello", "world" }));
+    EXPECT_EQ(reader.Next(), State::END);
+}
+
+TEST(KeyValueBlobReaderTest, EncodingAgnostic1)
+{
+    std::string simple = u8"smile ☺️";
+    KeyValueBlobReader reader(simple.c_str(), simple.length());
+    KeyValue keyValue;
+    EXPECT_EQ(reader.Next(&keyValue), State::HAS_PAIR);
+    EXPECT_EQ(keyValue, (KeyValue { "smile", u8"☺️" }));
+    EXPECT_EQ(reader.Next(), State::END);
+}
+
+TEST(KeyValueBlobReaderTest, EncodingAgnostic2)
+{
+    std::string simple = "Nobel-Laureate "
+                         "\xe9\x81\x94\xe8\xb3\xb4\xe5\x96\x87\xe5\x98\x9b";
+    KeyValueBlobReader reader(simple.c_str(), simple.length());
+    KeyValue keyValue;
+    EXPECT_EQ(reader.Next(&keyValue), State::HAS_PAIR);
+    EXPECT_EQ(keyValue,
+        (KeyValue { "Nobel-Laureate",
+            "\xe9\x81\x94\xe8\xb3\xb4\xe5\x96\x87\xe5\x98\x9b" }));
+    EXPECT_EQ(reader.Next(), State::END);
+}
+
+TEST(KeyValueBlobReaderTest, ValueDoesNotIncludeSpace)
+{
+    std::string simple = "hello world and all\nanother value";
+    KeyValueBlobReader reader(simple.c_str(), simple.length());
+    KeyValue keyValue;
+    EXPECT_EQ(reader.Next(&keyValue), State::HAS_PAIR);
+    EXPECT_EQ(keyValue, (KeyValue { "hello", "world" }));
+    EXPECT_EQ(reader.Next(&keyValue), State::HAS_PAIR);
+    EXPECT_EQ(keyValue, (KeyValue { "another", "value" }));
+    EXPECT_EQ(reader.Next(), State::END);
+}
+
+TEST(KeyValueBlobReaderTest, TrailingSpaceInValueIsIgnored)
+{
+    std::string simple
+        = "\thello   world        \n\n    foo bar \t\t\t   \n\n\n";
+    KeyValueBlobReader reader(simple.c_str(), simple.length());
+    KeyValue keyValue;
+    EXPECT_EQ(reader.Next(&keyValue), State::HAS_PAIR);
+    EXPECT_EQ(keyValue, (KeyValue { "hello", "world" }));
+    EXPECT_EQ(reader.Next(&keyValue), State::HAS_PAIR);
+    EXPECT_EQ(keyValue, (KeyValue { "foo", "bar" }));
+    EXPECT_EQ(reader.Next(), State::END);
+}
+
+TEST(KeyValueBlobReaderTest, WindowsCRLFSupported)
+{
+    std::string simple = "lorem ipsum\r\nhello world";
+    KeyValueBlobReader reader(simple.c_str(), simple.length());
+    KeyValue keyValue;
+    EXPECT_EQ(reader.Next(&keyValue), State::HAS_PAIR);
+    EXPECT_EQ(keyValue, (KeyValue { "lorem", "ipsum" }));
+    EXPECT_EQ(reader.Next(&keyValue), State::HAS_PAIR);
+    EXPECT_EQ(keyValue, (KeyValue { "hello", "world" }));
+    EXPECT_EQ(reader.Next(), State::END);
+}
+
+TEST(KeyValueBlobReaderTest, MultipleKeyValuePair)
+{
+    std::string multi = "\n   \nhello world\n  foo \t bar  ";
+    KeyValueBlobReader reader(multi.c_str(), multi.length());
+    KeyValue keyValue;
+    EXPECT_EQ(reader.Next(&keyValue), State::HAS_PAIR);
+    EXPECT_EQ(keyValue, (KeyValue { "hello", "world" }));
+    EXPECT_EQ(reader.Next(&keyValue), State::HAS_PAIR);
+    EXPECT_EQ(keyValue, (KeyValue { "foo", "bar" }));
+    EXPECT_EQ(reader.Next(), State::END);
+}
+
+TEST(KeyValueBlobReaderTest, ReadUntilNullChar)
+{
+    char buf[] = { 'p', '\t', 'q', '\n', 0, 'r', ' ', 's' };
+    KeyValueBlobReader reader(buf, sizeof(buf));
+    KeyValue keyValue;
+    EXPECT_EQ(reader.Next(&keyValue), State::HAS_PAIR);
+    EXPECT_EQ(keyValue, (KeyValue { "p", "q" }));
+    EXPECT_EQ(reader.Next(), State::END);
+}
+
+TEST(KeyValueBlobReaderTest, MultipleKeyValuePairWithComments)
+{
+    std::string text = R"(
+# comment1
+# comment2
+
+# comment3
+  hello World
+  caffè latte
+
+    # another comment
+  foo bar
+
+# comment4
+# comment5
+)";
+
+    KeyValueBlobReader reader(text.c_str(), text.length());
+    KeyValue keyValue;
+    EXPECT_EQ(reader.Next(&keyValue), State::HAS_PAIR);
+    EXPECT_EQ(keyValue, (KeyValue { "hello", "World" }));
+    EXPECT_EQ(reader.Next(&keyValue), State::HAS_PAIR);
+    EXPECT_EQ(keyValue, (KeyValue { "caffè", "latte" }));
+    EXPECT_EQ(reader.Next(&keyValue), State::HAS_PAIR);
+    EXPECT_EQ(keyValue, (KeyValue { "foo", "bar" }));
+    EXPECT_EQ(reader.Next(), State::END);
+}
+
+TEST(KeyValueBlobReaderTest, ValueCommentSupported)
+{
+    std::string text = R"(
+  # empty
+
+  hello world#peace
+       hello world#peace #peace
+hello world#peace  // peace
+  caffè latte # café au lait
+  foo bar
+)";
+
+    KeyValueBlobReader reader(text.c_str(), text.length());
+    KeyValue keyValue;
+    EXPECT_EQ(reader.Next(&keyValue), State::HAS_PAIR);
+    EXPECT_EQ(keyValue, (KeyValue { "hello", "world#peace" }));
+    EXPECT_EQ(reader.Next(&keyValue), State::HAS_PAIR);
+    EXPECT_EQ(keyValue, (KeyValue { "hello", "world#peace" }));
+    EXPECT_EQ(reader.Next(&keyValue), State::HAS_PAIR);
+    EXPECT_EQ(keyValue, (KeyValue { "hello", "world#peace" }));
+    EXPECT_EQ(reader.Next(&keyValue), State::HAS_PAIR);
+    EXPECT_EQ(keyValue, (KeyValue { "caffè", "latte" }));
+    EXPECT_EQ(reader.Next(&keyValue), State::HAS_PAIR);
+    EXPECT_EQ(keyValue, (KeyValue { "foo", "bar" }));
+    EXPECT_EQ(reader.Next(), State::END);
+}
+
+} // namespace McBopomofo

--- a/src/Engine/Mandarin/CMakeLists.txt
+++ b/src/Engine/Mandarin/CMakeLists.txt
@@ -1,0 +1,31 @@
+cmake_minimum_required(VERSION 3.17)
+project(Mandarin)
+
+set(CMAKE_CXX_STANDARD 17)
+
+add_library(MandarinLib Mandarin.h Mandarin.cpp)
+
+# Let CMake fetch Google Test for us.
+# https://github.com/google/googletest/tree/main/googletest#incorporating-into-an-existing-cmake-project
+include(FetchContent)
+
+FetchContent_Declare(
+        googletest
+        # Specify the commit you depend on and update it regularly.
+        URL https://github.com/google/googletest/archive/609281088cfefc76f9d0ce82e1ff6c30cc3591e5.zip
+)
+# For Windows: Prevent overriding the parent project's compiler/linker settings
+set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
+FetchContent_MakeAvailable(googletest)
+
+# Test target declarations.
+add_executable(MandarinTest MandarinTest.cpp)
+target_link_libraries(MandarinTest gtest_main MandarinLib)
+include(GoogleTest)
+gtest_discover_tests(MandarinTest)
+
+add_custom_target(
+        runMandarinTest
+        COMMAND ${CMAKE_CURRENT_BINARY_DIR}/MandarinTest
+)
+add_dependencies(runMandarinTest MandarinTest)

--- a/src/Engine/Mandarin/MandarinTest.cpp
+++ b/src/Engine/Mandarin/MandarinTest.cpp
@@ -1,0 +1,120 @@
+// Copyright (c) 2022 and onwards Lukhnos Liu
+//
+// Permission is hereby granted, free of charge, to any person
+// obtaining a copy of this software and associated documentation
+// files (the "Software"), to deal in the Software without
+// restriction, including without limitation the rights to use,
+// copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following
+// conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+// OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+// HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+// OTHER DEALINGS IN THE SOFTWARE.
+
+#include "Mandarin.h"
+#include "gtest/gtest.h"
+
+namespace Formosa {
+namespace Mandarin {
+
+static std::string RoundTrip(const std::string& composedString) {
+  return BopomofoSyllable::FromComposedString(composedString).composedString();
+}
+
+TEST(MandarinTest, FromComposedString) {
+  ASSERT_EQ(RoundTrip("ㄅ"), "ㄅ");
+  ASSERT_EQ(RoundTrip("ㄅㄧ"), "ㄅㄧ");
+  ASSERT_EQ(RoundTrip("ㄅㄧˇ"), "ㄅㄧˇ");
+  ASSERT_EQ(RoundTrip("ㄅㄧˇㄆ"), "ㄆㄧˇ");
+  ASSERT_EQ(RoundTrip("ㄅㄧˇㄆ"), "ㄆㄧˇ");
+  ASSERT_EQ(RoundTrip("e"), "");
+  ASSERT_EQ(RoundTrip("é"), "");
+  ASSERT_EQ(RoundTrip("ㄅéㄆ"), "ㄅ");
+  ASSERT_EQ(RoundTrip("ㄅeㄆ"), "ㄅ");
+}
+
+TEST(MandarinTest, SimpleCompositions) {
+  BopomofoSyllable syllable;
+  syllable += BopomofoSyllable(BopomofoSyllable::X);
+  syllable += BopomofoSyllable(BopomofoSyllable::I);
+  ASSERT_EQ(syllable.composedString(), "ㄒㄧ");
+
+  syllable.clear();
+  syllable += BopomofoSyllable(BopomofoSyllable::Z);
+  syllable += BopomofoSyllable(BopomofoSyllable::ANG);
+  syllable += BopomofoSyllable(BopomofoSyllable::Tone4);
+  ASSERT_EQ(syllable.composedString(), "ㄗㄤˋ");
+}
+
+TEST(MandarinTest, StandardLayout) {
+  BopomofoReadingBuffer buf(BopomofoKeyboardLayout::StandardLayout());
+  buf.combineKey('w');
+  buf.combineKey('9');
+  buf.combineKey('6');
+  ASSERT_EQ(buf.composedString(), "ㄊㄞˊ");
+}
+
+TEST(MandarinTest, StandardLayoutCombination) {
+  BopomofoReadingBuffer buf(BopomofoKeyboardLayout::StandardLayout());
+  buf.combineKey('w');
+  buf.combineKey('9');
+  buf.combineKey('6');
+  ASSERT_EQ(buf.composedString(), "ㄊㄞˊ");
+
+  buf.backspace();
+  ASSERT_EQ(buf.composedString(), "ㄊㄞ");
+
+  buf.combineKey('y');
+  ASSERT_EQ(buf.composedString(), "ㄗㄞ");
+
+  buf.combineKey('4');
+  ASSERT_EQ(buf.composedString(), "ㄗㄞˋ");
+
+  buf.combineKey('3');
+  ASSERT_EQ(buf.composedString(), "ㄗㄞˇ");
+}
+
+TEST(MandarinTest, ETenLayout) {
+  BopomofoReadingBuffer buf(BopomofoKeyboardLayout::ETenLayout());
+  buf.combineKey('x');
+  buf.combineKey('8');
+  ASSERT_EQ(buf.composedString(), "ㄨㄢ");
+}
+
+TEST(MandarinTest, ETen26Layout) {
+  BopomofoReadingBuffer buf(BopomofoKeyboardLayout::ETen26Layout());
+  buf.combineKey('q');
+  buf.combineKey('m');  // AN in the vowel state
+  buf.combineKey('k');  // Tone 4 in the tone state
+  ASSERT_EQ(buf.composedString(), "ㄗㄢˋ");
+}
+
+TEST(MandarinTest, HsuLayout) {
+  BopomofoReadingBuffer buf(BopomofoKeyboardLayout::HsuLayout());
+  buf.combineKey('f');
+  buf.combineKey('a');  // EI when in the vowel state
+  buf.combineKey('f');  // Tone 3 when in the tone state
+  ASSERT_EQ(buf.composedString(), "ㄈㄟˇ");
+}
+
+TEST(MandarinTest, IBMLayout) {
+  BopomofoReadingBuffer buf(BopomofoKeyboardLayout::IBMLayout());
+  buf.combineKey('9');
+  buf.combineKey('s');
+  buf.combineKey('g');
+  buf.combineKey('m');
+  ASSERT_EQ(buf.composedString(), "ㄍㄨㄛˊ");
+}
+
+}  // namespace Mandarin
+}  // namespace Formosa

--- a/src/Engine/ParselessLMTest.cpp
+++ b/src/Engine/ParselessLMTest.cpp
@@ -1,0 +1,59 @@
+// Copyright (c) 2022 and onwards The McBopomofo Authors.
+//
+// Permission is hereby granted, free of charge, to any person
+// obtaining a copy of this software and associated documentation
+// files (the "Software"), to deal in the Software without
+// restriction, including without limitation the rights to use,
+// copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following
+// conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+// OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+// HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+// OTHER DEALINGS IN THE SOFTWARE.
+
+#include <filesystem>
+#include <iostream>
+
+#include "ParselessLM.h"
+#include "gtest/gtest.h"
+
+namespace McBopomofo {
+
+TEST(ParselessLMTest, SanityCheckTest)
+{
+    constexpr const char* data_path = "data.txt";
+    if (!std::filesystem::exists(data_path)) {
+        GTEST_SKIP();
+    }
+
+    ParselessLM lm;
+    bool status = lm.open(data_path);
+    ASSERT_TRUE(status);
+
+    ASSERT_TRUE(lm.hasUnigramsForKey("ㄕ"));
+    ASSERT_TRUE(lm.hasUnigramsForKey("ㄕˋ-ㄕˊ"));
+    ASSERT_TRUE(lm.hasUnigramsForKey("_punctuation_list"));
+
+    auto unigrams = lm.unigramsForKey("ㄕ");
+    ASSERT_GT(unigrams.size(), 0);
+
+    unigrams = lm.unigramsForKey("ㄕˋ-ㄕˊ");
+    ASSERT_GT(unigrams.size(), 0);
+
+    unigrams = lm.unigramsForKey("_punctuation_list");
+    ASSERT_GT(unigrams.size(), 0);
+
+    lm.close();
+}
+
+}; // namespace McBopomofo

--- a/src/Engine/ParselessPhraseDBTest.cpp
+++ b/src/Engine/ParselessPhraseDBTest.cpp
@@ -1,0 +1,198 @@
+// Copyright (c) 2022 and onwards The McBopomofo Authors.
+//
+// Permission is hereby granted, free of charge, to any person
+// obtaining a copy of this software and associated documentation
+// files (the "Software"), to deal in the Software without
+// restriction, including without limitation the rights to use,
+// copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following
+// conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+// OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+// HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+// OTHER DEALINGS IN THE SOFTWARE.
+
+#include <cstdio>
+#include <filesystem>
+#include <map>
+#include <sstream>
+#include <vector>
+
+#include "ParselessPhraseDB.h"
+#include "gtest/gtest-death-test.h"
+#include "gtest/gtest.h"
+
+using StringViews = std::vector<std::string_view>;
+
+namespace McBopomofo {
+
+static bool VectorsEqual(
+    const std::vector<std::string_view>& a, const std::vector<std::string>& b)
+{
+    if (a.size() != b.size()) {
+        return false;
+    }
+
+    size_t s = a.size();
+    for (size_t i = 0; i < s; i++) {
+        if (a[i] != b[i]) {
+            return false;
+        }
+    }
+    return true;
+}
+
+TEST(ParselessPhraseDBTest, Simple)
+{
+    std::string data = "a 1";
+    ParselessPhraseDB db(data.c_str(), data.length());
+
+    const char* first = db.findFirstMatchingLine("a");
+    EXPECT_NE(first, nullptr);
+    EXPECT_EQ(memcmp(first, "a 1", 3), 0);
+
+    first = db.findFirstMatchingLine("a ");
+    EXPECT_NE(first, nullptr);
+    EXPECT_EQ(memcmp(first, "a 1", 3), 0);
+
+    first = db.findFirstMatchingLine("a 1");
+    EXPECT_NE(first, nullptr);
+    EXPECT_EQ(memcmp(first, "a 1", 3), 0);
+}
+
+TEST(ParselessPhraseDBTest, NotFound)
+{
+    std::string data = "a 1\na 2\na 3\nb 1";
+    ParselessPhraseDB db(data.c_str(), data.length());
+    EXPECT_EQ(db.findFirstMatchingLine("c"), nullptr);
+    EXPECT_EQ(db.findFirstMatchingLine("A"), nullptr);
+}
+
+TEST(ParselessPhraseDBTest, FindRowsLongerExample)
+{
+    std::string data = "a 1\na 2\na 3\nb 42\nb 1\nb 2\nc 7\nd 1";
+    ParselessPhraseDB db(data.c_str(), data.length());
+
+    EXPECT_EQ(db.findRows("a"), (StringViews { "a 1", "a 2", "a 3" }));
+    EXPECT_EQ(db.findRows("b"), (StringViews { "b 42", "b 1", "b 2" }));
+    EXPECT_EQ(db.findRows("c"), (StringViews { "c 7" }));
+    EXPECT_EQ(db.findRows("d"), (StringViews { "d 1" }));
+    EXPECT_EQ(db.findRows("e"), (StringViews {}));
+    EXPECT_EQ(db.findRows("A"), (StringViews {}));
+}
+
+TEST(ParselessPhraseDBTest, FindFirstMatchingLineLongerExample)
+{
+    std::string data = "a 1\na 2\na 3\nb 42\nb 1\nb 2\nc 7\nd 1";
+    ParselessPhraseDB db(data.c_str(), data.length());
+
+    const char* first = db.findFirstMatchingLine("a");
+    EXPECT_NE(first, nullptr);
+    EXPECT_EQ(memcmp(first, "a 1", 3), 0);
+
+    db.findFirstMatchingLine("a 1");
+    EXPECT_NE(first, nullptr);
+    EXPECT_EQ(memcmp(first, "a 1", 3), 0);
+
+    first = db.findFirstMatchingLine("b");
+    EXPECT_NE(first, nullptr);
+    EXPECT_EQ(memcmp(first, "b 42", 4), 0);
+
+    first = db.findFirstMatchingLine("c");
+    EXPECT_NE(first, nullptr);
+    EXPECT_EQ(memcmp(first, "c 7", 3), 0);
+
+    first = db.findFirstMatchingLine("d");
+    EXPECT_NE(first, nullptr);
+    EXPECT_EQ(memcmp(first, "d 1", 3), 0);
+
+    first = db.findFirstMatchingLine("d 1");
+    EXPECT_NE(first, nullptr);
+    EXPECT_EQ(memcmp(first, "d 1", 3), 0);
+
+    first = db.findFirstMatchingLine("d 2");
+    EXPECT_EQ(first, nullptr);
+}
+
+TEST(ParselessPhraseDBTest, InvalidConstructorArguments)
+{
+    EXPECT_DEATH((ParselessPhraseDB { nullptr, 1 }), "buf != nullptr");
+    EXPECT_DEATH((ParselessPhraseDB { nullptr, 0 }), "buf != nullptr");
+    EXPECT_DEATH((ParselessPhraseDB { "", 0 }), "length > 0");
+    EXPECT_DEATH((ParselessPhraseDB { "a", 1, /*validate_pragma=*/true }),
+        "length > SORTED_PRAGMA_HEADER\\.length\\(\\)");
+}
+
+TEST(ParselessPhraseDBTest, PragmaGuard)
+{
+    std::string buf1 = std::string(SORTED_PRAGMA_HEADER) + "a";
+    std::string buf2 = "#" + buf1;
+    std::string buf3 = buf1;
+    buf3[3] = 'x';
+
+    ParselessPhraseDB { buf1.c_str(), buf1.length(), /*validate_pragma=*/true };
+    EXPECT_DEATH(
+        (ParselessPhraseDB { buf2.c_str(), buf2.length(), /*validate_pragma=*/
+            true }),
+        "==");
+    EXPECT_DEATH(
+        (ParselessPhraseDB { buf3.c_str(), buf3.length(), /*validate_pragma=*/
+            true }),
+        "==");
+}
+
+TEST(ParselessPhraseDBTest, StressTest)
+{
+    constexpr const char* data_path = "data.txt";
+    if (!std::filesystem::exists(data_path)) {
+        GTEST_SKIP();
+    }
+
+    FILE* f = fopen(data_path, "r");
+    ASSERT_NE(f, nullptr);
+    int status = fseek(f, 0L, SEEK_END);
+    ASSERT_EQ(status, 0);
+    size_t length = ftell(f);
+    std::unique_ptr<char[]> buf(new char[length]);
+    status = fseek(f, 0L, SEEK_SET);
+    ASSERT_EQ(status, 0);
+    size_t items_read = fread(buf.get(), length, 1, f);
+    ASSERT_EQ(items_read, 1);
+    fclose(f);
+
+    std::stringstream sstr(std::string(buf.get(), length));
+    std::string line;
+    std::map<std::string, std::vector<std::string>> key_to_lines;
+
+    // Skip the pragma line.
+    std::getline(sstr, line);
+
+    while (!sstr.eof()) {
+        std::getline(sstr, line);
+        if (line == "") {
+            continue;
+        }
+
+        std::stringstream linest(line);
+        std::string key;
+        linest >> key;
+        key_to_lines[key].push_back(line);
+    }
+
+    ParselessPhraseDB db(buf.get(), length, /*validate_pragma=*/true);
+    for (const auto& it : key_to_lines) {
+        std::vector<std::string_view> rows = db.findRows(it.first + " ");
+        ASSERT_TRUE(VectorsEqual(rows, it.second));
+    }
+}
+
+}; // namespace McBopomofo

--- a/src/Engine/PhraseReplacementMapTest.cpp
+++ b/src/Engine/PhraseReplacementMapTest.cpp
@@ -1,0 +1,58 @@
+// Copyright (c) 2022 and onwards The McBopomofo Authors.
+//
+// Permission is hereby granted, free of charge, to any person
+// obtaining a copy of this software and associated documentation
+// files (the "Software"), to deal in the Software without
+// restriction, including without limitation the rights to use,
+// copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following
+// conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+// OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+// HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+// OTHER DEALINGS IN THE SOFTWARE.
+
+#include <cstdio>
+#include <filesystem>
+#include <string>
+
+#include "PhraseReplacementMap.h"
+#include "gtest/gtest.h"
+
+namespace McBopomofo {
+
+TEST(PhraseReplacementMapTest, LenientReading)
+{
+    std::string tmp_name
+        = std::string(std::filesystem::temp_directory_path() / "test.txt");
+    FILE* f = fopen(tmp_name.c_str(), "w");
+    ASSERT_NE(f, nullptr);
+
+    fprintf(f, "key value\n");
+    fprintf(f, "key2\n"); // error line
+    fprintf(f, "key3 value2\n");
+    int r = fclose(f);
+    ASSERT_EQ(r, 0);
+
+    PhraseReplacementMap map;
+    map.open(tmp_name.c_str());
+    ASSERT_EQ(map.valueForKey("key"), "value");
+    ASSERT_EQ(map.valueForKey("key2"), "");
+
+    // key2 causes parsing error, and the line that has key3 won't be parsed.
+    ASSERT_EQ(map.valueForKey("key3"), "");
+
+    r = remove(tmp_name.c_str());
+    ASSERT_EQ(r, 0);
+}
+
+} // namespace McBopomofo

--- a/src/Engine/UserPhrasesLMTest.cpp
+++ b/src/Engine/UserPhrasesLMTest.cpp
@@ -1,0 +1,59 @@
+// Copyright (c) 2022 and onwards The McBopomofo Authors.
+//
+// Permission is hereby granted, free of charge, to any person
+// obtaining a copy of this software and associated documentation
+// files (the "Software"), to deal in the Software without
+// restriction, including without limitation the rights to use,
+// copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following
+// conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+// OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+// HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+// OTHER DEALINGS IN THE SOFTWARE.
+
+#include <cstdio>
+#include <filesystem>
+#include <string>
+
+#include "UserPhrasesLM.h"
+#include "gtest/gtest.h"
+
+namespace McBopomofo {
+
+TEST(UserPhreasesLMTest, LenientReading)
+{
+    std::string tmp_name
+        = std::string(std::filesystem::temp_directory_path() / "test.txt");
+
+    FILE* f = fopen(tmp_name.c_str(), "w");
+    ASSERT_NE(f, nullptr);
+
+    fprintf(f, "value1 reading1\n");
+    fprintf(f, "value2 \n"); // error line
+    fprintf(f, "value3 reading2\n");
+    int r = fclose(f);
+    ASSERT_EQ(r, 0);
+
+    UserPhrasesLM lm;
+    lm.open(tmp_name.c_str());
+    ASSERT_TRUE(lm.hasUnigramsForKey("reading1"));
+    ASSERT_FALSE(lm.hasUnigramsForKey("value2"));
+
+    // Anything after the error won't be parsed, so reading2 won't be found.
+    ASSERT_FALSE(lm.hasUnigramsForKey("reading2"));
+
+    r = remove(tmp_name.c_str());
+    ASSERT_EQ(r, 0);
+}
+
+} // namespace McBopomofo


### PR DESCRIPTION
This imports the test code from the macOS version and updates the CI settings to run the engine tests (`McBopomofoLMLibTest`). This does not affect how the main IME project is currently structured: I'd like restructuring the CMake projects (such as using subprojects properly) for another day.
