### PR TITLE
build(cmake): Use FindGTest if possible

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -6,6 +6,9 @@ find_package(Fcitx5Utils REQUIRED)
 find_package(fmt REQUIRED)
 find_package(Gettext REQUIRED)
 find_package(ICU COMPONENTS uc i18n REQUIRED)
+if (CMAKE_VERSION VERSION_GREATER_EQUAL "3.23.0")
+    find_package(GTest)
+endif()
 
 add_subdirectory(Engine)
 
@@ -73,30 +76,33 @@ if (ENABLE_TEST)
                 cmake_policy(SET CMP0135 NEW)
         endif()
 
-        # Let CMake fetch Google Test for us.
-        # https://github.com/google/googletest/tree/main/googletest#incorporating-into-an-existing-cmake-project
-        include(FetchContent)
+        if (NOT GTest_FOUND)
+            # Specify release version from https://github.com/google/googletest/releases
+            set(GTEST_VERSION "v1.14.0")
+            MESSAGE(STATUS "Fetching GoogleTest ${GTEST_VERSION} from GitHub")
+            # Let CMake fetch Google Test for us.
+            # https://github.com/google/googletest/tree/main/googletest#incorporating-into-an-existing-cmake-project
+            include(FetchContent)
 
-        FetchContent_Declare(
-                googletest
-                # Specify the commit you depend on and update it regularly.
-                URL https://github.com/google/googletest/archive/refs/tags/v1.14.0.zip
-        )
-        # For Windows: Prevent overriding the parent project's compiler/linker settings
-        set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
-        FetchContent_MakeAvailable(googletest)
-
-        include(GoogleTest)
+            FetchContent_Declare(
+                    googletest
+                    URL "https://github.com/google/googletest/archive/refs/tags/${GTEST_VERSION}.zip"
+            )
+            # For Windows: Prevent overriding the parent project's compiler/linker settings
+            set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
+            FetchContent_MakeAvailable(googletest)
+        endif()
 
         # Test target declarations.
         add_executable(McBopomofoTest
                 KeyHandlerTest.cpp UTF8HelperTest.cpp)
         target_compile_options(McBopomofoTest PRIVATE -Wno-unknown-pragmas)
-        target_link_libraries(McBopomofoTest PRIVATE Fcitx5::Core gtest_main gmock_main McBopomofoLib)
+        target_link_libraries(McBopomofoTest PRIVATE Fcitx5::Core GTest::gtest_main GTest::gmock_main McBopomofoLib)
         target_include_directories(McBopomofoTest PRIVATE Fcitx5::Core)
 
         configure_file(../data/data.txt mcbopomofo-test-data.txt)
 
+        include(GoogleTest)
         gtest_discover_tests(McBopomofoTest)
 
         add_custom_target(

--- a/src/Engine/CMakeLists.txt
+++ b/src/Engine/CMakeLists.txt
@@ -35,19 +35,6 @@ if (ENABLE_TEST)
                 cmake_policy(SET CMP0135 NEW)
         endif()
 
-        # Let CMake fetch Google Test for us.
-        # https://github.com/google/googletest/tree/main/googletest#incorporating-into-an-existing-cmake-project
-        include(FetchContent)
-
-        FetchContent_Declare(
-                googletest
-                # Specify the commit you depend on and update it regularly.
-                URL https://github.com/google/googletest/archive/refs/tags/v1.14.0.zip
-        )
-        # For Windows: Prevent overriding the parent project's compiler/linker settings
-        set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
-        FetchContent_MakeAvailable(googletest)
-
         # Test target declarations.
         add_executable(McBopomofoLMLibTest
                 KeyValueBlobReaderTest.cpp
@@ -56,7 +43,7 @@ if (ENABLE_TEST)
                 PhraseReplacementMapTest.cpp
                 UserOverrideModelTest.cpp
                 UserPhrasesLMTest.cpp)
-        target_link_libraries(McBopomofoLMLibTest gtest_main McBopomofoLMLib gramambular2_lib)
+        target_link_libraries(McBopomofoLMLibTest GTest::gtest_main McBopomofoLMLib gramambular2_lib)
         include(GoogleTest)
         gtest_discover_tests(McBopomofoLMLibTest)
 

--- a/src/Engine/Mandarin/CMakeLists.txt
+++ b/src/Engine/Mandarin/CMakeLists.txt
@@ -16,22 +16,9 @@ if (ENABLE_TEST)
                 cmake_policy(SET CMP0135 NEW)
         endif()
 
-        # Let CMake fetch Google Test for us.
-        # https://github.com/google/googletest/tree/main/googletest#incorporating-into-an-existing-cmake-project
-        include(FetchContent)
-
-        FetchContent_Declare(
-                googletest
-                # Specify the commit you depend on and update it regularly.
-                URL https://github.com/google/googletest/archive/refs/tags/v1.14.0.zip
-        )
-        # For Windows: Prevent overriding the parent project's compiler/linker settings
-        set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
-        FetchContent_MakeAvailable(googletest)
-
         # Test target declarations.
         add_executable(MandarinTest MandarinTest.cpp)
-        target_link_libraries(MandarinTest gtest_main MandarinLib)
+        target_link_libraries(MandarinTest GTest::gtest_main MandarinLib)
         include(GoogleTest)
         gtest_discover_tests(MandarinTest)
 

--- a/src/Engine/gramambular2/CMakeLists.txt
+++ b/src/Engine/gramambular2/CMakeLists.txt
@@ -16,23 +16,10 @@ if (ENABLE_TEST)
                 cmake_policy(SET CMP0135 NEW)
         endif()
 
-        # Let CMake fetch Google Test for us.
-        # https://github.com/google/googletest/tree/main/googletest#incorporating-into-an-existing-cmake-project
-        include(FetchContent)
-
-        FetchContent_Declare(
-                googletest
-                # Specify the commit you depend on and update it regularly.
-                URL https://github.com/google/googletest/archive/refs/tags/v1.14.0.zip
-        )
-        # For Windows: Prevent overriding the parent project's compiler/linker settings
-        set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
-        FetchContent_MakeAvailable(googletest)
-
         # Test target declarations.
         add_executable(gramambular2_test reading_grid_test.cpp)
         target_include_directories(gramambular2_test PRIVATE "${GMOCK_INCLUDE_DIRS}" "${GTEST_INCLUDE_DIRS}")
-        target_link_libraries(gramambular2_test gtest_main gramambular2_lib)
+        target_link_libraries(gramambular2_test GTest::gtest_main gramambular2_lib)
         include(GoogleTest)
         gtest_discover_tests(gramambular2_test)
 


### PR DESCRIPTION
Utilize FindGTest to locate googletest if installed on the system. If googletest is not installed, fetch the specified version in src/CMakeLists.txt

Also remove redundant FetchContent blocks in subdirectories.