### PR TITLE
User Override Model improvements

### DIFF
--- a/src/Engine/CMakeLists.txt
+++ b/src/Engine/CMakeLists.txt
@@ -17,7 +17,6 @@ add_library(McBopomofoLMLib
         PhraseReplacementMap.cpp
         UserOverrideModel.h
         UserOverrideModel.cpp
-        UserOverrideModelTest.cpp
         UserPhrasesLM.h
         UserPhrasesLM.cpp)
 

--- a/src/Engine/CMakeLists.txt
+++ b/src/Engine/CMakeLists.txt
@@ -15,6 +15,9 @@ add_library(McBopomofoLMLib
         ParselessLM.h
         PhraseReplacementMap.h
         PhraseReplacementMap.cpp
+        UserOverrideModel.h
+        UserOverrideModel.cpp
+        UserOverrideModelTest.cpp
         UserPhrasesLM.h
         UserPhrasesLM.cpp)
 
@@ -37,8 +40,9 @@ add_executable(McBopomofoLMLibTest
         ParselessLMTest.cpp
         ParselessPhraseDBTest.cpp
         PhraseReplacementMapTest.cpp
+        UserOverrideModelTest.cpp
         UserPhrasesLMTest.cpp)
-target_link_libraries(McBopomofoLMLibTest gtest_main McBopomofoLMLib)
+target_link_libraries(McBopomofoLMLibTest gtest_main McBopomofoLMLib gramambular2_lib)
 include(GoogleTest)
 gtest_discover_tests(McBopomofoLMLibTest)
 

--- a/src/Engine/UserOverrideModel.cpp
+++ b/src/Engine/UserOverrideModel.cpp
@@ -62,6 +62,23 @@ void UserOverrideModel::observe(const std::vector<Formosa::Gramambular2::Reading
         return;
     }
 
