### PR TITLE
chore: fix issues raised by clang-tidy (part 2)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,25 +17,30 @@ include(ECMUninstallTarget)
 option(ENABLE_TEST "Build Test" On)
 
 # clang-tidy
-option(ENABLE_CLANG_TIDY "Enable clang-tidy" Off)
+option(ENABLE_CLANG_TIDY "Enable clang-tidy" On)
 if (ENABLE_CLANG_TIDY)
-    MESSAGE(STATUS "Enabled clang-tidy")
-    find_program(CLANG_TIDY NAMES "clang-tidy" REQUIRED)
-    MESSAGE(STATUS "Found clang-tidy: ${CLANG_TIDY}")
-    string(CONCAT CLANG_TIDY_CHECKS "-checks=-*,"
-        "clang-analyzer-*,bugprone-*,cert-*,readability-*,"
-        "-bugprone-easily-swappable-parameters,"
-        "-readability-const-return-type,"
-        "-readability-convert-member-functions-to-static,"
-        "-readability-function-cognitive-complexity,"
-        "-readability-identifier-length,"
-        "-readability-implicit-bool-conversion,"
-        "-readability-isolate-declaration,"
-        "-readability-suspicious-call-argument"
-    )
-    set(CLANG_TIDY_COMMAND "${CLANG_TIDY}" "${CLANG_TIDY_CHECKS}")
-    # one may wants to use the following instead to focus on a specific category
-    # set(CLANG_TIDY_COMMAND "${CLANG_TIDY}" "-checks=-*,clang-analyzer-*")
+    MESSAGE(STATUS "Checking clang-tidy...")
+    find_program(CLANG_TIDY NAMES "clang-tidy")
+    if (CLANG_TIDY)
+        MESSAGE(STATUS "Found clang-tidy: ${CLANG_TIDY}")
+        string(CONCAT CLANG_TIDY_CHECKS "-checks=-*,"
+            "clang-analyzer-*,bugprone-*,cert-*,readability-*,"
+            "-bugprone-easily-swappable-parameters,"
+            "-readability-const-return-type,"
+            "-readability-convert-member-functions-to-static,"
+            "-readability-function-cognitive-complexity,"
+            "-readability-identifier-length,"
+            "-readability-implicit-bool-conversion,"
+            "-readability-isolate-declaration,"
+            "-readability-suspicious-call-argument"
+        )
+        set(CLANG_TIDY_COMMAND "${CLANG_TIDY}" "${CLANG_TIDY_CHECKS}")
+        # one may wants to use the following instead to focus on a specific category
+        # set(CLANG_TIDY_COMMAND "${CLANG_TIDY}" "-checks=-*,clang-analyzer-*")
+    else ()
+        MESSAGE(STATUS "clang-tidy not found, disable clang-tidy checks")
+        set(ENABLE_CLANG_TIDY Off)
+    endif ()
 endif ()
 
 # Setup some compiler option that is generally useful and compatible with Fcitx 5 (C++17)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,30 +17,25 @@ include(ECMUninstallTarget)
 option(ENABLE_TEST "Build Test" On)
 
 # clang-tidy
-option(ENABLE_CLANG_TIDY "Enable clang-tidy" On)
+option(ENABLE_CLANG_TIDY "Enable clang-tidy" Off)
 if (ENABLE_CLANG_TIDY)
