### PR TITLE
chore: fix issues raised by clang-tidy

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,7 +22,7 @@ if (ENABLE_CLANG_TIDY)
     MESSAGE(STATUS "Enabled clang-tidy")
     find_program(CLANG_TIDY NAMES "clang-tidy" REQUIRED)
     MESSAGE(STATUS "Found clang-tidy: ${CLANG_TIDY}")
-    set(CLANG_TIDY_COMMAND "${CLANG_TIDY}" "-checks=-*,clang-analyzer-*,bugprone-*,cert-*,readability-*")
+    set(CLANG_TIDY_COMMAND "${CLANG_TIDY}" "-checks=-*,clang-analyzer-*,bugprone-*,-bugprone-easily-swappable-parameters,cert-*,readability-*")
     # one may wants to use the following instead to focus on a specific category
     # set(CLANG_TIDY_COMMAND "${CLANG_TIDY}" "-checks=-*,clang-analyzer-*")
 endif ()

--- a/src/Engine/Mandarin/Mandarin.cpp
+++ b/src/Engine/Mandarin/Mandarin.cpp
@@ -73,6 +73,9 @@ const BPMF BPMF::FromHanyuPinyin(const std::string& str) {
   // lookup consonants and consume them
   bool independentConsonant = false;
 
+  // disable this check for if-else/switch blocks below
+  // NOLINTBEGIN(bugprone-branch-clone)
+
   // the y exceptions fist
   if (0) {
   } else if (PinyinParseHelper::ConsumePrefix(pinyin, "yuan")) {
@@ -101,7 +104,7 @@ const BPMF BPMF::FromHanyuPinyin(const std::string& str) {
   }
 
   // try the first character
-  char c = pinyin.length() ? pinyin[0] : 0;
+  char c = pinyin.length() ? pinyin[0] : '\0';
   switch (c) {
     case 'b':
       firstComponent = BPMF::B;
@@ -160,7 +163,7 @@ const BPMF BPMF::FromHanyuPinyin(const std::string& str) {
       pinyin = pinyin.substr(1);
       break;
 
-    // special hanlding for w and y
+    // special handling for w and y
     case 'w':
       secondComponent = BPMF::U;
       pinyin = pinyin.substr(1);
@@ -316,6 +319,7 @@ const BPMF BPMF::FromHanyuPinyin(const std::string& str) {
       thirdComponent = BPMF::ER;
     }
   }
+  // NOLINTEND(bugprone-branch-clone)
 
   // at last!
   if (0) {
@@ -447,6 +451,7 @@ const std::string BPMF::HanyuPinyinString(bool includesTone,
       break;
   }
 
+  // NOLINTBEGIN(bugprone-branch-clone)
   switch (vc) {
     case A:
       vowel = "a";
@@ -488,6 +493,7 @@ const std::string BPMF::HanyuPinyinString(bool includesTone,
       vowel = "er";
       break;
   }
+  // NOLINTEND(bugprone-branch-clone)
 
   // combination rules
 
@@ -566,7 +572,7 @@ const BPMF BPMF::FromComposedString(const std::string& str) {
       break;
     }
 
-    size_t utf8_length = -1;
+    std::string::difference_type utf8_length = -1;
 
     // These are the code points for the tone markers.
     if ((*iter & (0x80 | 0x40)) && !(*iter & 0x20)) {
@@ -600,10 +606,10 @@ const BPMF BPMF::FromComposedString(const std::string& str) {
 const std::string BPMF::composedString() const {
   std::string result;
 #define APPEND(c)                                                         \
-  if (syllable_ & c)                                                      \
+  if (syllable_ & (c))                                                    \
   result +=                                                               \
       (*BopomofoCharacterMap::SharedInstance().componentToCharacter.find( \
-           syllable_ & c))                                                \
+           syllable_ & (c)))                                              \
           .second
   APPEND(ConsonantMask);
   APPEND(MiddleVowelMask);
@@ -667,6 +673,8 @@ BopomofoCharacterMap::BopomofoCharacterMap() {
     componentToCharacter[(*iter).second] = (*iter).first;
 }
 
+// we don't need parentheses for these macros
+// NOLINTBEGIN(bugprone-macro-parentheses)
 #define ASSIGNKEY1(m, vec, k, val) \
   m[k] = (vec.clear(), vec.push_back((BPMF::Component)val), vec)
 #define ASSIGNKEY2(m, vec, k, val1, val2)                    \
@@ -676,6 +684,7 @@ BopomofoCharacterMap::BopomofoCharacterMap() {
   m[k] = (vec.clear(), vec.push_back((BPMF::Component)val1), \
           vec.push_back((BPMF::Component)val2),              \
           vec.push_back((BPMF::Component)val3), vec)
+// NOLINTEND(bugprone-macro-parentheses)
 
 static BopomofoKeyboardLayout* CreateStandardLayout() {
   std::vector<BPMF::Component> vec;

--- a/src/Engine/ParselessLM.cpp
+++ b/src/Engine/ParselessLM.cpp
@@ -70,7 +70,7 @@ bool McBopomofo::ParselessLM::open(const std::string_view& path)
     }
 
     db_ = std::unique_ptr<ParselessPhraseDB>(new ParselessPhraseDB(
-        static_cast<char*>(data_), length_, /*validate_pragme=*/
+        static_cast<char*>(data_), length_, /*validate_pragma=*/
         true));
     return true;
 }

--- a/src/Engine/PhraseReplacementMap.cpp
+++ b/src/Engine/PhraseReplacementMap.cpp
@@ -54,8 +54,7 @@ bool PhraseReplacementMap::open(const char* path)
 
     KeyValueBlobReader reader(static_cast<char*>(data), length);
     KeyValueBlobReader::KeyValue keyValue;
-    KeyValueBlobReader::State state;
-    while ((state = reader.Next(&keyValue)) == KeyValueBlobReader::State::HAS_PAIR) {
+    while (reader.Next(&keyValue) == KeyValueBlobReader::State::HAS_PAIR) {
         keyValueMap[keyValue.key] = keyValue.value;
     }
     return true;

--- a/src/Engine/UserPhrasesLM.cpp
+++ b/src/Engine/UserPhrasesLM.cpp
@@ -83,8 +83,7 @@ bool UserPhrasesLM::open(const char* path)
 
     KeyValueBlobReader reader(static_cast<char*>(data), length);
     KeyValueBlobReader::KeyValue keyValue;
-    KeyValueBlobReader::State state;
-    while ((state = reader.Next(&keyValue)) == KeyValueBlobReader::State::HAS_PAIR) {
+    while (reader.Next(&keyValue) == KeyValueBlobReader::State::HAS_PAIR) {
         // We invert the key and value, since in user phrases, "key" is the phrase value, and "value" is the BPMF reading.
         keyRowMap[keyValue.value].emplace_back(keyValue.value, keyValue.key);
     }

--- a/src/KeyHandler.cpp
+++ b/src/KeyHandler.cpp
@@ -101,7 +101,7 @@ bool KeyHandler::handle(Key key, McBopomofo::InputState* state,
                         const ErrorCallback& errorCallback) {
   // From Key's definition, if shiftPressed is true, it can't be a simple key
   // that can be represented by ASCII.
-  char simpleAscii = (key.ctrlPressed || key.shiftPressed) ? 0 : key.ascii;
+  char simpleAscii = (key.ctrlPressed || key.shiftPressed) ? '\0' : key.ascii;
 
   // See if it's valid BPMF reading.
   bool keyConsumedByReading = false;
@@ -424,7 +424,7 @@ void KeyHandler::candidatePanelCancelled(const StateCallback& stateCallback) {
   stateCallback(buildInputtingState());
 }
 
-bool KeyHandler::handleCandidateKeyForTraditionalBompomofoIfRequired(
+bool KeyHandler::handleCandidateKeyForTraditionalBopomofoIfRequired(
     Key key,
     const SelectCurrentCandidateCallback& SelectCurrentCandidateCallback,
     const StateCallback& stateCallback, const ErrorCallback& errorCallback) {

--- a/src/KeyHandler.h
+++ b/src/KeyHandler.h
@@ -79,7 +79,7 @@ class KeyHandler {
   void candidatePanelCancelled(const StateCallback& stateCallback);
 
   // Workaround for the Traditional Bopomofo mode.
-  bool handleCandidateKeyForTraditionalBompomofoIfRequired(
+  bool handleCandidateKeyForTraditionalBopomofoIfRequired(
       Key key,
       const SelectCurrentCandidateCallback& SelectCurrentCandidateCallback,
       const StateCallback& stateCallback, const ErrorCallback& errorCallback);
@@ -103,7 +103,7 @@ class KeyHandler {
   // Sets if we should move cursor after selection.
   void setMoveCursorAfterSelection(bool flag);
 
-  // Sets if we should put lowercasesd letters into the composing buffer.
+  // Sets if we should put lowercased letters into the composing buffer.
   void setPutLowercaseLettersToComposingBuffer(bool flag);
 
   /// Sets if the ESC key clears entire composing buffer.

--- a/src/LanguageModelLoader.cpp
+++ b/src/LanguageModelLoader.cpp
@@ -28,6 +28,7 @@
 #include <filesystem>
 #include <fstream>
 #include <memory>
+#include <utility>
 
 #include "Log.h"
 


### PR DESCRIPTION
This fixes the following code issues raised by `clang-analyzer-*,bugprone-*`.

- use '\0' instead of 0 to avoid int to char down casting.
- use iter::difference_type instead of the misuse of size_t (must be unsigned).
- parentheses on macro parameters
- avoid unused assignments in loop conditions
- use static_cast to downcast size_t to int properly.
- various typos

Some warnings are suppressed as they may not be applicable in the context, provided notes on reasons disabling them.

`bugprone-easily-swappable-parameters` is probably too noisy for this project, disable globally.