### PR TITLE
Sync Archlinux PKGBUILD file with AUR

### DIFF
--- a/distro/archlinux/PKGBUILD
+++ b/distro/archlinux/PKGBUILD
@@ -1,14 +1,15 @@
+# Maintainer: xatier
 # Contributor: xatier
 _pkgname=fcitx5-mcbopomofo
 pkgname=fcitx5-mcbopomofo-git
-pkgver=97.f08da14
+pkgver=2.5.2.r16.g8f629e9
 pkgrel=1
 pkgdesc="McBopomofo for fcitx5"
 arch=('x86_64')
 url="https://github.com/openvanilla/fcitx5-mcbopomofo"
 license=('MIT')
-depends=('fcitx5')
-makedepends=('cmake' 'extra-cmake-modules')
+depends=('fcitx5' 'fmt')
+makedepends=('cmake' 'extra-cmake-modules' 'git')
 optdepends=()
 conflicts=('fcitx5-mcbopomofo')
 provides=('fcitx5-mcbopomofo')
@@ -17,14 +18,14 @@ sha512sums=('SKIP')
 
 pkgver() {
     cd "${srcdir}/${_pkgname}"
-    echo "$(git rev-list --count HEAD).$(git rev-parse --short HEAD)"
+    git describe --long --tags | sed 's/\([^-]*-g\)/r\1/;s/-/./g'
 }
 
 build() {
     cd "${srcdir}/${_pkgname}"
     mkdir -p build
     cd build
-    cmake ../ -DCMAKE_INSTALL_PREFIX=/usr
+    cmake ../ -DCMAKE_INSTALL_PREFIX=/usr -DENABLE_TEST=Off
     make
 }
 


### PR DESCRIPTION
This should fix https://github.com/openvanilla/fcitx5-mcbopomofo/pull/86

This commit sync the `PKGBUILD` file from AUR [1].

[1] https://aur.archlinux.org/cgit/aur.git/?h=fcitx5-mcbopomofo-git

