### PR TITLE
Sync engine source code with the macOS version

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -13,6 +13,8 @@ set(MCBOPOMOFO_LIB_SOURCES
  LanguageModelLoader.cpp
  UTF8Helper.cpp
  Log.cpp  # Log is part of McBopomofoLib to facilitate debugging via logging.
+ Engine/AssociatedPhrases.h
+ Engine/AssociatedPhrases.cpp
  Engine/KeyValueBlobReader.cpp 
  Engine/McBopomofoLM.cpp
  Engine/ParselessLM.cpp

--- a/src/Engine/AssociatedPhrases.cpp
+++ b/src/Engine/AssociatedPhrases.cpp
@@ -1,0 +1,126 @@
+//
+// AssociatedPhrases.cpp
+//
+// Copyright (c) 2017 The McBopomofo Project.
+//
+// Permission is hereby granted, free of charge, to any person
+// obtaining a copy of this software and associated documentation
+// files (the "Software"), to deal in the Software without
+// restriction, including without limitation the rights to use,
+// copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following
+// conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+// OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+// HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+// OTHER DEALINGS IN THE SOFTWARE.
+//
+
+#include "AssociatedPhrases.h"
+
+#include <fcntl.h>
+#include <fstream>
+#include <sys/mman.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+#include "KeyValueBlobReader.h"
+
+namespace McBopomofo {
+
+AssociatedPhrases::AssociatedPhrases()
+    : fd(-1)
+    , data(0)
+    , length(0)
+{
+}
+
+AssociatedPhrases::~AssociatedPhrases()
+{
+    if (data) {
+        close();
+    }
+}
+
+bool AssociatedPhrases::isLoaded()
+{
+    if (data) {
+        return true;
+    }
+    return false;
+}
+
+bool AssociatedPhrases::open(const char* path)
+{
+    if (data) {
+        return false;
+    }
+
+    fd = ::open(path, O_RDONLY);
+    if (fd == -1) {
+        printf("open:: file not exist");
+        return false;
+    }
+
+    struct stat sb;
+    if (fstat(fd, &sb) == -1) {
+        printf("open:: cannot open file");
+        return false;
+    }
+
+    length = (size_t)sb.st_size;
+
+    data = mmap(NULL, length, PROT_READ, MAP_SHARED, fd, 0);
+    if (!data) {
+        ::close(fd);
+        return false;
+    }
+
+    KeyValueBlobReader reader(static_cast<char*>(data), length);
+    KeyValueBlobReader::KeyValue keyValue;
+    while (reader.Next(&keyValue) == KeyValueBlobReader::State::HAS_PAIR) {
+        keyRowMap[keyValue.key].emplace_back(keyValue.key, keyValue.value);
+    }
+    return true;
+}
+
+void AssociatedPhrases::close()
+{
+    if (data) {
+        munmap(data, length);
+        ::close(fd);
+        data = 0;
+    }
+
+    keyRowMap.clear();
+}
+
+const std::vector<std::string> AssociatedPhrases::valuesForKey(const std::string& key)
+{
+    std::vector<std::string> v;
+    auto iter = keyRowMap.find(key);
+    if (iter != keyRowMap.end()) {
+        const std::vector<Row>& rows = iter->second;
+        for (const auto& row : rows) {
+            std::string_view value = row.value;
+            v.push_back({ value.data(), value.size() });
+        }
+    }
+    return v;
+}
+
+bool AssociatedPhrases::hasValuesForKey(const std::string& key)
+{
+    return keyRowMap.find(key) != keyRowMap.end();
+}
+
+} // namespace McBopomofo

--- a/src/Engine/AssociatedPhrases.h
+++ b/src/Engine/AssociatedPhrases.h
@@ -1,0 +1,69 @@
+//
+// AssociatedPhrases.h
+//
+// Copyright (c) 2017 The McBopomofo Project.
+//
+// Permission is hereby granted, free of charge, to any person
+// obtaining a copy of this software and associated documentation
+// files (the "Software"), to deal in the Software without
+// restriction, including without limitation the rights to use,
+// copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following
+// conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+// OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+// HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+// OTHER DEALINGS IN THE SOFTWARE.
+//
+
+#ifndef ASSOCIATEDPHRASES_H
+#define ASSOCIATEDPHRASES_H
+
+#include <iostream>
+#include <map>
+#include <string>
+#include <vector>
+
+namespace McBopomofo {
+
+class AssociatedPhrases {
+public:
+    AssociatedPhrases();
+    ~AssociatedPhrases();
+
+    bool isLoaded();
+    bool open(const char* path);
+    void close();
+    const std::vector<std::string> valuesForKey(const std::string& key);
+    bool hasValuesForKey(const std::string& key);
+
+protected:
+    struct Row {
+        Row(std::string_view& k, std::string_view& v)
+            : key(k)
+            , value(v)
+        {
+        }
+        std::string_view key;
+        std::string_view value;
+    };
+
+    std::map<std::string_view, std::vector<Row>> keyRowMap;
+
+    int fd;
+    void* data;
+    size_t length;
+};
+
+}
+
+#endif // ASSOCIATEDPHRASES_H

--- a/src/Engine/CMakeLists.txt
+++ b/src/Engine/CMakeLists.txt
@@ -7,6 +7,8 @@ add_subdirectory(gramambular2)
 
 include_directories("Gramambular")
 add_library(McBopomofoLMLib
+        AssociatedPhrases.h
+        AssociatedPhrases.cpp
         KeyValueBlobReader.cpp
         KeyValueBlobReader.h
         ParselessPhraseDB.cpp

--- a/src/Engine/Mandarin/Mandarin.cpp
+++ b/src/Engine/Mandarin/Mandarin.cpp
@@ -31,8 +31,7 @@ namespace Mandarin {
 
 class PinyinParseHelper {
  public:
-  static bool ConsumePrefix(std::string& target,
-                                  const std::string& prefix) {
+  static bool ConsumePrefix(std::string& target, const std::string& prefix) {
     if (target.length() < prefix.length()) {
       return false;
     }
@@ -601,10 +600,10 @@ const BPMF BPMF::FromComposedString(const std::string& str) {
 const std::string BPMF::composedString() const {
   std::string result;
 #define APPEND(c)                                                         \
-  if (syllable_ & c)                                                     \
+  if (syllable_ & c)                                                      \
   result +=                                                               \
       (*BopomofoCharacterMap::SharedInstance().componentToCharacter.find( \
-           syllable_ & c))                                               \
+           syllable_ & c))                                                \
           .second
   APPEND(ConsonantMask);
   APPEND(MiddleVowelMask);
@@ -613,8 +612,6 @@ const std::string BPMF::composedString() const {
 #undef APPEND
   return result;
 }
-
-
 
 const BopomofoCharacterMap& BopomofoCharacterMap::SharedInstance() {
   static BopomofoCharacterMap* map = new BopomofoCharacterMap();

--- a/src/Engine/McBopomofoLM.cpp
+++ b/src/Engine/McBopomofoLM.cpp
@@ -37,7 +37,7 @@ McBopomofoLM::~McBopomofoLM()
     m_userPhrases.close();
     m_excludedPhrases.close();
     m_phraseReplacement.close();
-    // m_associatedPhrases.close();
+    m_associatedPhrases.close();
 }
 
 void McBopomofoLM::loadLanguageModel(const char* languageModelDataPath)
@@ -53,18 +53,18 @@ bool McBopomofoLM::isDataModelLoaded()
     return m_languageModel.isLoaded();
 }
 
-// void McBopomofoLM::loadAssociatedPhrases(const char* associatedPhrasesPath)
-// {
-//     if (associatedPhrasesPath) {
-//         m_associatedPhrases.close();
-//         m_associatedPhrases.open(associatedPhrasesPath);
-//     }
-// }
+void McBopomofoLM::loadAssociatedPhrases(const char* associatedPhrasesPath)
+{
+    if (associatedPhrasesPath) {
+        m_associatedPhrases.close();
+        m_associatedPhrases.open(associatedPhrasesPath);
+    }
+}
 
-// bool McBopomofoLM::isAssociatedPhrasesLoaded()
-// {
-//     return m_associatedPhrases.isLoaded();
-// }
+bool McBopomofoLM::isAssociatedPhrasesLoaded()
+{
+    return m_associatedPhrases.isLoaded();
+}
 
 void McBopomofoLM::loadUserPhrases(const char* userPhrasesDataPath,
     const char* excludedPhrasesDataPath)
@@ -191,14 +191,14 @@ std::vector<Formosa::Gramambular2::LanguageModel::Unigram> McBopomofoLM::filterA
     return results;
 }
 
-// const std::vector<std::string> McBopomofoLM::associatedPhrasesForKey(const std::string& key)
-// {
-//     return m_associatedPhrases.valuesForKey(key);
-// }
+const std::vector<std::string> McBopomofoLM::associatedPhrasesForKey(const std::string& key)
+{
+    return m_associatedPhrases.valuesForKey(key);
+}
 
-// bool McBopomofoLM::hasAssociatedPhrasesForKey(const std::string& key)
-// {
-//     return m_associatedPhrases.hasValuesForKey(key);
-// }
+bool McBopomofoLM::hasAssociatedPhrasesForKey(const std::string& key)
+{
+    return m_associatedPhrases.hasValuesForKey(key);
+}
 
 } // namespace McBopomofo

--- a/src/Engine/McBopomofoLM.h
+++ b/src/Engine/McBopomofoLM.h
@@ -24,6 +24,7 @@
 #ifndef MCBOPOMOFOLM_H
 #define MCBOPOMOFOLM_H
 
+#include "AssociatedPhrases.h"
 #include "ParselessLM.h"
 #include "PhraseReplacementMap.h"
 #include "UserPhrasesLM.h"
@@ -67,11 +68,11 @@ public:
     /// If the data model is already loaded.
     bool isDataModelLoaded();
 
-    // /// Asks to load the associated phrases at the given path.
-    // /// @param associatedPhrasesPath The path of the associated phrases.
-    // void loadAssociatedPhrases(const char* associatedPhrasesPath);
-    // /// If the associated phrases already loaded.
-    // bool isAssociatedPhrasesLoaded();
+    /// Asks to load the associated phrases at the given path.
+    /// @param associatedPhrasesPath The path of the associated phrases.
+    void loadAssociatedPhrases(const char* associatedPhrasesPath);
+    /// If the associated phrases already loaded.
+    bool isAssociatedPhrasesLoaded();
 
     /// Asks to load the user phrases and excluded phrases at the given path.
     /// @param userPhrasesPath The path of user phrases.
@@ -120,7 +121,7 @@ protected:
     UserPhrasesLM m_userPhrases;
     UserPhrasesLM m_excludedPhrases;
     PhraseReplacementMap m_phraseReplacement;
-    // AssociatedPhrases m_associatedPhrases;
+    AssociatedPhrases m_associatedPhrases;
     bool m_phraseReplacementEnabled;
     bool m_externalConverterEnabled;
     std::function<std::string(std::string)> m_externalConverter;

--- a/src/Engine/ParselessLMBenchmark.cpp
+++ b/src/Engine/ParselessLMBenchmark.cpp
@@ -1,0 +1,63 @@
+// Copyright (c) 2022 and onwards The McBopomofo Authors.
+//
+// Permission is hereby granted, free of charge, to any person
+// obtaining a copy of this software and associated documentation
+// files (the "Software"), to deal in the Software without
+// restriction, including without limitation the rights to use,
+// copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following
+// conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+// OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+// HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+// OTHER DEALINGS IN THE SOFTWARE.
+
+#include <benchmark/benchmark.h>
+
+#include <cassert>
+#include <filesystem>
+
+#include "ParselessLM.h"
+
+namespace {
+
+using ParselessLM = McBopomofo::ParselessLM;
+
+static const char* kDataPath = "data.txt";
+static const char* kUnigramSearchKey = "ㄕˋ-ㄕˊ";
+
+static void BM_ParselessLMOpenClose(benchmark::State& state)
+{
+    assert(std::filesystem::exists(kDataPath));
+    for (auto _ : state) {
+        ParselessLM lm;
+        lm.open(kDataPath);
+        lm.close();
+    }
+}
+BENCHMARK(BM_ParselessLMOpenClose);
+
+static void BM_ParselessLMFindUnigrams(benchmark::State& state)
+{
+    assert(std::filesystem::exists(kDataPath));
+    ParselessLM lm;
+    lm.open(kDataPath);
+    for (auto _ : state) {
+        lm.unigramsForKey(kUnigramSearchKey);
+    }
+    lm.close();
+}
+BENCHMARK(BM_ParselessLMFindUnigrams);
+
+}; // namespace
+
+BENCHMARK_MAIN();


### PR DESCRIPTION
Even though fcitx5-bopomofo does not support associated phrases (a
feature for the "plain" bopomofo, unsupported here), it's still a good
idea to keep the engine source code in sync.