-    MESSAGE(STATUS "Checking clang-tidy...")
-    find_program(CLANG_TIDY NAMES "clang-tidy")
-    if (CLANG_TIDY)
-        MESSAGE(STATUS "Found clang-tidy: ${CLANG_TIDY}")
-        string(CONCAT CLANG_TIDY_CHECKS "-checks=-*,"
-            "clang-analyzer-*,bugprone-*,cert-*,readability-*,"
-            "-bugprone-easily-swappable-parameters,"
-            "-readability-const-return-type,"
-            "-readability-convert-member-functions-to-static,"
-            "-readability-function-cognitive-complexity,"
-            "-readability-identifier-length,"
-            "-readability-implicit-bool-conversion,"
-            "-readability-isolate-declaration,"
-            "-readability-suspicious-call-argument"
-        )
-        set(CLANG_TIDY_COMMAND "${CLANG_TIDY}" "${CLANG_TIDY_CHECKS}")
-        # one may wants to use the following instead to focus on a specific category
-        # set(CLANG_TIDY_COMMAND "${CLANG_TIDY}" "-checks=-*,clang-analyzer-*")
-    else ()
-        MESSAGE(STATUS "clang-tidy not found, disable clang-tidy checks")
-        set(ENABLE_CLANG_TIDY Off)
-    endif ()
+    MESSAGE(STATUS "Enabled clang-tidy")
+    find_program(CLANG_TIDY NAMES "clang-tidy" REQUIRED)
+    MESSAGE(STATUS "Found clang-tidy: ${CLANG_TIDY}")
+    string(CONCAT CLANG_TIDY_CHECKS "-checks=-*,"
+        "clang-analyzer-*,bugprone-*,cert-*,readability-*,"
+        "-bugprone-easily-swappable-parameters,"
+        "-readability-const-return-type,"
+        "-readability-convert-member-functions-to-static,"
+        "-readability-function-cognitive-complexity,"
+        "-readability-identifier-length,"
+        "-readability-implicit-bool-conversion,"
+        "-readability-isolate-declaration,"
+        "-readability-suspicious-call-argument"
+    )
+    set(CLANG_TIDY_COMMAND "${CLANG_TIDY}" "${CLANG_TIDY_CHECKS}")
+    # one may wants to use the following instead to focus on a specific category
+    # set(CLANG_TIDY_COMMAND "${CLANG_TIDY}" "-checks=-*,clang-analyzer-*")
 endif ()
 
 # Setup some compiler option that is generally useful and compatible with Fcitx 5 (C++17)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,7 +22,18 @@ if (ENABLE_CLANG_TIDY)
     MESSAGE(STATUS "Enabled clang-tidy")
     find_program(CLANG_TIDY NAMES "clang-tidy" REQUIRED)
     MESSAGE(STATUS "Found clang-tidy: ${CLANG_TIDY}")
-    set(CLANG_TIDY_COMMAND "${CLANG_TIDY}" "-checks=-*,clang-analyzer-*,bugprone-*,-bugprone-easily-swappable-parameters,cert-*,readability-*")
+    string(CONCAT CLANG_TIDY_CHECKS "-checks=-*,"
+        "clang-analyzer-*,bugprone-*,cert-*,readability-*,"
+        "-bugprone-easily-swappable-parameters,"
+        "-readability-const-return-type,"
+        "-readability-convert-member-functions-to-static,"
+        "-readability-function-cognitive-complexity,"
+        "-readability-identifier-length,"
+        "-readability-implicit-bool-conversion,"
+        "-readability-isolate-declaration,"
+        "-readability-suspicious-call-argument"
+    )
+    set(CLANG_TIDY_COMMAND "${CLANG_TIDY}" "${CLANG_TIDY_CHECKS}")
     # one may wants to use the following instead to focus on a specific category
     # set(CLANG_TIDY_COMMAND "${CLANG_TIDY}" "-checks=-*,clang-analyzer-*")
 endif ()

--- a/src/Engine/AssociatedPhrases.cpp
+++ b/src/Engine/AssociatedPhrases.cpp
@@ -53,10 +53,7 @@ AssociatedPhrases::~AssociatedPhrases()
 
 bool AssociatedPhrases::isLoaded()
 {
-    if (data) {
-        return true;
-    }
-    return false;
+    return data != nullptr;
 }
 
 bool AssociatedPhrases::open(const char* path)

