### PR TITLE
build(cmake): fix `fcitx5_translate_desktop_file` po directory path

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,7 +60,8 @@ install(FILES "${CMAKE_CURRENT_BINARY_DIR}/mcbopomofo-data-plain-bpmf.txt" DESTI
 install(FILES "${CMAKE_CURRENT_BINARY_DIR}/mcbopomofo-add-phrase-hook.sh" DESTINATION "${FCITX_INSTALL_PKGDATADIR}/data")
 
 fcitx5_translate_desktop_file(org.fcitx.Fcitx5.Addon.McBopomofo.metainfo.xml.in
-                              org.fcitx.Fcitx5.Addon.McBopomofo.metainfo.xml XML)
+                              org.fcitx.Fcitx5.Addon.McBopomofo.metainfo.xml XML
+                              PO_DIRECTORY "${CMAKE_SOURCE_DIR}/po")
 install(FILES "${CMAKE_CURRENT_BINARY_DIR}/org.fcitx.Fcitx5.Addon.McBopomofo.metainfo.xml" DESTINATION ${CMAKE_INSTALL_DATADIR}/metainfo)
 feature_summary(WHAT ALL FATAL_ON_MISSING_REQUIRED_PACKAGES)
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -54,15 +54,15 @@ endif ()
 # Addon config file
 # We need additional layer of conversion because we want PROJECT_VERSION in it.
 configure_file(mcbopomofo-addon.conf.in.in mcbopomofo-addon.conf.in)
-fcitx5_translate_desktop_file("${CMAKE_CURRENT_BINARY_DIR}/mcbopomofo-addon.conf.in" mcbopomofo-addon.conf)
+fcitx5_translate_desktop_file("${CMAKE_CURRENT_BINARY_DIR}/mcbopomofo-addon.conf.in" mcbopomofo-addon.conf PO_DIRECTORY "${CMAKE_SOURCE_DIR}/po")
 install(FILES "${CMAKE_CURRENT_BINARY_DIR}/mcbopomofo-addon.conf" RENAME mcbopomofo.conf DESTINATION "${FCITX_INSTALL_PKGDATADIR}/addon")
 
 # Input Method registration file
 configure_file(mcbopomofo.conf.in.in mcbopomofo.conf.in)
-fcitx5_translate_desktop_file("${CMAKE_CURRENT_BINARY_DIR}/mcbopomofo.conf.in" mcbopomofo.conf)
+fcitx5_translate_desktop_file("${CMAKE_CURRENT_BINARY_DIR}/mcbopomofo.conf.in" mcbopomofo.conf PO_DIRECTORY "${CMAKE_SOURCE_DIR}/po")
 install(FILES "${CMAKE_CURRENT_BINARY_DIR}/mcbopomofo.conf" DESTINATION "${FCITX_INSTALL_PKGDATADIR}/inputmethod")
 configure_file(mcbopomofo-plain.conf.in.in mcbopomofo-plain.conf.in)
-fcitx5_translate_desktop_file("${CMAKE_CURRENT_BINARY_DIR}/mcbopomofo-plain.conf.in" mcbopomofo-plain.conf)
+fcitx5_translate_desktop_file("${CMAKE_CURRENT_BINARY_DIR}/mcbopomofo-plain.conf.in" mcbopomofo-plain.conf PO_DIRECTORY "${CMAKE_SOURCE_DIR}/po")
 install(FILES "${CMAKE_CURRENT_BINARY_DIR}/mcbopomofo-plain.conf" DESTINATION "${FCITX_INSTALL_PKGDATADIR}/inputmethod")
 
 if (ENABLE_TEST)


### PR DESCRIPTION
The CMake function `fcitx5_translate_desktop_file` from `Fcitx5Macros` finds po files from `${PROJECT_SOURCE_DIR}` by default, which is `src/` in this project. This will result in a warning from `msgfmt` command.

The fix is to set `PO_DIRECTORY` to `${CMAKE_SOURCE_DIR}/po` explicitly for all use of `fcitx5_translate_desktop_file` function.

ref: https://github.com/fcitx/fcitx5/blob/master/src/lib/fcitx-utils/Fcitx5Macros.cmake

----

## Issue details:

Here are the warnings from the previous build:

