### PR TITLE
Refactor project structure

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -5,7 +5,7 @@ on: [push, pull_request]
 jobs:
   build_ubuntu_22:
     runs-on: ubuntu-latest
-    container: ubuntu:jammy-20220531
+    container: ubuntu:22.04
 
     steps:
       - uses: actions/checkout@v1
@@ -20,7 +20,7 @@ jobs:
         run: |
           mkdir -p build
           cd build
-          cmake ../ -DCMAKE_INSTALL_PREFIX=/usr
+          cmake ../ -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_BUILD_TYPE=Debug
           make -j
           cd ../
           mkdir -p src/Engine/build
@@ -30,11 +30,11 @@ jobs:
       - name: Test
         run: |
           cd build
-          make runTest runGramambular2Test runMcBopomofoLMLibTest
+          ctest --output-on-failure
 
   build_ubuntu_20:
     runs-on: ubuntu-latest
-    container: ubuntu:focal-20220531
+    container: ubuntu:20.04
 
     steps:
       - uses: actions/checkout@v1
@@ -49,12 +49,12 @@ jobs:
         run: |
           mkdir -p build
           cd build
-          cmake ../ -DCMAKE_INSTALL_PREFIX=/usr -DUSE_LEGACY_FCITX5_API=1
+          cmake ../ -DCMAKE_INSTALL_PREFIX=/usr -DUSE_LEGACY_FCITX5_API=1 -DCMAKE_BUILD_TYPE=Debug
           make -j
       - name: Test
         run: |
           cd build
-          make runTest
+          ctest --output-on-failure
 
   build_archlinux:
     runs-on: ubuntu-latest

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,3 +41,7 @@ fcitx5_translate_desktop_file(org.fcitx.Fcitx5.Addon.McBopomofo.metainfo.xml.in
                               org.fcitx.Fcitx5.Addon.McBopomofo.metainfo.xml XML)
 install(FILES "${CMAKE_CURRENT_BINARY_DIR}/org.fcitx.Fcitx5.Addon.McBopomofo.metainfo.xml" DESTINATION ${CMAKE_INSTALL_DATADIR}/metainfo)
 feature_summary(WHAT ALL FATAL_ON_MISSING_REQUIRED_PACKAGES)
