### PR TITLE
Use const references where appropriate

### DIFF
--- a/src/Engine/AssociatedPhrases.h
+++ b/src/Engine/AssociatedPhrases.h
@@ -31,6 +31,7 @@
 #include <iostream>
 #include <map>
 #include <string>
+#include <utility>
 #include <vector>
 
 namespace McBopomofo {
@@ -48,13 +49,13 @@ public:
 
 protected:
     struct Row {
-        Row(std::string_view& k, std::string_view& v)
-            : key(k)
-            , value(v)
+        Row(std::string_view k, std::string_view v)
+            : key(std::move(k))
+            , value(std::move(v))
         {
         }
-        std::string_view key;
-        std::string_view value;
+        const std::string_view key;
+        const std::string_view value;
     };
 
     std::map<std::string_view, std::vector<Row>> keyRowMap;

--- a/src/Engine/Mandarin/Mandarin.cpp
+++ b/src/Engine/Mandarin/Mandarin.cpp
@@ -31,6 +31,7 @@ namespace Mandarin {
 
 class PinyinParseHelper {
  public:
+  // Returns true after `target` got stripped the specified `prefix`.
   static bool ConsumePrefix(std::string& target, const std::string& prefix) {
     if (target.length() < prefix.length()) {
       return false;

--- a/src/Engine/UserPhrasesLM.h
+++ b/src/Engine/UserPhrasesLM.h
@@ -28,6 +28,7 @@
 #include <iostream>
 #include <map>
 #include <string>
+#include <utility>
 #include <vector>
 
 namespace McBopomofo {
@@ -47,13 +48,13 @@ public:
 
 protected:
     struct Row {
-        Row(std::string_view& k, std::string_view& v)
-            : key(k)
-            , value(v)
+        Row(std::string_view k, std::string_view v)
+            : key(std::move(k))
+            , value(std::move(v))
         {
         }
-        std::string_view key;
-        std::string_view value;
+        const std::string_view key;
+        const std::string_view value;
     };
 
     std::map<std::string_view, std::vector<Row>> keyRowMap;

--- a/src/UTF8Helper.cpp
+++ b/src/UTF8Helper.cpp
@@ -31,8 +31,8 @@ namespace McBopomofo {
 constexpr char32_t kMaxUnicode = 0x10FFFF;
 static inline bool IsContinuationByte(char32_t c) { return (c & 0xC0) == 0x80; }
 
-// Decodes one UTF-8 code point and advances the string iterator past the code
-// point. Returns false if i is already at the end, or if the iterated UTF-8
+// Decodes one UTF-8 code point and advances the iterator `i` past the code
+// point. Returns false if `i` is already at the end, or if the iterated UTF-8
 // sequence is not valid.
 static inline bool DecodeUTF8(std::string::const_iterator& i,
                               const std::string::const_iterator& end) {


### PR DESCRIPTION
This is a follow-up of #89 by @xatier. After this, all non-const references are really used to be output parameters, i.e. they will be mutated.