```text
/usr/bin/msgfmt: fcitx5-mcbopomofo/distro/archlinux/src/fcitx5-mcbopomofo/src/po/LINGUAS does not exist
/usr/bin/msgfmt: fcitx5-mcbopomofo/distro/archlinux/src/fcitx5-mcbopomofo/src/po/LINGUAS does not exist
/usr/bin/msgfmt: fcitx5-mcbopomofo/distro/archlinux/src/fcitx5-mcbopomofo/src/po/LINGUAS does not exist
```

It appears that `msgfmt` is looking for `src/po/LINGUAS `, instead of `po/LINGUAS`. We can confirm the behavior by checking the Makefiles generated by `cmake` from the build directory. It sets the incorrect path at `-d fcitx5-mcbopomofo/distro/archlinux/src/fcitx5-mcbopomofo/src/po`.

```text
$ ag msgfmt
src/CMakeFiles/mcbopomofo-addon.conf.in-fmt.dir/build.make
73:     cd fcitx5-mcbopomofo/distro/archlinux/src/fcitx5-mcbopomofo/build/src && /usr/bin/msgfmt --desktop -d fcitx5-mcbopomofo/distro/archlinux/src/fcitx5-mcbopomofo/src/po --template fcitx5-mcbopomofo/distro/archlinux/src/fcitx5-mcbopomofo/build/src/mcbopomofo-addon.conf.in -o fcitx5-mcbopomofo/distro/archlinux/src/fcitx5-mcbopomofo/build/src/mcbopomofo-addon.conf

src/CMakeFiles/mcbopomofo.conf.in-fmt.dir/build.make
73:     cd fcitx5-mcbopomofo/distro/archlinux/src/fcitx5-mcbopomofo/build/src && /usr/bin/msgfmt --desktop -d fcitx5-mcbopomofo/distro/archlinux/src/fcitx5-mcbopomofo/src/po --template fcitx5-mcbopomofo/distro/archlinux/src/fcitx5-mcbopomofo/build/src/mcbopomofo.conf.in -o fcitx5-mcbopomofo/distro/archlinux/src/fcitx5-mcbopomofo/build/src/mcbopomofo.conf

src/CMakeFiles/mcbopomofo-plain.conf.in-fmt.dir/build.make
73:     cd fcitx5-mcbopomofo/distro/archlinux/src/fcitx5-mcbopomofo/build/src && /usr/bin/msgfmt --desktop -d fcitx5-mcbopomofo/distro/archlinux/src/fcitx5-mcbopomofo/src/po --template fcitx5-mcbopomofo/distro/archlinux/src/fcitx5-mcbopomofo/build/src/mcbopomofo-plain.conf.in -o fcitx5-mcbopomofo/distro/archlinux/src/fcitx5-mcbopomofo/build/src/mcbopomofo-plain.conf


CMakeFiles/org.fcitx.Fcitx5.Addon.McBopomofo.metainfo.xml.in-fmt.dir/build.make
75:     /usr/bin/msgfmt --xml -d fcitx5-mcbopomofo/distro/archlinux/src/fcitx5-mcbopomofo/po --template fcitx5-mcbopomofo/distro/archlinux/src/fcitx5-mcbopomofo/org.fcitx.Fcitx5.Addon.McBopomofo.metainfo.xml.in -o fcitx5-mcbopomofo/distro/archlinux/src/fcitx5-mcbopomofo/build/org.fcitx.Fcitx5.Addon.McBopomofo.metainfo.xml
```

----

## CMake scripts from Fcitx5Macros

These Makefiles are generated by the function `fcitx5_translate_desktop_file` in our CMake scripts, source code: https://github.com/fcitx/fcitx5/blob/master/src/lib/fcitx-utils/Fcitx5Macros.cmake#L103

If the `FCITX5_TRANSLATE_PO_DIRECTORY` variable is not set, it sets `${PROJECT_SOURCE_DIR}/po` to the `-d` flag.

