### PR TITLE
ci: bump GitHub action

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,7 +8,7 @@ jobs:
     container: ubuntu:22.04
 
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v4
       - name: Install dependencies
         run: |
           export DEBIAN_FRONTEND=noninteractive
@@ -37,7 +37,7 @@ jobs:
     container: ubuntu:20.04
 
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v4
       - name: Install dependencies
         run: |
           export DEBIAN_FRONTEND=noninteractive


### PR DESCRIPTION
This PR catches up to the latest actions/checkout, where the main change was to bump nodejs runtime in the CI environment. We shouldn't notice any difference in our builds.

Ref: https://github.com/actions/checkout/releases