+    observe(key, candidate, timestamp);
+}
+
+std::string UserOverrideModel::suggest(const std::vector<Formosa::Gramambular2::ReadingGrid::NodePtr>& walkedNodes,
+    size_t cursorIndex,
+    double timestamp)
+{
+    std::string key = WalkedNodesToKey(walkedNodes, cursorIndex);
+    if (key.empty()) {
+        return std::string();
+    }
+
+    return suggest(key, timestamp);
+}
+
+void UserOverrideModel::observe(const std::string& key, const std::string& candidate, double timestamp)
+{
     auto mapIter = m_lruMap.find(key);
     if (mapIter == m_lruMap.end()) {
         auto keyValuePair = KeyObservationPair(key, Observation());
@@ -90,15 +107,8 @@ void UserOverrideModel::observe(const std::vector<Formosa::Gramambular2::Reading
     }
 }
 
-std::string UserOverrideModel::suggest(const std::vector<Formosa::Gramambular2::ReadingGrid::NodePtr>& walkedNodes,
-    size_t cursorIndex,
-    double timestamp)
+std::string UserOverrideModel::suggest(const std::string& key, double timestamp)
 {
-    std::string key = WalkedNodesToKey(walkedNodes, cursorIndex);
-    if (key.empty()) {
-        return std::string();
-    }
-
     auto mapIter = m_lruMap.find(key);
     if (mapIter == m_lruMap.end()) {
         return std::string();

--- a/src/Engine/UserOverrideModel.cpp
+++ b/src/Engine/UserOverrideModel.cpp
@@ -1,7 +1,4 @@
-//
-// UserOverrideModel.cpp
-//
-// Copyright (c) 2017 The McBopomofo Project.
+// Copyright (c) 2017 ond onwards The McBopomofo Authors.
 //
 // Permission is hereby granted, free of charge, to any person
 // obtaining a copy of this software and associated documentation
@@ -35,7 +32,7 @@
 namespace McBopomofo {
 
 // About 20 generations.
-static const double DecayThreshould = 1.0 / 1048576.0;
+static const double DecayThreshold = 1.0 / 1048576.0;
 
 static double Score(size_t eventCount,
     size_t totalCount,
@@ -157,7 +154,7 @@ static double Score(size_t eventCount,
     double lambda)
 {
     double decay = exp((timestamp - eventTimestamp) * lambda);
-    if (decay < DecayThreshould) {
+    if (decay < DecayThreshold) {
         return 0.0;
     }
 

--- a/src/Engine/UserOverrideModel.cpp
+++ b/src/Engine/UserOverrideModel.cpp
@@ -27,20 +27,28 @@
 #include "gramambular2/reading_grid.h"
 #include <cassert>
 #include <cmath>
-#include <sstream>
 
 namespace McBopomofo {
 
-// About 20 generations.
-static const double DecayThreshold = 1.0 / 1048576.0;
+// Fully decay after about 20 generations.
+static constexpr double kDecayThreshold = 1.0 / 1048576.0;
 
+static constexpr char kEmptyNodeString[] = "()";
+
+// A scoring function that balances between "recent but infrequently observed"
+// and "old but frequently observed".
 static double Score(size_t eventCount,
     size_t totalCount,
     double eventTimestamp,
     double timestamp,
     double lambda);
-static std::string WalkedNodesToKey(const std::vector<Formosa::Gramambular2::ReadingGrid::NodePtr>& walkedNodes,
-    size_t cursorIndex);
+
+// Form the observation key from the nodes of a walk. This goes backward, but
+// we are using a const_iterator, the "end" here should be a .cbegin() of a
+// vector.
+static std::string FormObservationKey(
+    std::vector<Formosa::Gramambular2::ReadingGrid::NodePtr>::const_iterator head,
+    std::vector<Formosa::Gramambular2::ReadingGrid::NodePtr>::const_iterator end);
 
 UserOverrideModel::UserOverrideModel(size_t capacity, double decayConstant)
     : m_capacity(capacity)
@@ -49,38 +57,104 @@ UserOverrideModel::UserOverrideModel(size_t capacity, double decayConstant)
     m_decayExponent = log(0.5) / decayConstant;
 }
 
-void UserOverrideModel::observe(const std::vector<Formosa::Gramambular2::ReadingGrid::NodePtr>& walkedNodes,
-    size_t cursorIndex,
-    const std::string& candidate,
+void UserOverrideModel::observe(
+    const Formosa::Gramambular2::ReadingGrid::WalkResult& walkBeforeUserOverride,
+    const Formosa::Gramambular2::ReadingGrid::WalkResult& walkAfterUserOverride,
+    size_t cursor,
     double timestamp)
 {
-    std::string key = WalkedNodesToKey(walkedNodes, cursorIndex);
-    if (key.empty()) {
+    // Sanity check.
+    if (walkBeforeUserOverride.nodes.empty() || walkAfterUserOverride.nodes.empty()) {
         return;
     }
 
-    observe(key, candidate, timestamp);
-}
-
-std::string UserOverrideModel::suggest(const std::vector<Formosa::Gramambular2::ReadingGrid::NodePtr>& walkedNodes,
-    size_t cursorIndex,
-    double timestamp)
-{
-    std::string key = WalkedNodesToKey(walkedNodes, cursorIndex);
-    if (key.empty()) {
-        return std::string();
+    if (walkBeforeUserOverride.totalReadings != walkAfterUserOverride.totalReadings) {
+        return;
     }
 
+    // We first infer what the user override is.
+    size_t actualCursor = 0;
+    auto currentNodeIt = walkAfterUserOverride.findNodeAt(cursor, &actualCursor);
+    if (currentNodeIt == walkAfterUserOverride.nodes.cend()) {
+        return;
+    }
+
+    // Based on previous analysis, we found it meaningless to handle phrases
+    // over 3 characters.
+    if ((*currentNodeIt)->spanningLength() > 3) {
+        return;
+    }
+
+    // Now we need to find the head node in the previous walk (that is, before
+    // the user override). Remember that actualCursor now is actually *past*
+    // the current node, so we need to decrement by 1.
+    if (actualCursor == 0) {
+        // Shouldn't happen.
+        return;
+    }
+    --actualCursor;
+    auto prevHeadNodeIt = walkBeforeUserOverride.findNodeAt(actualCursor);
+    if (prevHeadNodeIt == walkBeforeUserOverride.nodes.cend()) {
+        return;
+    }
+
+    // Now we have everything. We want to handle the following cases:
+    // (1) both prev and current head nodes represent an n-char phrase.
+    // (2) current head node is a 2-/3-char phrase but prev head node and
+    //     the nodes that lead to the prev head node are 1-char phrases.
+    // (3) current head node is a 1-char phrase but the prev head node is
+    //     a phrase of multi-char phrases.
+    //
+    // (1) is the simplest case. Our observation is based on the "walk before
+    // user override", and we don't need to recommend force-high-score
+    // overrides when we return such a suggestion. Example: overriding
+    // "他姓[中]" with "他姓[鍾]".
+    //
+    // (2) is a case that UOM historically didn't handle properly. The
+    // observation needs to be based on the walk before user override, but
+    // we also need to recommend force-high-score override when we make the
+    // suggestion, due to the fact (based on our data analysis) that many
+    // n-char (esp. 2-char) phrases need to compete with individual chars
+    // that together have higher score than the phrases themselves. Example:
+    // overriding "增加[自][會]" with "增加[字彙]". Here [自][會] together have
+    // higher score than the single unigram [字彙], and hence the boosting
+    // here.
+    //
+    // (3) is a very special case where we need to base our observation on
+    // the walk *after* user override. This is because when (3) happens, the
+    // user intent is to break up a long phrase. We don't want to recommend
+    // force-high-score overrides, which would cause the multi-char phrase
+    // to lose over the user override all the time. For example (a somewhat
+    // forced one): overriding "[三百元]" with "[參]百元".
+    const auto& currentNode = *currentNodeIt;
+    const auto& prevHeadNode = *prevHeadNodeIt;
+    bool forceHighScoreOverride = currentNode->spanningLength() > prevHeadNode->spanningLength();
+    bool breakingUp = currentNode->spanningLength() == 1 && prevHeadNode->spanningLength() > 1;
+
+    auto nodeIter = breakingUp ? currentNodeIt : prevHeadNodeIt;
+    auto endPoint = breakingUp ? walkAfterUserOverride.nodes.begin() : walkBeforeUserOverride.nodes.begin();
+
+    std::string key = FormObservationKey(nodeIter, endPoint);
+    observe(key, currentNode->currentUnigram().value(), timestamp, forceHighScoreOverride);
+}
+
+UserOverrideModel::Suggestion UserOverrideModel::suggest(
+    const Formosa::Gramambular2::ReadingGrid::WalkResult& currentWalk,
+    size_t cursor,
+    double timestamp)
+{
+    auto nodeIter = currentWalk.findNodeAt(cursor);
+    std::string key = FormObservationKey(nodeIter, currentWalk.nodes.begin());
     return suggest(key, timestamp);
 }
 
-void UserOverrideModel::observe(const std::string& key, const std::string& candidate, double timestamp)
+void UserOverrideModel::observe(const std::string& key, const std::string& candidate, double timestamp, bool forceHighScoreOverride)
 {
     auto mapIter = m_lruMap.find(key);
     if (mapIter == m_lruMap.end()) {
         auto keyValuePair = KeyObservationPair(key, Observation());
         Observation& observation = keyValuePair.second;
-        observation.update(candidate, timestamp);
+        observation.update(candidate, timestamp, forceHighScoreOverride);
 
         m_lruList.push_front(keyValuePair);
         auto listIter = m_lruList.begin();
@@ -100,15 +174,15 @@ void UserOverrideModel::observe(const std::string& key, const std::string& candi
 
         auto& keyValuePair = *listIter;
         Observation& observation = keyValuePair.second;
-        observation.update(candidate, timestamp);
+        observation.update(candidate, timestamp, forceHighScoreOverride);
     }
 }
 
-std::string UserOverrideModel::suggest(const std::string& key, double timestamp)
+UserOverrideModel::Suggestion UserOverrideModel::suggest(const std::string& key, double timestamp)
 {
     auto mapIter = m_lruMap.find(key);
     if (mapIter == m_lruMap.end()) {
-        return std::string();
+        return UserOverrideModel::Suggestion {};
     }
 
     auto listIter = mapIter->second;
@@ -116,7 +190,8 @@ std::string UserOverrideModel::suggest(const std::string& key, double timestamp)
     const Observation& observation = keyValuePair.second;
 
     std::string candidate;
-    double score = 0.0;
+    bool forceHighScoreOverride = false;
+    double score = 0;
     for (auto i = observation.overrides.begin();
          i != observation.overrides.end();
          ++i) {
@@ -132,19 +207,21 @@ std::string UserOverrideModel::suggest(const std::string& key, double timestamp)
 
         if (overrideScore > score) {
             candidate = i->first;
+            forceHighScoreOverride = o.forceHighScoreOverride;
             score = overrideScore;
         }
     }
-    return candidate;
+    return UserOverrideModel::Suggestion { candidate, forceHighScoreOverride };
 }
 
 void UserOverrideModel::Observation::update(const std::string& candidate,
-    double timestamp)
+    double timestamp, bool forceHighScoreOverride)
 {
     count++;
     auto& o = overrides[candidate];
     o.timestamp = timestamp;
     o.count++;
+    o.forceHighScoreOverride = forceHighScoreOverride;
 }
 
 static double Score(size_t eventCount,
@@ -154,7 +231,7 @@ static double Score(size_t eventCount,
     double lambda)
 {
     double decay = exp((timestamp - eventTimestamp) * lambda);
-    if (decay < DecayThreshold) {
+    if (decay < kDecayThreshold) {
         return 0.0;
     }
 
@@ -162,84 +239,51 @@ static double Score(size_t eventCount,
     return prob * decay;
 }
 
-static bool IsPunctuation(const Formosa::Gramambular2::ReadingGrid::NodePtr node)
+static std::string CombineReadingValue(const std::string& reading, const std::string& value)
+{
+    return std::string("(") + reading + "," + value + ")";
+}
+
+static bool IsPunctuation(const Formosa::Gramambular2::ReadingGrid::NodePtr& node)
 {
     const std::string& reading = node->reading();
     return !reading.empty() && reading[0] == '_';
 }
 
-static std::string WalkedNodesToKey(const std::vector<Formosa::Gramambular2::ReadingGrid::NodePtr>& walkedNodes,
-    size_t cursorIndex)
+static std::string FormObservationKey(std::vector<Formosa::Gramambular2::ReadingGrid::NodePtr>::const_iterator head,
+    std::vector<Formosa::Gramambular2::ReadingGrid::NodePtr>::const_iterator end)
 {
-    std::stringstream s;
-    std::vector<Formosa::Gramambular2::ReadingGrid::NodePtr> n;
-    size_t ll = 0;
-    for (auto i = walkedNodes.cbegin(); i != walkedNodes.cend(); ++i) {
-        n.push_back(*i);
-        ll += (*i)->spanningLength();
-        if (ll > cursorIndex) {
-            break;
-        }
-    }
+    // Using the top unigram from the head node. Recall that this is an
+    // observation for *before* the user override, and when we provide
+    // a suggestion, this head node is never overridden yet.
+    std::string headStr = CombineReadingValue((*head)->reading(), (*head)->unigrams()[0].value());
 
-    auto r = n.crbegin();
-    if (r == n.crend()) {
-        return "";
-    }
-
-    if ((*r)->unigrams().empty()) {
-        return "";
-    }
-
-    std::string current = (*r)->unigrams()[0].value();
-
-    ++r;
-
-    s.clear();
-    s.str(std::string());
-    if (r != n.crend()) {
-        if (IsPunctuation(*r)) {
-            // Ignore punctuation.
-            s << "()";
-            r = n.rend();
+    // For the next two nodes, use their current unigram values. If it's a
+    // punctuation, we ignore the reading and the value altogether and treat
+    // it as if it's like the beginning of the sentence.
+    std::string prevStr;
+    bool prevIsPunctuation = false;
+    if (head != end) {
+        --head;
+        prevIsPunctuation = IsPunctuation(*head);
+        if (prevIsPunctuation) {
+            prevStr = kEmptyNodeString;
         } else {
-            s << "("
-              << (*r)->reading()
-              << ","
-              << (*r)->value()
-              << ")";
-            ++r;
+            prevStr = CombineReadingValue((*head)->reading(), (*head)->currentUnigram().value());
         }
     } else {
-        s << "()";
+        prevStr = kEmptyNodeString;
     }
-    std::string prev = s.str();
 
-    s.clear();
-    s.str(std::string());
-    if (r != n.rend()) {
-        if (IsPunctuation(*r)) {
-            // Ignore punctuation.
-            s << "()";
-            r = n.rend();
-        } else {
-            s << "("
-              << (*r)->reading()
-              << ","
-              << (*r)->value()
-              << ")";
-            ++r;
-        }
+    std::string anteriorStr;
+    if (head != end && !prevIsPunctuation) {
+        --head;
+        anteriorStr = CombineReadingValue((*head)->reading(), (*head)->currentUnigram().value());
     } else {
-        s << "()";
+        anteriorStr = kEmptyNodeString;
     }
-    std::string anterior = s.str();
 
-    s.clear();
-    s.str(std::string());
-    s << "(" << anterior << "," << prev << "," << current << ")";
-
-    return s.str();
+    return anteriorStr + "-" + prevStr + "-" + headStr;
 }
 
 } // namespace McBopomofo

--- a/src/Engine/UserOverrideModel.h
+++ b/src/Engine/UserOverrideModel.h
@@ -45,6 +45,9 @@ public:
         size_t cursorIndex,
         double timestamp);
 
+    void observe(const std::string& key, const std::string& candidate, double timestamp);
+    std::string suggest(const std::string& key, double timestamp);
+
 private:
     struct Override {
         size_t count;

--- a/src/Engine/UserOverrideModel.h
+++ b/src/Engine/UserOverrideModel.h
@@ -36,28 +36,42 @@ class UserOverrideModel {
 public:
     UserOverrideModel(size_t capacity, double decayConstant);
 
-    void observe(const std::vector<Formosa::Gramambular2::ReadingGrid::NodePtr>& walkedNodes,
-        size_t cursorIndex,
-        const std::string& candidate,
+    struct Suggestion {
+        Suggestion() { }
+        Suggestion(std::string c, bool f)
+            : candidate(std::move(c))
+            , forceHighScoreOverride(f)
+        {
+        }
+        std::string candidate;
+        bool forceHighScoreOverride = false;
+
+        bool empty()
+        {
+            return candidate.empty();
+        }
+    };
+
+    void observe(
+        const Formosa::Gramambular2::ReadingGrid::WalkResult& walkBeforeUserOverride,
+        const Formosa::Gramambular2::ReadingGrid::WalkResult& walkAfterUserOverride,
+        size_t cursor,
         double timestamp);
 
-    std::string suggest(const std::vector<Formosa::Gramambular2::ReadingGrid::NodePtr>& walkedNodes,
-        size_t cursorIndex,
+    Suggestion suggest(
+        const Formosa::Gramambular2::ReadingGrid::WalkResult& currentWalk,
+        size_t cursor,
         double timestamp);
 
-    void observe(const std::string& key, const std::string& candidate, double timestamp);
-    std::string suggest(const std::string& key, double timestamp);
+    void observe(const std::string& key, const std::string& candidate, double timestamp, bool forceHighScoreOverride = false);
+
+    Suggestion suggest(const std::string& key, double timestamp);
 
 private:
     struct Override {
-        size_t count;
-        double timestamp;
-
-        Override()
-            : count(0)
-            , timestamp(0.0)
-        {
-        }
+        size_t count = 0;
+        double timestamp = 0;
+        bool forceHighScoreOverride = false;
     };
 
     struct Observation {
@@ -68,7 +82,7 @@ private:
             : count(0)
         {
         }
-        void update(const std::string& candidate, double timestamp);
+        void update(const std::string& candidate, double timestamp, bool forceHighScoreOverride);
     };
 
     typedef std::pair<std::string, Observation> KeyObservationPair;

--- a/src/Engine/UserOverrideModelTest.cpp
+++ b/src/Engine/UserOverrideModelTest.cpp
@@ -40,16 +40,16 @@ TEST(UserOverrideModelTest, BasicOperation)
     uom.observe(key, candidate, kFakeNow);
 
     auto v = uom.suggest(key, kFakeNow);
-    ASSERT_EQ(v, candidate);
+    ASSERT_EQ(v.candidate, candidate);
 
     v = uom.suggest(key, kFakeNow + kHalflife * 1);
-    ASSERT_EQ(v, candidate);
+    ASSERT_EQ(v.candidate, candidate);
     v = uom.suggest(key, kFakeNow + kHalflife * 5);
-    ASSERT_EQ(v, candidate);
+    ASSERT_EQ(v.candidate, candidate);
     v = uom.suggest(key, kFakeNow + kHalflife * 10);
-    ASSERT_EQ(v, candidate);
+    ASSERT_EQ(v.candidate, candidate);
     v = uom.suggest(key, kFakeNow + kHalflife * 20);
-    ASSERT_EQ(v, candidate);
+    ASSERT_EQ(v.candidate, candidate);
 
     // The suggestion is no longer valid after ~30 hours.
     v = uom.suggest(key, kFakeNow + kHalflife * 21);
@@ -74,20 +74,20 @@ TEST(UserOverrideModelTest, FreshVsFrequent)
     // Even if newerValue is more recent, olderValue is used more frequently,
     // and so initially olderValue is still suggested.
     auto v = uom.suggest(key, kFakeNow + kHalflife * 7);
-    ASSERT_EQ(v, olderValue);
+    ASSERT_EQ(v.candidate, olderValue);
     v = uom.suggest(key, kFakeNow + kHalflife * 20);
-    ASSERT_EQ(v, olderValue);
+    ASSERT_EQ(v.candidate, olderValue);
     v = uom.suggest(key, kFakeNow + kHalflife * 22);
-    ASSERT_EQ(v, olderValue);
+    ASSERT_EQ(v.candidate, olderValue);
 
     // At this point, even if olderValue hasn't expired yet, but the
     // less-frequently observed newerValue is fresher.
     uom.observe(key, newerValue, kFakeNow + kHalflife * 23);
     v = uom.suggest(key, kFakeNow + kHalflife * 23.5);
-    ASSERT_EQ(v, newerValue);
+    ASSERT_EQ(v.candidate, newerValue);
 
     v = uom.suggest(key, kFakeNow + kHalflife * 25);
-    ASSERT_EQ(v, newerValue);
+    ASSERT_EQ(v.candidate, newerValue);
 
     v = uom.suggest(key, kFakeNow + kHalflife * 45);
     ASSERT_TRUE(v.empty());
@@ -101,10 +101,10 @@ TEST(UserOverrideModelTest, LRUBehavior)
     uom.observe("ghi", "z", kFakeNow + kHalflife * 2);
 
     auto v = uom.suggest("ghi", kFakeNow + kHalflife * 3);
-    ASSERT_EQ(v, "z");
+    ASSERT_EQ(v.candidate, "z");
 
     v = uom.suggest("def", kFakeNow + kHalflife * 4);
-    ASSERT_EQ(v, "y");
+    ASSERT_EQ(v.candidate, "y");
 
     // abc evicted.
     v = uom.suggest("abc", kFakeNow + kHalflife * 5);
@@ -113,7 +113,7 @@ TEST(UserOverrideModelTest, LRUBehavior)
     uom.observe("jkl", "p", kFakeNow + kHalflife * 6);
 
     v = uom.suggest("ghi", kFakeNow + kHalflife * 7);
-    ASSERT_EQ(v, "z");
+    ASSERT_EQ(v.candidate, "z");
 
     // def evicted.
     v = uom.suggest("def", kFakeNow + kHalflife * 7);

--- a/src/Engine/UserOverrideModelTest.cpp
+++ b/src/Engine/UserOverrideModelTest.cpp
@@ -1,0 +1,96 @@
+// Copyright (c) 2022 and onwards The McBopomofo Authors.
+//
+// Permission is hereby granted, free of charge, to any person
+// obtaining a copy of this software and associated documentation
+// files (the "Software"), to deal in the Software without
+// restriction, including without limitation the rights to use,
+// copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following
+// conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+// OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+// HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+// OTHER DEALINGS IN THE SOFTWARE.
+
+#include "UserOverrideModel.h"
+#include "gtest/gtest.h"
+
+namespace McBopomofo {
+
+namespace {
+    constexpr double kFakeNow = 1657772432;
+    constexpr int kCapacity = 2;
+    constexpr double kHalflife = 5400.0; // 1.5 hr.
+} // namespace
+
+TEST(UserOverrideModelTest, BasicOperation)
+{
+    UserOverrideModel uom(kCapacity, kHalflife);
+    std::string key = "abc";
+    std::string candidate = "v";
+    uom.observe(key, candidate, kFakeNow);
+
+    auto v = uom.suggest(key, kFakeNow);
+    ASSERT_EQ(v, candidate);
+
+    v = uom.suggest(key, kFakeNow + kHalflife * 1);
+    ASSERT_EQ(v, candidate);
+    v = uom.suggest(key, kFakeNow + kHalflife * 5);
+    ASSERT_EQ(v, candidate);
+    v = uom.suggest(key, kFakeNow + kHalflife * 10);
+    ASSERT_EQ(v, candidate);
+    v = uom.suggest(key, kFakeNow + kHalflife * 20);
+    ASSERT_EQ(v, candidate);
+
+    // The suggestion is no longer valid after ~30 hours.
+    v = uom.suggest(key, kFakeNow + kHalflife * 21);
+    ASSERT_TRUE(v.empty());
+}
+
+TEST(UserOverrideModelTest, FreshVsFrequent)
+{
+    UserOverrideModel uom(kCapacity, kHalflife);
+    std::string key = "abc";
+    std::string olderValue = "older";
+    std::string newerValue = "newer";
+
+    uom.observe(key, olderValue, kFakeNow);
+    uom.observe(key, olderValue, kFakeNow + kHalflife * 1);
+    uom.observe(key, olderValue, kFakeNow + kHalflife * 2);
+    uom.observe(key, olderValue, kFakeNow + kHalflife * 3);
+    uom.observe(key, olderValue, kFakeNow + kHalflife * 4);
+    uom.observe(key, newerValue, kFakeNow + kHalflife * 5);
+    uom.observe(key, newerValue, kFakeNow + kHalflife * 5.25);
+
+    // Even if newerValue is more recent, olderValue is used more frequently,
+    // and so initially olderValue is still suggested.
+    auto v = uom.suggest(key, kFakeNow + kHalflife * 7);
+    ASSERT_EQ(v, olderValue);
+    v = uom.suggest(key, kFakeNow + kHalflife * 20);
+    ASSERT_EQ(v, olderValue);
+    v = uom.suggest(key, kFakeNow + kHalflife * 22);
+    ASSERT_EQ(v, olderValue);
+
+    // At this point, even if olderValue hasn't expired yet, but the
+    // less-frequently observed newerValue is fresher.
+    uom.observe(key, newerValue, kFakeNow + kHalflife * 23);
+    v = uom.suggest(key, kFakeNow + kHalflife * 23.5);
+    ASSERT_EQ(v, newerValue);
+
+    v = uom.suggest(key, kFakeNow + kHalflife * 25);
+    ASSERT_EQ(v, newerValue);
+
+    v = uom.suggest(key, kFakeNow + kHalflife * 45);
+    ASSERT_TRUE(v.empty());
+}
+
+} // namespace McBopomofo

--- a/src/Engine/gramambular2/reading_grid.cpp
+++ b/src/Engine/gramambular2/reading_grid.cpp
@@ -550,7 +550,8 @@ bool ReadingGrid::Node::selectOverrideUnigram(
 }
 
 std::vector<ReadingGrid::NodePtr>::const_iterator
-ReadingGrid::WalkResult::findNodeAt(size_t cursor, size_t* outCursorPastNode) {
+ReadingGrid::WalkResult::findNodeAt(size_t cursor,
+                                    size_t* outCursorPastNode) const {
   if (nodes.empty()) {
     return nodes.cend();
   }
@@ -591,7 +592,7 @@ ReadingGrid::WalkResult::findNodeAt(size_t cursor, size_t* outCursorPastNode) {
   return nodes.cend();
 }
 
-std::vector<std::string> ReadingGrid::WalkResult::valuesAsStrings() {
+std::vector<std::string> ReadingGrid::WalkResult::valuesAsStrings() const {
   std::vector<std::string> result;
   for (const NodePtr& node : nodes) {
     result.emplace_back(node->value());
@@ -599,7 +600,7 @@ std::vector<std::string> ReadingGrid::WalkResult::valuesAsStrings() {
   return result;
 }
 
-std::vector<std::string> ReadingGrid::WalkResult::readingsAsStrings() {
+std::vector<std::string> ReadingGrid::WalkResult::readingsAsStrings() const {
   std::vector<std::string> result;
   for (const NodePtr& node : nodes) {
     result.emplace_back(node->reading());

--- a/src/Engine/gramambular2/reading_grid.cpp
+++ b/src/Engine/gramambular2/reading_grid.cpp
@@ -264,6 +264,7 @@ ReadingGrid::WalkResult ReadingGrid::walk() {
 
   assert(totalReadingLen == readings_.size());
   assert(walked.size() >= 2);
+  result.totalReadings = totalReadingLen;
   result.nodes = std::vector<NodePtr>(walked.rbegin() + 1, walked.rend());
   result.elapsedMicroseconds = GetEpochNowInMicroseconds() - start;
   return result;
@@ -547,6 +548,49 @@ bool ReadingGrid::Node::selectOverrideUnigram(
   }
   return false;
 }
+
+std::vector<ReadingGrid::NodePtr>::const_iterator
+ReadingGrid::WalkResult::findNodeAt(size_t cursor, size_t* outCursorPastNode) {
+  if (nodes.empty()) {
+    return nodes.cend();
+  }
+
+  if (cursor > totalReadings) {
+    return nodes.cend();
+  }
+
+  if (cursor == 0) {
+    auto it = nodes.cbegin();
+    if (outCursorPastNode != nullptr) {
+      *outCursorPastNode = (*it)->spanningLength();
+    }
+    return it;
+  }
+
+  // Covers both the "cursor is right at end" and "cursor is one reading before
+  // the end" cases.
+  if (cursor >= totalReadings - 1) {
+    if (outCursorPastNode != nullptr) {
+      *outCursorPastNode = totalReadings;
+    }
+    return std::next(nodes.cbegin(), static_cast<ptrdiff_t>(nodes.size() - 1));
+  }
+
+  size_t accumulated = 0;
+  for (auto i = nodes.cbegin(); i != nodes.cend(); ++i) {
+    accumulated += (*i)->spanningLength();
+    if (accumulated > cursor) {
+      if (outCursorPastNode != nullptr) {
+        *outCursorPastNode = accumulated;
+      }
+      return i;
+    }
+  }
+
+  // Shouldn't happen.
+  return nodes.cend();
+}
+
 std::vector<std::string> ReadingGrid::WalkResult::valuesAsStrings() {
   std::vector<std::string> result;
   for (const NodePtr& node : nodes) {

--- a/src/Engine/gramambular2/reading_grid.h
+++ b/src/Engine/gramambular2/reading_grid.h
@@ -165,10 +165,10 @@ class ReadingGrid {
     // position that is right past the node at cursor, and will be only be set
     // if it's not nullptr and the returned iterator is not nodes.cend().
     std::vector<NodePtr>::const_iterator findNodeAt(
-        size_t cursor, size_t* outCursorPastNode = nullptr);
+        size_t cursor, size_t* outCursorPastNode = nullptr) const;
 
-    std::vector<std::string> valuesAsStrings();
-    std::vector<std::string> readingsAsStrings();
+    std::vector<std::string> valuesAsStrings() const;
+    std::vector<std::string> readingsAsStrings() const;
   };
 
   WalkResult walk();

--- a/src/Engine/gramambular2/reading_grid.h
+++ b/src/Engine/gramambular2/reading_grid.h
@@ -154,9 +154,18 @@ class ReadingGrid {
 
   struct WalkResult {
     std::vector<NodePtr> nodes;
+    size_t totalReadings;
     size_t vertices;
     size_t edges;
     uint64_t elapsedMicroseconds;
+
+    // Convenient method for finding the node at the cursor. Returns
+    // nodes.cend() if the value of cursor argument doesn't make sense. An
+    // optional ourCursorPastNode argument can be used to obtain the cursor
+    // position that is right past the node at cursor, and will be only be set
+    // if it's not nullptr and the returned iterator is not nodes.cend().
+    std::vector<NodePtr>::const_iterator findNodeAt(
+        size_t cursor, size_t* outCursorPastNode = nullptr);
 
     std::vector<std::string> valuesAsStrings();
     std::vector<std::string> readingsAsStrings();

--- a/src/Engine/gramambular2/reading_grid_test.cpp
+++ b/src/Engine/gramambular2/reading_grid_test.cpp
@@ -207,11 +207,13 @@ TEST(ReadingGridTest, Span) {
   ASSERT_EQ(span.maxLength(), 0);
   ASSERT_EQ(span.nodeOf(1), nullptr);
 
+#ifndef NDEBUG
   auto n10 = std::make_shared<ReadingGrid::Node>("", 10, lm.getUnigrams(""));
   ASSERT_DEATH({ (void)span.add(n10); }, "Assertion");
   ASSERT_DEATH({ (void)span.nodeOf(0); }, "Assertion");
   ASSERT_DEATH({ (void)span.nodeOf(ReadingGrid::kMaximumSpanLength + 1); },
                "Assertion");
+#endif
 }
 
 TEST(ReadingGridTest, ScoreRankedLanguageModel) {

--- a/src/McBopomofo.cpp
+++ b/src/McBopomofo.cpp
@@ -686,7 +686,7 @@ void McBopomofoEngine::handleMarkingState(fcitx::InputContext* context,
 }
 
 fcitx::CandidateLayoutHint McBopomofoEngine::getCandidateLayoutHint() {
-  fcitx::CandidateLayoutHint layoutHint;
+  fcitx::CandidateLayoutHint layoutHint = fcitx::CandidateLayoutHint::NotSet;
   switch (config_.candidateLayout.value()) {
     case McBopomofo::CandidateLayoutHint::Vertical:
       layoutHint = fcitx::CandidateLayoutHint::Vertical;
@@ -696,8 +696,6 @@ fcitx::CandidateLayoutHint McBopomofoEngine::getCandidateLayoutHint() {
       break;
     case McBopomofo::CandidateLayoutHint::NotSet:
       layoutHint = fcitx::CandidateLayoutHint::NotSet;
-      break;
-    default:
       break;
   }
 


### PR DESCRIPTION
從 macOS 版 [PR#328](https://github.com/openvanilla/McBopomofo/pull/328) 的分析，發現詞庫中不少雙字詞，分數小於最高分同音單字詞，例如「依舊」的分數比不過「一」與「就」加起來。這其中有些或許可以從改善資料下手，但另一個長久以來的問題是：用戶選字記憶機制，並沒有正確把雙字詞的選字結果記起來。這中間問題很多，簡單說是跟 UserOverrideModel 怎麼決定選字事件，以及在建議雙字詞 override 時，沒有給足夠高的分數造成的。

總之這個 PR 做了不少重構，讓 UserOverrideModel 可以對 walked nodes 作比較精細的處理。

以下是 before and after video. Before:

[before.webm](https://user-images.githubusercontent.com/25210/179117977-281e592c-9acd-4275-89a9-bb30401cc5dd.webm)

After:

[after.webm](https://user-images.githubusercontent.com/25210/179117996-88f96c6a-632c-40e4-aa0e-dfa9057ec317.webm)