```cmake
function(fcitx5_translate_desktop_file SRC DEST)
  set(options XML)
  set(one_value_args PO_DIRECTORY)
  set(multi_value_args KEYWORDS)
  cmake_parse_arguments(FCITX5_TRANSLATE
    "${options}" "${one_value_args}" "${multi_value_args}" ${ARGN})

...

  if (NOT FCITX5_TRANSLATE_PO_DIRECTORY)
    set(FCITX5_TRANSLATE_PO_DIRECTORY "${PROJECT_SOURCE_DIR}/po")
  endif()
  file(GLOB PO_FILES "${FCITX5_TRANSLATE_PO_DIRECTORY}/*.po")

...

  add_custom_command(OUTPUT "${DEST}"
    COMMAND "${GETTEXT_MSGFMT_EXECUTABLE}" "${TYPE_ARG}" -d ${FCITX5_TRANSLATE_PO_DIRECTORY}
            ${KEYWORD_ARGS} --template "${SRC}" -o "${DEST}"
```

To set `FCITX5_TRANSLATE_PO_DIRECTORY` in our CMake scripts, we simply add `PO_DIRECTORY "${CMAKE_SOURCE_DIR}/po"` explicitly to all of our use of this function.

Note that the first parameter (`FCITX5_TRANSLATE`) in `cmake_parse_arguments` means the prefix of the argument. `PO_DIRECTORY` from the caller side will be translated to `FCITX5_TRANSLATE_PO_DIRECTORY`.

----

## After the fix:

We can see that CMake sets the correct path at `-d fcitx5-mcbopomofo/distro/archlinux/src/fcitx5-mcbopomofo/po`.

```text
$ ag msgfmt
src/CMakeFiles/mcbopomofo-addon.conf.in-fmt.dir/build.make
75:     cd fcitx5-mcbopomofo/distro/archlinux/src/fcitx5-mcbopomofo/build/src && /usr/bin/msgfmt --desktop -d fcitx5-mcbopomofo/distro/archlinux/src/fcitx5-mcbopomofo/po --template fcitx5-mcbopomofo/distro/archlinux/src/fcitx5-mcbopomofo/build/src/mcbopomofo-addon.conf.in -o fcitx5-mcbopomofo/distro/archlinux/src/fcitx5-mcbopomofo/build/src/mcbopomofo-addon.conf

src/CMakeFiles/mcbopomofo-plain.conf.in-fmt.dir/build.make
75:     cd fcitx5-mcbopomofo/distro/archlinux/src/fcitx5-mcbopomofo/build/src && /usr/bin/msgfmt --desktop -d fcitx5-mcbopomofo/distro/archlinux/src/fcitx5-mcbopomofo/po --template fcitx5-mcbopomofo/distro/archlinux/src/fcitx5-mcbopomofo/build/src/mcbopomofo-plain.conf.in -o fcitx5-mcbopomofo/distro/archlinux/src/fcitx5-mcbopomofo/build/src/mcbopomofo-plain.conf

src/CMakeFiles/mcbopomofo.conf.in-fmt.dir/build.make
75:     cd fcitx5-mcbopomofo/distro/archlinux/src/fcitx5-mcbopomofo/build/src && /usr/bin/msgfmt --desktop -d fcitx5-mcbopomofo/distro/archlinux/src/fcitx5-mcbopomofo/po --template fcitx5-mcbopomofo/distro/archlinux/src/fcitx5-mcbopomofo/build/src/mcbopomofo.conf.in -o fcitx5-mcbopomofo/distro/archlinux/src/fcitx5-mcbopomofo/build/src/mcbopomofo.conf

CMakeFiles/org.fcitx.Fcitx5.Addon.McBopomofo.metainfo.xml.in-fmt.dir/build.make
75:     /usr/bin/msgfmt --xml -d fcitx5-mcbopomofo/distro/archlinux/src/fcitx5-mcbopomofo/po --template fcitx5-mcbopomofo/distro/archlinux/src/fcitx5-mcbopomofo/org.fcitx.Fcitx5.Addon.McBopomofo.metainfo.xml.in -o fcitx5-mcbopomofo/distro/archlinux/src/fcitx5-mcbopomofo/build/org.fcitx.Fcitx5.Addon.McBopomofo.metainfo.xml
```

----

## Ubuntu 20.04

There's another bug in the CMake script previously, which was fixed a little later. The fix was shipped to Ubuntu 22, but not Ubuntu 20. Hence, we still see this warning message in Ubuntu 20 builds in the CI.

https://github.com/fcitx/fcitx5/commit/0c088a550ceb77f163bdb030b9f2c0f1ac5feb0d