+
+if (ENABLE_TEST)
+    enable_testing()
+endif ()

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ sudo apt install \
 ```
 mkdir -p build
 cd build
-cmake ../ -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_BUILD_TYPE=Debug
+cmake ../ -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_BUILD_TYPE=Release
 make
 sudo make install
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -80,7 +80,7 @@ if (ENABLE_TEST)
 
         # Test target declarations.
         add_executable(McBopomofoTest
-                KeyHandlerTest.cpp)
+                KeyHandlerTest.cpp UTF8HelperTest.cpp)
         target_compile_options(McBopomofoTest PRIVATE -Wno-unknown-pragmas)
         target_link_libraries(McBopomofoTest PRIVATE Fcitx5::Core gtest_main gmock_main McBopomofoLib)
         target_include_directories(McBopomofoTest PRIVATE Fcitx5::Core)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -12,17 +12,7 @@ set(MCBOPOMOFO_LIB_SOURCES
  KeyHandler.cpp
  LanguageModelLoader.cpp
  UTF8Helper.cpp
- Log.cpp  # Log is part of McBopomofoLib to facilitate debugging via logging.
- Engine/AssociatedPhrases.h
- Engine/AssociatedPhrases.cpp
- Engine/KeyValueBlobReader.cpp 
- Engine/McBopomofoLM.cpp
- Engine/ParselessLM.cpp
- Engine/ParselessPhraseDB.cpp
- Engine/PhraseReplacementMap.cpp
- Engine/UserOverrideModel.cpp
- Engine/UserPhrasesLM.cpp
- Engine/Mandarin/Mandarin.cpp)
+ Log.cpp)
 
 # https://stackoverflow.com/questions/26549137/shared-library-on-linux-and-fpic-error
 set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC")
@@ -30,9 +20,9 @@ set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC")
 # Setup some compiler option that is generally useful and compatible with Fcitx 5 (C++17)
 include("${FCITX_INSTALL_CMAKECONFIG_DIR}/Fcitx5Utils/Fcitx5CompilerSettings.cmake")
 
-add_library(McBopomofoLib STATIC ${MCBOPOMOFO_LIB_SOURCES})
+add_library(McBopomofoLib ${MCBOPOMOFO_LIB_SOURCES})
 target_compile_options(McBopomofoLib PRIVATE -Wno-unknown-pragmas)
-target_link_libraries(McBopomofoLib PRIVATE Fcitx5::Utils gramambular2_lib)
+target_link_libraries(McBopomofoLib PRIVATE Fcitx5::Utils gramambular2_lib McBopomofoLMLib MandarinLib)
 target_include_directories(McBopomofoLib PRIVATE Fcitx5::Utils)
 target_compile_definitions(McBopomofoLib PRIVATE FCITX_GETTEXT_DOMAIN=\"fcitx5-mcbopomofo\")
 
@@ -68,6 +58,11 @@ fcitx5_translate_desktop_file("${CMAKE_CURRENT_BINARY_DIR}/mcbopomofo-plain.conf
 install(FILES "${CMAKE_CURRENT_BINARY_DIR}/mcbopomofo-plain.conf" DESTINATION "${FCITX_INSTALL_PKGDATADIR}/inputmethod")
 
 if (ENABLE_TEST)
+        enable_testing()
+        if (CMAKE_VERSION VERSION_GREATER_EQUAL "3.24.0")
+                cmake_policy(SET CMP0135 NEW)
+        endif()
+
         # Let CMake fetch Google Test for us.
         # https://github.com/google/googletest/tree/main/googletest#incorporating-into-an-existing-cmake-project
         include(FetchContent)

--- a/src/Engine/CMakeLists.txt
+++ b/src/Engine/CMakeLists.txt
@@ -2,15 +2,18 @@ cmake_minimum_required(VERSION 3.6)
 project(McBopomofoLMLib)
 
 set(CMAKE_CXX_STANDARD 17)
+set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC")
 
 add_subdirectory(gramambular2)
+add_subdirectory(Mandarin)
 
-include_directories("Gramambular")
 add_library(McBopomofoLMLib
         AssociatedPhrases.h
         AssociatedPhrases.cpp
         KeyValueBlobReader.cpp
         KeyValueBlobReader.h
+        McBopomofoLM.cpp
+        McBopomofoLM.h
         ParselessPhraseDB.cpp
         ParselessPhraseDB.h
         ParselessLM.cpp
@@ -23,6 +26,11 @@ add_library(McBopomofoLMLib
         UserPhrasesLM.cpp)
 
 if (ENABLE_TEST)
+        enable_testing()
+        if (CMAKE_VERSION VERSION_GREATER_EQUAL "3.24.0")
+                cmake_policy(SET CMP0135 NEW)
+        endif()
+
         # Let CMake fetch Google Test for us.
         # https://github.com/google/googletest/tree/main/googletest#incorporating-into-an-existing-cmake-project
         include(FetchContent)

--- a/src/Engine/Mandarin/CMakeLists.txt
+++ b/src/Engine/Mandarin/CMakeLists.txt
@@ -2,10 +2,16 @@ cmake_minimum_required(VERSION 3.6)
 project(Mandarin)
 
 set(CMAKE_CXX_STANDARD 17)
+set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC")
 
 add_library(MandarinLib Mandarin.h Mandarin.cpp)
 
 if (ENABLE_TEST)
+        enable_testing()
+        if (CMAKE_VERSION VERSION_GREATER_EQUAL "3.24.0")
+                cmake_policy(SET CMP0135 NEW)
+        endif()
+
         # Let CMake fetch Google Test for us.
         # https://github.com/google/googletest/tree/main/googletest#incorporating-into-an-existing-cmake-project
         include(FetchContent)

--- a/src/Engine/gramambular2/CMakeLists.txt
+++ b/src/Engine/gramambular2/CMakeLists.txt
@@ -7,6 +7,11 @@ set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC")
 add_library(gramambular2_lib language_model.h reading_grid.h reading_grid.cpp)
 
 if (ENABLE_TEST)
+        enable_testing()
+        if (CMAKE_VERSION VERSION_GREATER_EQUAL "3.24.0")
+                cmake_policy(SET CMP0135 NEW)
+        endif()
+
         # Let CMake fetch Google Test for us.
         # https://github.com/google/googletest/tree/main/googletest#incorporating-into-an-existing-cmake-project
         include(FetchContent)

--- a/src/KeyHandler.cpp
+++ b/src/KeyHandler.cpp
@@ -787,21 +787,19 @@ KeyHandler::ComposedString KeyHandler::getComposedString(size_t builderCursor) {
 
     // The builder cursor is in the middle of the node.
     size_t distance = builderCursor - runningCursor;
-    std::u32string u32Value = ToU32(value);
+    size_t valueCodePointCount = CodePointCount(value);
 
     // The actual partial value's code point length is the shorter of the
     // distance and the value's code point count.
-    size_t cpLen = std::min(distance, u32Value.length());
-    std::u32string actualU32Value(
-        u32Value.begin(), u32Value.begin() + static_cast<ptrdiff_t>(cpLen));
-    std::string actualValue = ToU8(actualU32Value);
+    size_t cpLen = std::min(distance, valueCodePointCount);
+    std::string actualValue = SubstringToCodePoints(value, cpLen);
     composedCursor += actualValue.length();
     runningCursor += distance;
 
     // Create a tooltip to warn the user that their cursor is between two
     // readings (syllables) even if the cursor is not in the middle of a
     // composed string due to its being shorter than the number of readings.
-    if (u32Value.length() < readingLength) {
+    if (valueCodePointCount < readingLength) {
       // builderCursor is guaranteed to be > 0. If it was 0, we wouldn't even
       // reach here due to runningCursor having already "caught up" with
       // builderCursor. It is also guaranteed to be less than the size of the

--- a/src/KeyHandler.h
+++ b/src/KeyHandler.h
@@ -30,15 +30,15 @@
 #include <string>
 #include <vector>
 
+#include "Engine/Mandarin/Mandarin.h"
+#include "Engine/McBopomofoLM.h"
+#include "Engine/UserOverrideModel.h"
 #include "Engine/gramambular2/language_model.h"
 #include "Engine/gramambular2/reading_grid.h"
 #include "InputMode.h"
 #include "InputState.h"
 #include "Key.h"
 #include "LanguageModelLoader.h"
-#include "Mandarin.h"
-#include "McBopomofoLM.h"
-#include "UserOverrideModel.h"
 
 namespace McBopomofo {
 

--- a/src/LanguageModelLoader.h
+++ b/src/LanguageModelLoader.h
@@ -29,8 +29,8 @@
 #include <string>
 #include <string_view>
 
+#include "Engine/McBopomofoLM.h"
 #include "InputMode.h"
-#include "McBopomofoLM.h"
 
 namespace McBopomofo {
 

--- a/src/UTF8Helper.cpp
+++ b/src/UTF8Helper.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 and onwards The McBopomofo Authors.
+// Copyright (c) 2023 and onwards The McBopomofo Authors.
 //
 // Permission is hereby granted, free of charge, to any person
 // obtaining a copy of this software and associated documentation
@@ -23,19 +23,98 @@
 
 #include "UTF8Helper.h"
 
-#include <codecvt>
-#include <locale>
-
 namespace McBopomofo {
 
-std::u32string ToU32(const std::string& s) {
-  std::wstring_convert<std::codecvt_utf8<char32_t>, char32_t> conv;
-  return conv.from_bytes(s);
+// Adapted from https://github.com/lua/lua/blob/master/lutf8lib.c
+
+constexpr char32_t kMaxUnicode = 0x10FFFF;
+static inline bool IsContinuationByte(char32_t c) { return (c & 0xC0) == 0x80; }
+
+// Decodes one UTF-8 code point and advances the string iterator past the code
+// point. Returns false if i is already at the end, or if the iterated UTF-8
+// sequence is not valid.
+static inline bool DecodeUTF8(std::string::const_iterator& i,
+                              const std::string::const_iterator& end) {
+  static const char32_t limits[] = {~(char32_t)0, 0x80,     0x800,
+                                    0x10000,      0x200000, 0x4000000};
+  if (i == end) {
+    return false;
+  }
+
+  char32_t c = static_cast<unsigned char>(*i);
+  // Consumes the continuation bytes if c is not ASCII.
+  if (c >= 0x80) {
+    char32_t res = 0;
+    size_t count = 0;  // to count number of continuation bytes
+
+    std::string::const_iterator next = i;
+    for (; c & 0x40; c <<= 1) {
+      ++next;
+      if (next == end) {
+        // Sequence terminates prematurely. Bail.
+        return false;
+      }
+
+      ++count;
+      char32_t cc = static_cast<unsigned char>(*next);
+      if (!IsContinuationByte(cc)) {
+        return false;
+      }
+      // Add lower 6 bits from the continuous byte.
+      res = (res << 6) | (cc & 0x3F);
+    }
+    // Add first byte. Recall c has already been left-shifted (count * 1) times,
+    // and so we need to left-shift another (count * 5) bits so the net effect
+    // is left-shifting (count * 6) bits.
+    res |= ((char32_t)(c & 0x7F) << (count * 5));
+
+    bool invalid = count > 5 || res > kMaxUnicode || res < limits[count] ||
+                   (0xd800 <= res && res <= 0xdfff);
+    if (invalid) {
+      return false;
+    }
+    for (size_t j = 0; j < count && i != end; j++) {
+      ++i;
+    }
+  }
+
+  // Sequence terminates prematurely.
+  if (i == end) {
+    return false;
+  }
+
+  ++i;
+  return true;
 }
 
-std::string ToU8(const std::u32string& s) {
-  std::wstring_convert<std::codecvt_utf8<char32_t>, char32_t> conv;
-  return conv.to_bytes(s);
+size_t CodePointCount(const std::string& s) {
+  size_t c = 0;
+  std::string::const_iterator i = s.cbegin();
+  std::string::const_iterator end = s.cend();
+  while (i != end) {
+    bool r = DecodeUTF8(i, end);
+    if (!r) {
+      break;
+    }
+    ++c;
+  }
+
+  return c;
+}
+
+std::string SubstringToCodePoints(const std::string& s, size_t cp) {
+  size_t c = 0;
+  std::string::const_iterator i = s.cbegin();
+  std::string::const_iterator end = s.cend();
+  while (i != end && c < cp) {
+    bool r = DecodeUTF8(i, end);
+    if (!r) {
+      break;
+    }
+    ++c;
+  }
+
+  return {s.cbegin(), i};
 }
 
 }  // namespace McBopomofo

--- a/src/UTF8Helper.h
+++ b/src/UTF8Helper.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 and onwards The McBopomofo Authors.
+// Copyright (c) 2023 and onwards The McBopomofo Authors.
 //
 // Permission is hereby granted, free of charge, to any person
 // obtaining a copy of this software and associated documentation
@@ -28,8 +28,15 @@
 
 namespace McBopomofo {
 
-std::u32string ToU32(const std::string& s);
-std::string ToU8(const std::u32string& s);
+// Count the number of code points of a string encoded in UTF-8. If it
+// encounters an invalid UTF-8 sequence, the returned value is the number of
+// code points up to before that invalid sequence.
+size_t CodePointCount(const std::string& s);
+
+// Clamp the string by the cp code points. If the string is shorter, the result
+// is a copy of s. If s contains some invalid UTF-8 sequence, the returned value
+// will be the string clamped up to before that invalid sequence.
+std::string SubstringToCodePoints(const std::string& s, size_t cp);
 
 }  // namespace McBopomofo
 

--- a/src/UTF8HelperTest.cpp
+++ b/src/UTF8HelperTest.cpp
@@ -1,0 +1,94 @@
+// Copyright (c) 2023 and onwards The McBopomofo Authors.
+//
+// Permission is hereby granted, free of charge, to any person
+// obtaining a copy of this software and associated documentation
+// files (the "Software"), to deal in the Software without
+// restriction, including without limitation the rights to use,
+// copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following
+// conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+// OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+// HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+// OTHER DEALINGS IN THE SOFTWARE.
+
+#include <string>
+
+#include "UTF8Helper.h"
+#include "gtest/gtest.h"
+
+namespace McBopomofo {
+
+TEST(UTF8HelperTest, CountingAndClampingEmptyString) {
+  std::string s;
+  ASSERT_EQ(CodePointCount(s), 0);
+  ASSERT_EQ(SubstringToCodePoints(s, 0), s);
+  ASSERT_EQ(SubstringToCodePoints(s, 1), s);
+}
+
+TEST(UTF8HelperTest, CountingAndClapmingAsciiStrings) {
+  std::string s = "hello, world!";
+  ASSERT_EQ(CodePointCount(s), 13);
+  ASSERT_EQ(SubstringToCodePoints(s, 0), "");
+  ASSERT_EQ(SubstringToCodePoints(s, 5), "hello");
+  ASSERT_EQ(SubstringToCodePoints(s, 14), s);
+}
+// 🂡
+
+TEST(UTF8HelperTest, CountingAndClapmingStrings) {
+  std::string s = "café🂡火";
+  ASSERT_EQ(CodePointCount(s), 6);
+  ASSERT_EQ(SubstringToCodePoints(s, 0), "");
+  ASSERT_EQ(SubstringToCodePoints(s, 3), "caf");
+  ASSERT_EQ(SubstringToCodePoints(s, 4), "café");
+  ASSERT_EQ(SubstringToCodePoints(s, 5), "café🂡");
+  ASSERT_EQ(SubstringToCodePoints(s, 6), s);
+  ASSERT_EQ(SubstringToCodePoints(s, 7), s);
+  ASSERT_EQ(SubstringToCodePoints(s, 8), s);
+}
+
+TEST(UTF8HelperTest, CountingAndClapmingInvalidStrings) {
+  // Mangled UTF-8 sequence: \xc3\xa9 = é;
+  std::string s = "caf🂡\xa9\xc3火";
+  ASSERT_EQ(CodePointCount(s), 4);
+  ASSERT_EQ(SubstringToCodePoints(s, 0), "");
+  ASSERT_EQ(SubstringToCodePoints(s, 3), "caf");
+  ASSERT_EQ(SubstringToCodePoints(s, 4), "caf🂡");
+  ASSERT_EQ(SubstringToCodePoints(s, 5), "caf🂡");
+  ASSERT_EQ(SubstringToCodePoints(s, 6), "caf🂡");
+  ASSERT_EQ(SubstringToCodePoints(s, 7), "caf🂡");
+  ASSERT_EQ(SubstringToCodePoints(s, 8), "caf🂡");
+}
+
+TEST(UTF8HelperTest, CountingAndClapmingPrematurelyTerminatingSequence) {
+  // \xc3\xa9 = é;
+  std::string s = "\xc3";
+  ASSERT_EQ(CodePointCount(s), 0);
+  ASSERT_EQ(SubstringToCodePoints(s, 0), "");
+  ASSERT_EQ(SubstringToCodePoints(s, 1), "");
+  ASSERT_EQ(SubstringToCodePoints(s, 2), "");
+
+  s = "abc\xc3 def";
+  ASSERT_EQ(CodePointCount(s), 3);
+  ASSERT_EQ(SubstringToCodePoints(s, 0), "");
+  ASSERT_EQ(SubstringToCodePoints(s, 1), "a");
+  ASSERT_EQ(SubstringToCodePoints(s, 4), "abc");
+
+  // This is an invalid start.
+  s = "\xa9";
+  ASSERT_EQ(CodePointCount(s), 0);
+  ASSERT_EQ(SubstringToCodePoints(s, 0), "");
+  ASSERT_EQ(SubstringToCodePoints(s, 1), "");
+  ASSERT_EQ(SubstringToCodePoints(s, 2), "");
+}
+
+}  // namespace McBopomofo


### PR DESCRIPTION
Fixes #73

This commit:

- Makes it possible to use ctest to run *all* tests
- Makes McBopomofoLib links against Engine, Mandarin, and gramambular2
- References subproject headers explicitly (`Engine/McBopomofoLM.h`)

This commit also:

- Updates GitHub CI action
- Fixes the DOWNLOAD_EXTRACT_TIMESTAMP warning from CMake 3.24+
- Updates README.md to encourage use of Release builds, as it results in a smaller shared library; note: tests still need to be run against Debug builds, due to how asserts work