--- a/src/Engine/Mandarin/Mandarin.cpp
+++ b/src/Engine/Mandarin/Mandarin.cpp
@@ -77,8 +77,7 @@ const BPMF BPMF::FromHanyuPinyin(const std::string& str) {
   // NOLINTBEGIN(bugprone-branch-clone)
 
   // the y exceptions fist
-  if (false) {  // NOLINT(readability-simplify-boolean-expr)
-  } else if (PinyinParseHelper::ConsumePrefix(pinyin, "yuan")) {
+  if (PinyinParseHelper::ConsumePrefix(pinyin, "yuan")) {
     secondComponent = BPMF::UE;
     thirdComponent = BPMF::AN;
   } else if (PinyinParseHelper::ConsumePrefix(pinyin, "ying")) {
@@ -177,8 +176,7 @@ const BPMF BPMF::FromHanyuPinyin(const std::string& str) {
   }
 
   // then we try ZH, CH, SH, R, Z, C, S (in that order)
-  if (false) {  // NOLINT(readability-simplify-boolean-expr)
-  } else if (PinyinParseHelper::ConsumePrefix(pinyin, "zh")) {
+  if (PinyinParseHelper::ConsumePrefix(pinyin, "zh")) {
     firstComponent = BPMF::ZH;
     independentConsonant = true;
   } else if (PinyinParseHelper::ConsumePrefix(pinyin, "ch")) {
@@ -203,8 +201,7 @@ const BPMF BPMF::FromHanyuPinyin(const std::string& str) {
 
   // consume exceptions first: (ien, in), (iou, iu), (uen, un), (veng, iong),
   // (ven, vn), (uei, ui), ung but longer sequence takes precedence
-  if (false) {  // NOLINT(readability-simplify-boolean-expr)
-  } else if (PinyinParseHelper::ConsumePrefix(pinyin, "veng")) {
+  if (PinyinParseHelper::ConsumePrefix(pinyin, "veng")) {
     secondComponent = BPMF::UE;
     thirdComponent = BPMF::ENG;
   } else if (PinyinParseHelper::ConsumePrefix(pinyin, "iong")) {
@@ -272,8 +269,7 @@ const BPMF BPMF::FromHanyuPinyin(const std::string& str) {
   }
 
   // then consume the middle component...
-  if (false) {  // NOLINT(readability-simplify-boolean-expr)
-  } else if (PinyinParseHelper::ConsumePrefix(pinyin, "i")) {
+  if (PinyinParseHelper::ConsumePrefix(pinyin, "i")) {
     secondComponent = independentConsonant ? 0 : BPMF::I;
   } else if (PinyinParseHelper::ConsumePrefix(pinyin, "u")) {
     if (firstComponent == BPMF::J || firstComponent == BPMF::Q ||
@@ -287,8 +283,7 @@ const BPMF BPMF::FromHanyuPinyin(const std::string& str) {
   }
 
   // the vowels, longer sequence takes precedence
-  if (false) {  // NOLINT(readability-simplify-boolean-expr)
-  } else if (PinyinParseHelper::ConsumePrefix(pinyin, "ang")) {
+  if (PinyinParseHelper::ConsumePrefix(pinyin, "ang")) {
     thirdComponent = BPMF::ANG;
   } else if (PinyinParseHelper::ConsumePrefix(pinyin, "eng")) {
     thirdComponent = BPMF::ENG;
@@ -322,8 +317,7 @@ const BPMF BPMF::FromHanyuPinyin(const std::string& str) {
   // NOLINTEND(bugprone-branch-clone)
 
   // at last!
-  if (false) {  // NOLINT(readability-simplify-boolean-expr)
-  } else if (PinyinParseHelper::ConsumePrefix(pinyin, "1")) {
+  if (PinyinParseHelper::ConsumePrefix(pinyin, "1")) {
     toneComponent = BPMF::Tone1;
   } else if (PinyinParseHelper::ConsumePrefix(pinyin, "2")) {
     toneComponent = BPMF::Tone2;

--- a/src/Engine/Mandarin/Mandarin.cpp
+++ b/src/Engine/Mandarin/Mandarin.cpp
@@ -58,7 +58,7 @@ class BopomofoCharacterMap {
 };
 
 const BPMF BPMF::FromHanyuPinyin(const std::string& str) {
-  if (!str.length()) {
+  if (str.length() == 0) {
     return BPMF();
   }
 
@@ -77,7 +77,7 @@ const BPMF BPMF::FromHanyuPinyin(const std::string& str) {
   // NOLINTBEGIN(bugprone-branch-clone)
 
   // the y exceptions fist
-  if (0) {
+  if (false) {  // NOLINT(readability-simplify-boolean-expr)
   } else if (PinyinParseHelper::ConsumePrefix(pinyin, "yuan")) {
     secondComponent = BPMF::UE;
     thirdComponent = BPMF::AN;
@@ -104,7 +104,7 @@ const BPMF BPMF::FromHanyuPinyin(const std::string& str) {
   }
 
   // try the first character
-  char c = pinyin.length() ? pinyin[0] : '\0';
+  char c = pinyin.length() != 0 ? pinyin[0] : '\0';
   switch (c) {
     case 'b':
       firstComponent = BPMF::B;
@@ -177,7 +177,7 @@ const BPMF BPMF::FromHanyuPinyin(const std::string& str) {
   }
 
   // then we try ZH, CH, SH, R, Z, C, S (in that order)
-  if (0) {
+  if (false) {  // NOLINT(readability-simplify-boolean-expr)
   } else if (PinyinParseHelper::ConsumePrefix(pinyin, "zh")) {
     firstComponent = BPMF::ZH;
     independentConsonant = true;
@@ -203,7 +203,7 @@ const BPMF BPMF::FromHanyuPinyin(const std::string& str) {
 
   // consume exceptions first: (ien, in), (iou, iu), (uen, un), (veng, iong),
   // (ven, vn), (uei, ui), ung but longer sequence takes precedence
-  if (0) {
+  if (false) {  // NOLINT(readability-simplify-boolean-expr)
   } else if (PinyinParseHelper::ConsumePrefix(pinyin, "veng")) {
     secondComponent = BPMF::UE;
     thirdComponent = BPMF::ENG;
@@ -272,7 +272,7 @@ const BPMF BPMF::FromHanyuPinyin(const std::string& str) {
   }
 
   // then consume the middle component...
-  if (0) {
+  if (false) {  // NOLINT(readability-simplify-boolean-expr)
   } else if (PinyinParseHelper::ConsumePrefix(pinyin, "i")) {
     secondComponent = independentConsonant ? 0 : BPMF::I;
   } else if (PinyinParseHelper::ConsumePrefix(pinyin, "u")) {
@@ -287,7 +287,7 @@ const BPMF BPMF::FromHanyuPinyin(const std::string& str) {
   }
 
   // the vowels, longer sequence takes precedence
-  if (0) {
+  if (false) {  // NOLINT(readability-simplify-boolean-expr)
   } else if (PinyinParseHelper::ConsumePrefix(pinyin, "ang")) {
     thirdComponent = BPMF::ANG;
   } else if (PinyinParseHelper::ConsumePrefix(pinyin, "eng")) {
@@ -322,7 +322,7 @@ const BPMF BPMF::FromHanyuPinyin(const std::string& str) {
   // NOLINTEND(bugprone-branch-clone)
 
   // at last!
-  if (0) {
+  if (false) {  // NOLINT(readability-simplify-boolean-expr)
   } else if (PinyinParseHelper::ConsumePrefix(pinyin, "1")) {
     toneComponent = BPMF::Tone1;
   } else if (PinyinParseHelper::ConsumePrefix(pinyin, "2")) {
@@ -383,43 +383,63 @@ const std::string BPMF::HanyuPinyinString(bool includesTone,
       break;
     case J:
       consonant = "j";
-      if (hasNoMVCOrVC) middle = "i";
+      if (hasNoMVCOrVC) {
+        middle = "i";
+      }
       break;
     case Q:
       consonant = "q";
-      if (hasNoMVCOrVC) middle = "i";
+      if (hasNoMVCOrVC) {
+        middle = "i";
+      }
       break;
     case X:
       consonant = "x";
-      if (hasNoMVCOrVC) middle = "i";
+      if (hasNoMVCOrVC) {
+        middle = "i";
+      }
       break;
     case ZH:
       consonant = "zh";
-      if (hasNoMVCOrVC) middle = "i";
+      if (hasNoMVCOrVC) {
+        middle = "i";
+      }
       break;
     case CH:
       consonant = "ch";
-      if (hasNoMVCOrVC) middle = "i";
+      if (hasNoMVCOrVC) {
+        middle = "i";
+      }
       break;
     case SH:
       consonant = "sh";
-      if (hasNoMVCOrVC) middle = "i";
+      if (hasNoMVCOrVC) {
+        middle = "i";
+      }
       break;
     case R:
       consonant = "r";
-      if (hasNoMVCOrVC) middle = "i";
+      if (hasNoMVCOrVC) {
+        middle = "i";
+      }
       break;
     case Z:
       consonant = "z";
-      if (hasNoMVCOrVC) middle = "i";
+      if (hasNoMVCOrVC) {
+        middle = "i";
+      }
       break;
     case C:
       consonant = "c";
-      if (hasNoMVCOrVC) middle = "i";
+      if (hasNoMVCOrVC) {
+        middle = "i";
+      }
       break;
     case S:
       consonant = "s";
-      if (hasNoMVCOrVC) middle = "i";
+      if (hasNoMVCOrVC) {
+        middle = "i";
+      }
       break;
   }
 
@@ -567,6 +587,9 @@ const BPMF BPMF::FromComposedString(const std::string& str) {
     // the Bopomofo character map or to split the input by codepoints. This
     // suffices for now.
 
+    // disable for check for code points below
+    // NOLINTBEGIN(readability-magic-numbers)
+
     // Illegal.
     if (!(*iter & 0x80)) {
       break;
@@ -583,6 +606,7 @@ const BPMF BPMF::FromComposedString(const std::string& str) {
       // Illegal.
       break;
     }
+    // NOLINTEND(readability-magic-numbers)
 
     if (iter + (utf8_length - 1) == str.end()) {
       break;
@@ -595,9 +619,8 @@ const BPMF BPMF::FromComposedString(const std::string& str) {
         charToComp.find(component);
     if (result == charToComp.end()) {
       break;
-    } else {
-      syllable += BPMF((*result).second);
     }
+    syllable += BPMF((*result).second);
     iter += utf8_length;
   }
   return syllable;
@@ -669,8 +692,9 @@ BopomofoCharacterMap::BopomofoCharacterMap() {
 
   for (std::map<std::string, BPMF::Component>::iterator iter =
            characterToComponent.begin();
-       iter != characterToComponent.end(); ++iter)
+       iter != characterToComponent.end(); ++iter) {
     componentToCharacter[(*iter).second] = (*iter).first;
+  }
 }
 
 // we don't need parentheses for these macros

--- a/src/Engine/McBopomofoLM.cpp
+++ b/src/Engine/McBopomofoLM.cpp
@@ -132,7 +132,7 @@ bool McBopomofoLM::hasUnigrams(const std::string& key)
         return m_userPhrases.hasUnigrams(key) || m_languageModel.hasUnigrams(key);
     }
 
-    return getUnigrams(key).size() > 0;
+    return !getUnigrams(key).empty();
 }
 
 void McBopomofoLM::setPhraseReplacementEnabled(bool enabled)
@@ -140,7 +140,7 @@ void McBopomofoLM::setPhraseReplacementEnabled(bool enabled)
     m_phraseReplacementEnabled = enabled;
 }
 
-bool McBopomofoLM::phraseReplacementEnabled()
+bool McBopomofoLM::phraseReplacementEnabled() const
 {
     return m_phraseReplacementEnabled;
 }
@@ -150,7 +150,7 @@ void McBopomofoLM::setExternalConverterEnabled(bool enabled)
     m_externalConverterEnabled = enabled;
 }
 
-bool McBopomofoLM::externalConverterEnabled()
+bool McBopomofoLM::externalConverterEnabled() const
 {
     return m_externalConverterEnabled;
 }
@@ -175,7 +175,7 @@ std::vector<Formosa::Gramambular2::LanguageModel::Unigram> McBopomofoLM::filterA
         std::string value = originalValue;
         if (m_phraseReplacementEnabled) {
             std::string replacement = m_phraseReplacement.valueForKey(value);
-            if (replacement != "") {
+            if (!replacement.empty()) {
                 value = replacement;
             }
         }

--- a/src/Engine/McBopomofoLM.h
+++ b/src/Engine/McBopomofoLM.h
@@ -64,7 +64,7 @@ public:
 
     /// Asks to load the primary language model at the given path.
     /// @param languageModelPath The path of the language model.
-    void loadLanguageModel(const char* languageModelPath);
+    void loadLanguageModel(const char* languageModelDataPath);
     /// If the data model is already loaded.
     bool isDataModelLoaded();
 
@@ -77,7 +77,7 @@ public:
     /// Asks to load the user phrases and excluded phrases at the given path.
     /// @param userPhrasesPath The path of user phrases.
     /// @param excludedPhrasesPath The path of excluded phrases.
-    void loadUserPhrases(const char* userPhrasesPath, const char* excludedPhrasesPath);
+    void loadUserPhrases(const char* userPhrasesDataPath, const char* excludedPhrasesDataPath);
     /// Asks to load th phrase replacement table at the given path.
     /// @param phraseReplacementPath The path of the phrase replacement table.
     void loadPhraseReplacementMap(const char* phraseReplacementPath);
@@ -93,12 +93,12 @@ public:
     /// Enables or disables phrase replacement.
     void setPhraseReplacementEnabled(bool enabled);
     /// If phrase replacement is enabled or not.
-    bool phraseReplacementEnabled();
+    bool phraseReplacementEnabled() const;
 
     /// Enables or disables the external converter.
     void setExternalConverterEnabled(bool enabled);
     /// If the external converted is enabled or not.
-    bool externalConverterEnabled();
+    bool externalConverterEnabled() const;
     /// Sets a lambda to let the values of unigrams could be converted by it.
     void setExternalConverter(std::function<std::string(std::string)> externalConverter);
 

--- a/src/Engine/ParselessLM.cpp
+++ b/src/Engine/ParselessLM.cpp
@@ -35,10 +35,7 @@ McBopomofo::ParselessLM::~ParselessLM() { close(); }
 
 bool McBopomofo::ParselessLM::isLoaded()
 {
-    if (data_) {
-        return true;
-    }
-    return false;
+    return data_ != nullptr;
 }
 
 bool McBopomofo::ParselessLM::open(const std::string_view& path)
@@ -99,7 +96,7 @@ McBopomofo::ParselessLM::getUnigrams(const std::string& key)
         double score = 0;
 
         // Move ahead until we encounter the first space. This is the key.
-        auto it = row.begin();
+        const auto* it = row.begin();
         while (it != row.end() && *it != ' ') {
             ++it;
         }
@@ -113,7 +110,7 @@ McBopomofo::ParselessLM::getUnigrams(const std::string& key)
 
         if (it != row.end()) {
             // Now it is the start of the value portion.
-            auto value_begin = it;
+            const auto* value_begin = it;
 
             // Move ahead until we encounter the second space. This is the
             // value.

--- a/src/Engine/ParselessPhraseDB.cpp
+++ b/src/Engine/ParselessPhraseDB.cpp
@@ -36,6 +36,7 @@ ParselessPhraseDB::ParselessPhraseDB(
     assert(buf != nullptr);
     assert(length > 0);
 
+    // NOLINTBEGIN(readability-magic-numbers)
     if (validate_pragma) {
         assert(length > SORTED_PRAGMA_HEADER.length());
 
@@ -51,6 +52,7 @@ ParselessPhraseDB::ParselessPhraseDB(
 
         begin_ += header.length();
     }
+    // NOLINTEND(readability-magic-numbers)
 }
 
 std::vector<std::string_view> ParselessPhraseDB::findRows(

--- a/src/Engine/ParselessPhraseDB.cpp
+++ b/src/Engine/ParselessPhraseDB.cpp
@@ -36,23 +36,14 @@ ParselessPhraseDB::ParselessPhraseDB(
     assert(buf != nullptr);
     assert(length > 0);
 
-    // NOLINTBEGIN(readability-magic-numbers)
     if (validate_pragma) {
         assert(length > SORTED_PRAGMA_HEADER.length());
 
         std::string_view header(buf, SORTED_PRAGMA_HEADER.length());
         assert(header == SORTED_PRAGMA_HEADER);
 
-        uint32_t x = 5381;
-        for (const auto& i : header) {
-            x = x * 33 + i;
-        }
-
-        assert(x == uint32_t { 3012373384 });
-
         begin_ += header.length();
     }
-    // NOLINTEND(readability-magic-numbers)
 }
 
 std::vector<std::string_view> ParselessPhraseDB::findRows(

--- a/src/Engine/UserOverrideModel.cpp
+++ b/src/Engine/UserOverrideModel.cpp
@@ -54,6 +54,7 @@ UserOverrideModel::UserOverrideModel(size_t capacity, double decayConstant)
     : m_capacity(capacity)
 {
     assert(m_capacity > 0);
+    // NOLINTNEXTLINE(readability-magic-numbers)
     m_decayExponent = log(0.5) / decayConstant;
 }
 

--- a/src/Engine/UserPhrasesLM.cpp
+++ b/src/Engine/UserPhrasesLM.cpp
@@ -49,10 +49,7 @@ UserPhrasesLM::~UserPhrasesLM()
 
 bool UserPhrasesLM::isLoaded()
 {
-    if (data) {
-        return true;
-    }
-    return false;
+    return data != nullptr;
 }
 
 bool UserPhrasesLM::open(const char* path)

--- a/src/McBopomofo.cpp
+++ b/src/McBopomofo.cpp
@@ -112,7 +112,7 @@ class McBopomofoCandidateWord : public fcitx::CandidateWord {
         keyHandler_(std::move(keyHandler)),
         stateCallback_(std::move(callback)) {}
 
-  void select(fcitx::InputContext*) const override {
+  void select(fcitx::InputContext* /*unused*/) const override {
     keyHandler_->candidateSelected(candidate_, stateCallback_);
   }
 
@@ -295,7 +295,8 @@ void McBopomofoEngine::activate(const fcitx::InputMethodEntry& entry,
   keyHandler_->setInputMode(mode);
 
   // NOLINTNEXTLINE(clang-analyzer-deadcode.DeadStores)
-  auto layout = Formosa::Mandarin::BopomofoKeyboardLayout::StandardLayout();
+  const auto* layout =
+      Formosa::Mandarin::BopomofoKeyboardLayout::StandardLayout();
   switch (config_.bopomofoKeyboardLayout.value()) {
     case BopomofoKeyboardLayout::Standard:
       layout = Formosa::Mandarin::BopomofoKeyboardLayout::StandardLayout();
@@ -335,7 +336,7 @@ void McBopomofoEngine::activate(const fcitx::InputMethodEntry& entry,
   languageModelLoader_->reloadUserModelsIfNeeded();
 }
 
-void McBopomofoEngine::reset(const fcitx::InputMethodEntry&,
+void McBopomofoEngine::reset(const fcitx::InputMethodEntry& /*unused*/,
                              fcitx::InputContextEvent& event) {
   keyHandler_->reset();
 
@@ -357,7 +358,7 @@ void McBopomofoEngine::reset(const fcitx::InputMethodEntry&,
   }
 }
 
-void McBopomofoEngine::keyEvent(const fcitx::InputMethodEntry&,
+void McBopomofoEngine::keyEvent(const fcitx::InputMethodEntry& /*unused*/,
                                 fcitx::KeyEvent& keyEvent) {
   if (!keyEvent.isInputContextEvent()) {
     return;
@@ -384,7 +385,7 @@ void McBopomofoEngine::keyEvent(const fcitx::InputMethodEntry&,
     auto maybeCandidateList = dynamic_cast<fcitx::CommonCandidateList*>(
         context->inputPanel().candidateList());
 #else
-    auto maybeCandidateList = dynamic_cast<fcitx::CommonCandidateList*>(
+    auto* maybeCandidateList = dynamic_cast<fcitx::CommonCandidateList*>(
         context->inputPanel().candidateList().get());
 #endif
     if (maybeCandidateList == nullptr) {
@@ -574,9 +575,9 @@ void McBopomofoEngine::enterNewState(fcitx::InputContext* context,
   InputState* prevPtr = prevState.get();
   InputState* currentPtr = state_.get();
 
-  if (auto empty = dynamic_cast<InputStates::Empty*>(currentPtr)) {
+  if (auto* empty = dynamic_cast<InputStates::Empty*>(currentPtr)) {
     handleEmptyState(context, prevPtr, empty);
-  } else if (auto emptyIgnoringPrevious =
+  } else if (auto* emptyIgnoringPrevious =
                  dynamic_cast<InputStates::EmptyIgnoringPrevious*>(
                      currentPtr)) {
     handleEmptyIgnoringPreviousState(context, prevPtr, emptyIgnoringPrevious);
@@ -584,40 +585,41 @@ void McBopomofoEngine::enterNewState(fcitx::InputContext* context,
     // Transition to Empty state as required by the spec: see
     // EmptyIgnoringPrevious's own definition for why.
     state_ = std::make_unique<InputStates::Empty>();
-  } else if (auto committing =
+  } else if (auto* committing =
                  dynamic_cast<InputStates::Committing*>(currentPtr)) {
     handleCommittingState(context, prevPtr, committing);
-  } else if (auto inputting =
+  } else if (auto* inputting =
                  dynamic_cast<InputStates::Inputting*>(currentPtr)) {
     handleInputtingState(context, prevPtr, inputting);
-  } else if (auto candidates =
+  } else if (auto* candidates =
                  dynamic_cast<InputStates::ChoosingCandidate*>(currentPtr)) {
     handleCandidatesState(context, prevPtr, candidates);
-  } else if (auto marking = dynamic_cast<InputStates::Marking*>(currentPtr)) {
+  } else if (auto* marking = dynamic_cast<InputStates::Marking*>(currentPtr)) {
     handleMarkingState(context, prevPtr, marking);
   }
 }
 
 void McBopomofoEngine::handleEmptyState(fcitx::InputContext* context,
-                                        InputState* prev, InputStates::Empty*) {
+                                        InputState* prev,
+                                        InputStates::Empty* /*unused*/) {
   context->inputPanel().reset();
   context->updateUserInterface(fcitx::UserInterfaceComponent::InputPanel);
-  if (auto notEmpty = dynamic_cast<InputStates::NotEmpty*>(prev)) {
+  if (auto* notEmpty = dynamic_cast<InputStates::NotEmpty*>(prev)) {
     context->commitString(notEmpty->composingBuffer);
   }
   context->updatePreedit();
 }
 
 void McBopomofoEngine::handleEmptyIgnoringPreviousState(
-    fcitx::InputContext* context, InputState*,
-    InputStates::EmptyIgnoringPrevious*) {
+    fcitx::InputContext* context, InputState* /*unused*/,
+    InputStates::EmptyIgnoringPrevious* /*unused*/) {
   context->inputPanel().reset();
   context->updateUserInterface(fcitx::UserInterfaceComponent::InputPanel);
   context->updatePreedit();
 }
 
 void McBopomofoEngine::handleCommittingState(fcitx::InputContext* context,
-                                             InputState*,
+                                             InputState* /*unused*/,
                                              InputStates::Committing* current) {
   context->inputPanel().reset();
   context->updateUserInterface(fcitx::UserInterfaceComponent::InputPanel);
@@ -628,7 +630,7 @@ void McBopomofoEngine::handleCommittingState(fcitx::InputContext* context,
 }
 
 void McBopomofoEngine::handleInputtingState(fcitx::InputContext* context,
-                                            InputState*,
+                                            InputState* /*unused*/,
                                             InputStates::Inputting* current) {
   context->inputPanel().reset();
   context->updateUserInterface(fcitx::UserInterfaceComponent::InputPanel);
@@ -636,7 +638,7 @@ void McBopomofoEngine::handleInputtingState(fcitx::InputContext* context,
 }
 
 void McBopomofoEngine::handleCandidatesState(
-    fcitx::InputContext* context, InputState*,
+    fcitx::InputContext* context, InputState* /*unused*/,
     InputStates::ChoosingCandidate* current) {
   std::unique_ptr<fcitx::CommonCandidateList> candidateList =
       std::make_unique<fcitx::CommonCandidateList>();
@@ -730,14 +732,14 @@ void McBopomofoEngine::handleCandidatesState(
 }
 
 void McBopomofoEngine::handleMarkingState(fcitx::InputContext* context,
-                                          InputState*,
+                                          InputState* /*unused*/,
                                           InputStates::Marking* current) {
   context->inputPanel().reset();
   context->updateUserInterface(fcitx::UserInterfaceComponent::InputPanel);
   updatePreedit(context, current);
 }
 
-fcitx::CandidateLayoutHint McBopomofoEngine::getCandidateLayoutHint() {
+fcitx::CandidateLayoutHint McBopomofoEngine::getCandidateLayoutHint() const {
   fcitx::CandidateLayoutHint layoutHint = fcitx::CandidateLayoutHint::NotSet;
   switch (config_.candidateLayout.value()) {
     case McBopomofo::CandidateLayoutHint::Vertical:
@@ -768,7 +770,7 @@ void McBopomofoEngine::updatePreedit(fcitx::InputContext* context,
                                           : fcitx::TextFormatFlag::NoFlag};
 #endif
   fcitx::Text preedit;
-  if (auto marking = dynamic_cast<InputStates::Marking*>(state)) {
+  if (auto* marking = dynamic_cast<InputStates::Marking*>(state)) {
     preedit.append(marking->head, normalFormat);
     preedit.append(marking->markedText, fcitx::TextFormatFlag::HighLight);
     preedit.append(marking->tail, normalFormat);

--- a/src/McBopomofo.h
+++ b/src/McBopomofo.h
@@ -203,7 +203,7 @@ class McBopomofoEngine : public fcitx::InputMethodEngine {
   void updatePreedit(fcitx::InputContext* context,
                      InputStates::NotEmpty* state);
 
-  fcitx::CandidateLayoutHint getCandidateLayoutHint();
+  fcitx::CandidateLayoutHint getCandidateLayoutHint() const;
 
   std::shared_ptr<LanguageModelLoader> languageModelLoader_;
   std::shared_ptr<KeyHandler> keyHandler_;

--- a/src/UTF8Helper.cpp
+++ b/src/UTF8Helper.cpp
@@ -24,6 +24,7 @@
 #include "UTF8Helper.h"
 
 namespace McBopomofo {
+// NOLINTBEGIN(readability-magic-numbers)
 
 // Adapted from https://github.com/lua/lua/blob/master/lutf8lib.c
 
@@ -117,4 +118,5 @@ std::string SubstringToCodePoints(const std::string& s, size_t cp) {
   return {s.cbegin(), i};
 }
 
+// NOLINTEND(readability-magic-numbers)
 }  // namespace McBopomofo


### PR DESCRIPTION
This PR fixes the following code issues raised by `cert-*,readability-*,`

- simplify nullptr checks
- explicit boolean conversions for length() == 0
- always have parentheses on if/for blocks
- avoid else block after return/break
- use !vector.empty() instead of size() > 0
- use !str.empty() instead of != ""
- const member functions
- fix inconsistent parameter names between header/impl files
- verbose auto for `auto *` and `const auto *` for semantic hints
- mark unused parameters with /*unused*/

- some controversial/noisy readability checks are disabled.


----

@lukhnos, I do have a few remarks/questions:

- there are a few empty `if (false)` blocks in `src/Engine/Mandarin/Mandarin.cpp`, which I wasn't sure the intention, I left them untouched and suppressed the linter.
- There are a few magic numbers in `src/Engine/ParselessPhraseDB.cpp`, can you please share more contexts on these?
- Some "readability rules" are somewhat opinionated, please let me know if you'd like to revert any of them, I can amend the PR.
- all warnings from `clang-tidy` are gone/disabled with this PR, please let me know if you would like to enable `clang-tidy` in CMake by default.