### PR TITLE
Fix a bug in how UOM ignores punctuations

### DIFF
--- a/src/Engine/UserOverrideModel.cpp
+++ b/src/Engine/UserOverrideModel.cpp
@@ -278,7 +278,11 @@ static std::string FormObservationKey(std::vector<Formosa::Gramambular2::Reading
     std::string anteriorStr;
     if (head != end && !prevIsPunctuation) {
         --head;
-        anteriorStr = CombineReadingValue((*head)->reading(), (*head)->currentUnigram().value());
+        if (IsPunctuation((*head))) {
+            anteriorStr = kEmptyNodeString;
+        } else {
+            anteriorStr = CombineReadingValue((*head)->reading(), (*head)->currentUnigram().value());
+        }
     } else {
         anteriorStr = kEmptyNodeString;
     }

--- a/src/Engine/UserOverrideModel.h
+++ b/src/Engine/UserOverrideModel.h
@@ -37,7 +37,7 @@ public:
     UserOverrideModel(size_t capacity, double decayConstant);
 
     struct Suggestion {
-        Suggestion() { }
+        Suggestion() = default;
         Suggestion(std::string c, bool f)
             : candidate(std::move(c))
             , forceHighScoreOverride(f)
@@ -46,7 +46,7 @@ public:
         std::string candidate;
         bool forceHighScoreOverride = false;
 
-        bool empty()
+        [[nodiscard]] bool empty() const
         {
             return candidate.empty();
         }
@@ -93,6 +93,6 @@ private:
     std::map<std::string, std::list<KeyObservationPair>::iterator> m_lruMap;
 };
 
-}; // namespace McBopomofo
+} // namespace McBopomofo
 
 #endif


### PR DESCRIPTION
Punctuations should be treated as empty words by the UOM, but a bug in
the code missed the check for the frontmost (called the "anterior")
unigram. For example, after typing "！！自會" and choosing "字彙", the
next time the UOM sees "？？自會", it should suggest "字彙", but because
of the bug it didn't happen.

Also addresses the issues found by clang-tidy.