### PR TITLE
Add `clang-tidy` to CMakeLists.txt files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,6 +16,17 @@ include(ECMUninstallTarget)
 
 option(ENABLE_TEST "Build Test" On)
 
+# clang-tidy
+option(ENABLE_CLANG_TIDY "Enable clang-tidy" Off)
+if (ENABLE_CLANG_TIDY)
+    MESSAGE(STATUS "Enabled clang-tidy")
+    find_program(CLANG_TIDY NAMES "clang-tidy" REQUIRED)
+    MESSAGE(STATUS "Found clang-tidy: ${CLANG_TIDY}")
+    set(CLANG_TIDY_COMMAND "${CLANG_TIDY}" "-checks=-*,clang-analyzer-*,bugprone-*,cert-*,readability-*")
+    # one may wants to use the following instead to focus on a specific category
+    # set(CLANG_TIDY_COMMAND "${CLANG_TIDY}" "-checks=-*,clang-analyzer-*")
+endif ()
+
 # Setup some compiler option that is generally useful and compatible with Fcitx 5 (C++17)
 include("${FCITX_INSTALL_CMAKECONFIG_DIR}/Fcitx5Utils/Fcitx5CompilerSettings.cmake")
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -26,6 +26,10 @@ target_link_libraries(McBopomofoLib PRIVATE Fcitx5::Utils gramambular2_lib McBop
 target_include_directories(McBopomofoLib PRIVATE Fcitx5::Utils)
 target_compile_definitions(McBopomofoLib PRIVATE FCITX_GETTEXT_DOMAIN=\"fcitx5-mcbopomofo\")
 
+if (ENABLE_CLANG_TIDY)
+    set_target_properties(McBopomofoLib PROPERTIES CXX_CLANG_TIDY "${CLANG_TIDY_COMMAND}")
+endif ()
+
 include_directories(Engine)
 include_directories(Engine/Gramambular)
 include_directories(Engine/Mandarin)
@@ -42,6 +46,10 @@ target_include_directories(mcbopomofo PRIVATE Fcitx5::Core fmt::fmt)
 set_target_properties(mcbopomofo PROPERTIES PREFIX "")
 target_compile_definitions(mcbopomofo PRIVATE FCITX_GETTEXT_DOMAIN=\"fcitx5-mcbopomofo\")
 install(TARGETS mcbopomofo DESTINATION "${FCITX_INSTALL_LIBDIR}/fcitx5")
+
+if (ENABLE_CLANG_TIDY)
+    set_target_properties(mcbopomofo PROPERTIES CXX_CLANG_TIDY "${CLANG_TIDY_COMMAND}")
+endif ()
 
 # Addon config file
 # We need additional layer of conversion because we want PROJECT_VERSION in it.
@@ -95,3 +103,4 @@ if (ENABLE_TEST)
         )
         add_dependencies(runTest McBopomofoTest)
 endif ()
+

--- a/src/Engine/CMakeLists.txt
+++ b/src/Engine/CMakeLists.txt
@@ -25,6 +25,10 @@ add_library(McBopomofoLMLib
         UserPhrasesLM.h
         UserPhrasesLM.cpp)
 
+if (ENABLE_CLANG_TIDY)
+    set_target_properties(McBopomofoLMLib PROPERTIES CXX_CLANG_TIDY "${CLANG_TIDY_COMMAND}")
+endif ()
+
 if (ENABLE_TEST)
         enable_testing()
         if (CMAKE_VERSION VERSION_GREATER_EQUAL "3.24.0")

--- a/src/Engine/Mandarin/CMakeLists.txt
+++ b/src/Engine/Mandarin/CMakeLists.txt
@@ -6,6 +6,10 @@ set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC")
 
 add_library(MandarinLib Mandarin.h Mandarin.cpp)
 
+if (ENABLE_CLANG_TIDY)
+    set_target_properties(MandarinLib PROPERTIES CXX_CLANG_TIDY "${CLANG_TIDY_COMMAND}")
+endif ()
+
 if (ENABLE_TEST)
         enable_testing()
         if (CMAKE_VERSION VERSION_GREATER_EQUAL "3.24.0")

--- a/src/Engine/gramambular2/CMakeLists.txt
+++ b/src/Engine/gramambular2/CMakeLists.txt
@@ -6,6 +6,10 @@ set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC")
 
 add_library(gramambular2_lib language_model.h reading_grid.h reading_grid.cpp)
 
+if (ENABLE_CLANG_TIDY)
+    set_target_properties(gramambular2_lib PROPERTIES CXX_CLANG_TIDY "${CLANG_TIDY_COMMAND}")
+endif ()
+
 if (ENABLE_TEST)
         enable_testing()
         if (CMAKE_VERSION VERSION_GREATER_EQUAL "3.24.0")


### PR DESCRIPTION
`clang-tidy` is a great tool to catch bugs at compile time. This commit adds support to execute `clang-tidy` to our CMake scripts.

This flag is OFF by default, to enable clang-tidy, append `-DENABLE_CLANG_TIDY=On` to `cmake` commands.

I picked a few popular ones, and we may want to enable more later.

https://releases.llvm.org/11.1.0/tools/clang/tools/extra/docs/clang-tidy/checks/list.html