### PR TITLE
chore: fix some markdown styling and typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@
 
 請先安裝 fcitx5, CMake, 以及以下開發用模組：
 
-```
+```bash
 sudo apt install \
     fcitx5 libfcitx5core-dev libfcitx5config-dev libfcitx5utils-dev \
     cmake extra-cmake-modules gettext libfmt-dev
@@ -37,7 +37,7 @@ sudo apt install \
 
 然後在本專案的 git 目錄下執行以下指令：
 
-```
+```bash
 mkdir -p build
 cd build
 cmake ../ -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_BUILD_TYPE=Release
@@ -50,7 +50,7 @@ sudo update-icon-caches /usr/share/icons/*
 
 ## 在其他 Linux Distro 或 FreeBSD 上安裝
 
-* 我們利用 [wiki](https://github.com/openvanilla/fcitx5-mcbopomofo/wiki#%E5%AE%89%E8%A3%9D%E8%AA%AA%E6%98%8E) 收集在其他 Linux distro 或 FreeBSD 上安裝的方式，歡迎提供內容與指正。
+- 我們利用 [wiki](https://github.com/openvanilla/fcitx5-mcbopomofo/wiki#%E5%AE%89%E8%A3%9D%E8%AA%AA%E6%98%8E) 收集在其他 Linux distro 或 FreeBSD 上安裝的方式，歡迎提供內容與指正。
 
 ## C++ 語法風格
 

--- a/src/Engine/McBopomofoLM.h
+++ b/src/Engine/McBopomofoLM.h
@@ -55,7 +55,7 @@ namespace McBopomofo {
 ///
 /// The controller can ask the model to load the primary input method language
 /// model while launching and to load the user phrases anytime if the custom
-/// files are modified. It does not keep the reference of the data pathes but
+/// files are modified. It does not keep the reference of the data paths but
 /// you have to pass the paths when you ask it to do loading.
 class McBopomofoLM : public Formosa::Gramambular2::LanguageModel {
 public:

--- a/src/Engine/UserPhrasesLMTest.cpp
+++ b/src/Engine/UserPhrasesLMTest.cpp
@@ -30,7 +30,7 @@
 
 namespace McBopomofo {
 
-TEST(UserPhreasesLMTest, LenientReading)
+TEST(UserPhrasesLMTest, LenientReading)
 {
     std::string tmp_name
         = std::string(std::filesystem::temp_directory_path() / "test.txt");

--- a/src/Engine/gramambular2/README.md
+++ b/src/Engine/gramambular2/README.md
@@ -7,7 +7,7 @@ actually reflect that design intent.
 
 The basic principle is a hidden Markov model, with the input (observations)
 being Chinese characters and the output (hidden events) being the possible
-groups (segmantations). When used for an input method, the input can be
+groups (segmentation). When used for an input method, the input can be
 a series of Bopomofo syllables, and the output will be the mostly likely
 Chinese characters. The actual computation uses a naive Bayes classifier,
 and the required language model is a very simple unigram model.

--- a/src/InputState.h
+++ b/src/InputState.h
@@ -112,7 +112,7 @@ inline bool operator==(const ChoosingCandidate::Candidate& a,
 // a composingBuffer, and the invariant is that composingBuffer = head +
 // markedText + tail. Unlike cursorIndex, which is UTF-8 based,
 // markStartGridCursorIndex is in the same unit that a Gramambular's grid
-// builder uses. In other words, markStratGridCursorIndex is the beginning
+// builder uses. In other words, markStartGridCursorIndex is the beginning
 // position of the reading cursor. This makes it easy for a key handler to know
 // where the marked range is when combined with the grid builder's (reading)
 // cursor index.


### PR DESCRIPTION
- MD004: consistent list style
- MD040: always add language on fenced code

Refs:

https://github.com/DavidAnson/markdownlint/blob/main/doc/md004.md https://github.com/DavidAnson/markdownlint/blob/main/doc/md040.md