### PR TITLE
Return candidates as (reading, value) pairs

### DIFF
--- a/src/KeyHandler.h
+++ b/src/KeyHandler.h
@@ -68,8 +68,9 @@ class KeyHandler {
               const ErrorCallback& errorCallback);
 
   // Candidate selected. Can assume the context is in a candidate state.
-  void candidateSelected(const std::string& candidate,
-                         const StateCallback& stateCallback);
+  void candidateSelected(
+      const InputStates::ChoosingCandidate::Candidate& candidate,
+      const StateCallback& stateCallback);
   // Candidate panel canceled. Can assume the context is in a candidate state.
   void candidatePanelCancelled(const StateCallback& stateCallback);
 
@@ -97,6 +98,9 @@ class KeyHandler {
 
   void setOnAddNewPhrase(
       std::function<void(const std::string&)> onAddNewPhrase);
+
+  // Reading joiner for retrieving unigrams from the language model.
+  static constexpr char kJoinSeparator[] = "-";
 
 #pragma endregion Settings
 
@@ -139,8 +143,8 @@ class KeyHandler {
   size_t actualCandidateCursorIndex();
 
   // Pin a node with a fixed unigram value, usually a candidate.
-  void pinNode(const std::string& candidate,
-               const bool useMoveCursorAfterSelectionSetting = true);
+  void pinNode(const InputStates::ChoosingCandidate::Candidate& candidate,
+               bool useMoveCursorAfterSelectionSetting = true);
 
   void walk();
 

--- a/src/KeyHandlerTest.cpp
+++ b/src/KeyHandlerTest.cpp
@@ -89,7 +89,7 @@ class KeyHandlerTest : public ::testing::Test {
 
   // Given a sequence of keys, return the last state.
   std::unique_ptr<InputState> handleKeySequence(
-      std::vector<Key> keys, bool expectHandled = true,
+      const std::vector<Key>& keys, bool expectHandled = true,
       bool expectErrorCallbackAtEnd = false) {
     std::unique_ptr<InputState> state = std::make_unique<InputStates::Empty>();
 
@@ -185,7 +185,10 @@ TEST_F(KeyHandlerTest, EnterCandidateState) {
   ASSERT_TRUE(choosingCandidateState != nullptr);
   ASSERT_EQ(choosingCandidateState->composingBuffer, "中文");
   ASSERT_EQ(choosingCandidateState->cursorIndex, strlen("中文"));
-  EXPECT_THAT(choosingCandidateState->candidates, testing::Contains("中文"));
+
+  EXPECT_THAT(choosingCandidateState->candidates,
+              testing::Contains(InputStates::ChoosingCandidate::Candidate(
+                  "ㄓㄨㄥ-ㄨㄣˊ", "中文")));
 }
 
 TEST_F(KeyHandlerTest, CursorMovementLeft) {
@@ -218,7 +221,9 @@ TEST_F(KeyHandlerTest, SelectCandidatesBeforeCursor) {
   ASSERT_TRUE(choosingCandidateState != nullptr);
   ASSERT_EQ(choosingCandidateState->composingBuffer, "中文");
   ASSERT_EQ(choosingCandidateState->cursorIndex, strlen("中"));
-  EXPECT_THAT(choosingCandidateState->candidates, testing::Contains("中"));
+  EXPECT_THAT(choosingCandidateState->candidates,
+              testing::Contains(
+                  InputStates::ChoosingCandidate::Candidate("ㄓㄨㄥ", "中")));
 }
 
 TEST_F(KeyHandlerTest, SelectCandidatesAfterCursor) {
@@ -233,7 +238,9 @@ TEST_F(KeyHandlerTest, SelectCandidatesAfterCursor) {
   ASSERT_TRUE(choosingCandidateState != nullptr);
   ASSERT_EQ(choosingCandidateState->composingBuffer, "中文");
   ASSERT_EQ(choosingCandidateState->cursorIndex, strlen("中"));
-  EXPECT_THAT(choosingCandidateState->candidates, testing::Contains("文"));
+  EXPECT_THAT(choosingCandidateState->candidates,
+              testing::Contains(
+                  InputStates::ChoosingCandidate::Candidate("ㄨㄣˊ", "文")));
 }
 
 TEST_F(KeyHandlerTest, UppercaseLetterCommitComposingBufferByDefault) {
@@ -357,7 +364,7 @@ TEST_F(
     NonViableCompositionShouldRevertToEmptyStateIfComposingBufferEndsUpEmptyCase2) {
   auto keys = asciiKeys("313");
   // "ˇㄅ" is not valid in McBopomofo. We are tolerant for some cases, such as
-  // we accpet "ˇ一"  to be "以" since it is usually a user just want to type
+  // we accept "ˇ一"  to be "以" since it is usually a user just want to type
   // "一ˇ". However, typing "ˇㄅ" does not make sense.
   auto endState = handleKeySequence(keys);
   auto inputtingState = dynamic_cast<InputStates::Inputting*>(endState.get());
@@ -370,7 +377,7 @@ TEST_F(
     NonViableCompositionShouldRevertToEmptyStateIfComposingBufferEndsUpEmptyCase3) {
   auto keys = asciiKeys("31 ");
   // "ˇㄅ" is not valid in McBopomofo. We are tolerant for some cases, such as
-  // we accpet "ˇ一"  to be "以" since it is usually a user just want to type
+  // we accept "ˇ一"  to be "以" since it is usually a user just want to type
   // "一ˇ". However, typing "ˇㄅ" does not make sense.
   auto endState = handleKeySequence(keys, /*expectHandled=*/false,
                                     /*expectErrorCallbackAtEnd=*/false);

--- a/src/McBopomofo.h
+++ b/src/McBopomofo.h
@@ -202,7 +202,7 @@ class McBopomofoEngine : public fcitx::InputMethodEngine {
   fcitx::CandidateLayoutHint getCandidateLayoutHint();
 
   std::shared_ptr<LanguageModelLoader> languageModelLoader_;
-  std::unique_ptr<KeyHandler> keyHandler_;
+  std::shared_ptr<KeyHandler> keyHandler_;
   std::unique_ptr<InputState> state_;
   McBopomofoConfig config_;
   fcitx::KeyList selectionKeys_;


### PR DESCRIPTION
This helps disambiguate candidates.

Fixes #59

Example screenshot with the scenario described in [this code review comment](https://github.com/openvanilla/fcitx5-mcbopomofo/pull/57#discussion_r915109161):

![Screenshot from 2022-07-07 23-57-36](https://user-images.githubusercontent.com/25210/177935310-5fa5cfe1-6381-49c2-a82d-61a9b50f152c.png)
