### PR TITLE
Remove codecvt use

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -80,7 +80,7 @@ if (ENABLE_TEST)
 
         # Test target declarations.
         add_executable(McBopomofoTest
-                KeyHandlerTest.cpp)
+                KeyHandlerTest.cpp UTF8HelperTest.cpp)
         target_compile_options(McBopomofoTest PRIVATE -Wno-unknown-pragmas)
         target_link_libraries(McBopomofoTest PRIVATE Fcitx5::Core gtest_main gmock_main McBopomofoLib)
         target_include_directories(McBopomofoTest PRIVATE Fcitx5::Core)

--- a/src/KeyHandler.cpp
+++ b/src/KeyHandler.cpp
@@ -787,21 +787,19 @@ KeyHandler::ComposedString KeyHandler::getComposedString(size_t builderCursor) {
 
     // The builder cursor is in the middle of the node.
     size_t distance = builderCursor - runningCursor;
-    std::u32string u32Value = ToU32(value);
+    size_t valueCodePointCount = CodePointCount(value);
 
     // The actual partial value's code point length is the shorter of the
     // distance and the value's code point count.
-    size_t cpLen = std::min(distance, u32Value.length());
-    std::u32string actualU32Value(
-        u32Value.begin(), u32Value.begin() + static_cast<ptrdiff_t>(cpLen));
-    std::string actualValue = ToU8(actualU32Value);
+    size_t cpLen = std::min(distance, valueCodePointCount);
+    std::string actualValue = SubstringToCodePoints(value, cpLen);
     composedCursor += actualValue.length();
     runningCursor += distance;
 
     // Create a tooltip to warn the user that their cursor is between two
     // readings (syllables) even if the cursor is not in the middle of a
     // composed string due to its being shorter than the number of readings.
-    if (u32Value.length() < readingLength) {
+    if (valueCodePointCount < readingLength) {
       // builderCursor is guaranteed to be > 0. If it was 0, we wouldn't even
       // reach here due to runningCursor having already "caught up" with
       // builderCursor. It is also guaranteed to be less than the size of the

--- a/src/UTF8Helper.cpp
+++ b/src/UTF8Helper.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 and onwards The McBopomofo Authors.
+// Copyright (c) 2023 and onwards The McBopomofo Authors.
 //
 // Permission is hereby granted, free of charge, to any person
 // obtaining a copy of this software and associated documentation
@@ -23,19 +23,98 @@
 
 #include "UTF8Helper.h"
 
-#include <codecvt>
-#include <locale>
-
 namespace McBopomofo {
 
-std::u32string ToU32(const std::string& s) {
-  std::wstring_convert<std::codecvt_utf8<char32_t>, char32_t> conv;
-  return conv.from_bytes(s);
+// Adapted from https://github.com/lua/lua/blob/master/lutf8lib.c
+
+constexpr char32_t kMaxUnicode = 0x10FFFF;
+static inline bool IsContinuationByte(char32_t c) { return (c & 0xC0) == 0x80; }
+
+// Decodes one UTF-8 code point and advances the string iterator past the code
+// point. Returns false if i is already at the end, or if the iterated UTF-8
+// sequence is not valid.
+static inline bool DecodeUTF8(std::string::const_iterator& i,
+                              const std::string::const_iterator& end) {
+  static const char32_t limits[] = {~(char32_t)0, 0x80,     0x800,
+                                    0x10000,      0x200000, 0x4000000};
+  if (i == end) {
+    return false;
+  }
+
+  char32_t c = static_cast<unsigned char>(*i);
+  // Consumes the continuation bytes if c is not ASCII.
+  if (c >= 0x80) {
+    char32_t res = 0;
+    size_t count = 0;  // to count number of continuation bytes
+
+    std::string::const_iterator next = i;
+    for (; c & 0x40; c <<= 1) {
+      ++next;
+      if (next == end) {
+        // Sequence terminates prematurely. Bail.
+        return false;
+      }
+
+      ++count;
+      char32_t cc = static_cast<unsigned char>(*next);
+      if (!IsContinuationByte(cc)) {
+        return false;
+      }
+      // Add lower 6 bits from the continuous byte.
+      res = (res << 6) | (cc & 0x3F);
+    }
+    // Add first byte. Recall c has already been left-shifted (count * 1) times,
+    // and so we need to left-shift another (count * 5) bits so the net effect
+    // is left-shifting (count * 6) bits.
+    res |= ((char32_t)(c & 0x7F) << (count * 5));
+
+    bool invalid = count > 5 || res > kMaxUnicode || res < limits[count] ||
+                   (0xd800 <= res && res <= 0xdfff);
+    if (invalid) {
+      return false;
+    }
+    for (size_t j = 0; j < count && i != end; j++) {
+      ++i;
+    }
+  }
+
+  // Sequence terminates prematurely.
+  if (i == end) {
+    return false;
+  }
+
+  ++i;
+  return true;
 }
 
-std::string ToU8(const std::u32string& s) {
-  std::wstring_convert<std::codecvt_utf8<char32_t>, char32_t> conv;
-  return conv.to_bytes(s);
+size_t CodePointCount(const std::string& s) {
+  size_t c = 0;
+  std::string::const_iterator i = s.cbegin();
+  std::string::const_iterator end = s.cend();
+  while (i != end) {
+    bool r = DecodeUTF8(i, end);
+    if (!r) {
+      break;
+    }
+    ++c;
+  }
+
+  return c;
+}
+
+std::string SubstringToCodePoints(const std::string& s, size_t cp) {
+  size_t c = 0;
+  std::string::const_iterator i = s.cbegin();
+  std::string::const_iterator end = s.cend();
+  while (i != end && c < cp) {
+    bool r = DecodeUTF8(i, end);
+    if (!r) {
+      break;
+    }
+    ++c;
+  }
+
+  return {s.cbegin(), i};
 }
 
 }  // namespace McBopomofo

--- a/src/UTF8Helper.h
+++ b/src/UTF8Helper.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 and onwards The McBopomofo Authors.
+// Copyright (c) 2023 and onwards The McBopomofo Authors.
 //
 // Permission is hereby granted, free of charge, to any person
 // obtaining a copy of this software and associated documentation
@@ -28,8 +28,15 @@
 
 namespace McBopomofo {
 
-std::u32string ToU32(const std::string& s);
-std::string ToU8(const std::u32string& s);
+// Count the number of code points of a string encoded in UTF-8. If it
+// encounters an invalid UTF-8 sequence, the returned value is the number of
+// code points up to before that invalid sequence.
+size_t CodePointCount(const std::string& s);
+
+// Clamp the string by the cp code points. If the string is shorter, the result
+// is a copy of s. If s contains some invalid UTF-8 sequence, the returned value
+// will be the string clamped up to before that invalid sequence.
+std::string SubstringToCodePoints(const std::string& s, size_t cp);
 
 }  // namespace McBopomofo
 

--- a/src/UTF8HelperTest.cpp
+++ b/src/UTF8HelperTest.cpp
@@ -1,0 +1,94 @@
+// Copyright (c) 2023 and onwards The McBopomofo Authors.
+//
+// Permission is hereby granted, free of charge, to any person
+// obtaining a copy of this software and associated documentation
+// files (the "Software"), to deal in the Software without
+// restriction, including without limitation the rights to use,
+// copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following
+// conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+// OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+// HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+// OTHER DEALINGS IN THE SOFTWARE.
+
+#include <string>
+
+#include "UTF8Helper.h"
+#include "gtest/gtest.h"
+
+namespace McBopomofo {
+
+TEST(UTF8HelperTest, CountingAndClampingEmptyString) {
+  std::string s;
+  ASSERT_EQ(CodePointCount(s), 0);
+  ASSERT_EQ(SubstringToCodePoints(s, 0), s);
+  ASSERT_EQ(SubstringToCodePoints(s, 1), s);
+}
+
+TEST(UTF8HelperTest, CountingAndClapmingAsciiStrings) {
+  std::string s = "hello, world!";
+  ASSERT_EQ(CodePointCount(s), 13);
+  ASSERT_EQ(SubstringToCodePoints(s, 0), "");
+  ASSERT_EQ(SubstringToCodePoints(s, 5), "hello");
+  ASSERT_EQ(SubstringToCodePoints(s, 14), s);
+}
+// 🂡
+
+TEST(UTF8HelperTest, CountingAndClapmingStrings) {
+  std::string s = "café🂡火";
+  ASSERT_EQ(CodePointCount(s), 6);
+  ASSERT_EQ(SubstringToCodePoints(s, 0), "");
+  ASSERT_EQ(SubstringToCodePoints(s, 3), "caf");
+  ASSERT_EQ(SubstringToCodePoints(s, 4), "café");
+  ASSERT_EQ(SubstringToCodePoints(s, 5), "café🂡");
+  ASSERT_EQ(SubstringToCodePoints(s, 6), s);
+  ASSERT_EQ(SubstringToCodePoints(s, 7), s);
+  ASSERT_EQ(SubstringToCodePoints(s, 8), s);
+}
+
+TEST(UTF8HelperTest, CountingAndClapmingInvalidStrings) {
+  // Mangled UTF-8 sequence: \xc3\xa9 = é;
+  std::string s = "caf🂡\xa9\xc3火";
+  ASSERT_EQ(CodePointCount(s), 4);
+  ASSERT_EQ(SubstringToCodePoints(s, 0), "");
+  ASSERT_EQ(SubstringToCodePoints(s, 3), "caf");
+  ASSERT_EQ(SubstringToCodePoints(s, 4), "caf🂡");
+  ASSERT_EQ(SubstringToCodePoints(s, 5), "caf🂡");
+  ASSERT_EQ(SubstringToCodePoints(s, 6), "caf🂡");
+  ASSERT_EQ(SubstringToCodePoints(s, 7), "caf🂡");
+  ASSERT_EQ(SubstringToCodePoints(s, 8), "caf🂡");
+}
+
+TEST(UTF8HelperTest, CountingAndClapmingPrematurelyTerminatingSequence) {
+  // \xc3\xa9 = é;
+  std::string s = "\xc3";
+  ASSERT_EQ(CodePointCount(s), 0);
+  ASSERT_EQ(SubstringToCodePoints(s, 0), "");
+  ASSERT_EQ(SubstringToCodePoints(s, 1), "");
+  ASSERT_EQ(SubstringToCodePoints(s, 2), "");
+
+  s = "abc\xc3 def";
+  ASSERT_EQ(CodePointCount(s), 3);
+  ASSERT_EQ(SubstringToCodePoints(s, 0), "");
+  ASSERT_EQ(SubstringToCodePoints(s, 1), "a");
+  ASSERT_EQ(SubstringToCodePoints(s, 4), "abc");
+
+  // This is an invalid start.
+  s = "\xa9";
+  ASSERT_EQ(CodePointCount(s), 0);
+  ASSERT_EQ(SubstringToCodePoints(s, 0), "");
+  ASSERT_EQ(SubstringToCodePoints(s, 1), "");
+  ASSERT_EQ(SubstringToCodePoints(s, 2), "");
+}
+
+}  // namespace McBopomofo


### PR DESCRIPTION
It's deprecated in C++17 and KeyHandler relly just needs a simple substring function, and so this reimplements it using the UTF-8 iteration code from Lua.