### PR TITLE
refactor(InputMacro): introduce InputMacro classes for grouping

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,6 +24,9 @@ if (ENABLE_CLANG_TIDY)
     MESSAGE(STATUS "Found clang-tidy: ${CLANG_TIDY}")
     string(CONCAT CLANG_TIDY_CHECKS "-checks=-*,"
         "clang-analyzer-*,bugprone-*,cert-*,readability-*,"
+        "clang-diagnostic-*,"
+        "cppcoreguidelines-explicit-virtual-functions,"
+        "cppcoreguidelines-virtual-class-destructor,"
         "-bugprone-easily-swappable-parameters,"
         "-readability-const-return-type,"
         "-readability-convert-member-functions-to-static,"

--- a/src/InputMacro.cpp
+++ b/src/InputMacro.cpp
@@ -11,8 +11,9 @@
 
 namespace McBopomofo {
 
-std::string formatDate(std::string calendarName, int DayOffset,
+std::string formatDate(std::string calendarName, int dayOffset,
                        icu::DateFormat::EStyle dateStyle);
+std::string formatWithPattern(std::string calendarName, int yearOffset, int dateOffset, icu::UnicodeString pattern);
 std::string formatTime(icu::DateFormat::EStyle timeStyle);
 std::string formatTimeZone(icu::TimeZone::EDisplayType type);
 int currentYear();
@@ -25,18 +26,38 @@ class InputMacroDate : public InputMacro {
                  icu::DateFormat::EStyle style)
       : name_(macroName),
         calendarName_(calendar),
-        DayOffset_(offset),
+        dayOffset_(offset),
         dateStyle_(style) {}
   std::string name() const override { return name_; }
   std::string replacement() const override {
-    return formatDate(calendarName_, DayOffset_, dateStyle_);
+    return formatDate(calendarName_, dayOffset_, dateStyle_);
   }
 
  private:
   std::string name_;
   std::string calendarName_;
-  int DayOffset_;
+  int dayOffset_;
   icu::DateFormat::EStyle dateStyle_;
+};
+
+class InputMacroYear : public InputMacro {
+ public:
+  InputMacroYear(std::string macroName, std::string calendar, int offset, icu::UnicodeString pattern)
+      : name_(macroName),
+        calendarName_(calendar),
+        yearOffset_(offset),
+        pattern_(pattern) {}
+  std::string name() const override { return name_; }
+  std::string replacement() const override {
+    return formatWithPattern(calendarName_, yearOffset_, /*dateOffset*/ 0, pattern_) + "年";
+  }
+
+ private:
+  std::string name_;
+  std::string calendarName_;
+  int yearOffset_;
+  // ref: https://unicode-org.github.io/icu/userguide/format_parse/datetime/index#datetime-format-syntax
+  icu::UnicodeString pattern_;
 };
 
 class InputMacroDateTime : public InputMacro {
@@ -204,6 +225,78 @@ class InputMacroDateTomorrowMediumJapanese : public InputMacroDate {
                        icu::DateFormat::EStyle::kMedium) {}
 };
 
+class InputMacroThisYearPlain : public InputMacroYear {
+  public:
+  InputMacroThisYearPlain()
+      : InputMacroYear("MACRO@THIS_YEAR_PLAIN", "", 0, "y") {}
+};
+
+class InputMacroThisYearPlainWithEra : public InputMacroYear {
+  public:
+  InputMacroThisYearPlainWithEra()
+      : InputMacroYear("MACRO@THIS_YEAR_PLAIN_WITH_ERA", "", 0, "Gy") {}
+};
+
+class InputMacroThisYearRoc : public InputMacroYear {
+  public:
+  InputMacroThisYearRoc()
+      : InputMacroYear("MACRO@THIS_YEAR_ROC", "roc", 0, "Gy") {}
+};
+
+class InputMacroThisYearJapanese : public InputMacroYear {
+  public:
+  InputMacroThisYearJapanese()
+      : InputMacroYear("MACRO@THIS_YEAR_JAPANESE", "japanese", 0, "Gy") {}
+};
+
+class InputMacroLastYearPlain : public InputMacroYear {
+  public:
+  InputMacroLastYearPlain()
+      : InputMacroYear("MACRO@LAST_YEAR_PLAIN", "", -1, "y") {}
+};
+
+class InputMacroLastYearPlainWithEra : public InputMacroYear {
+  public:
+  InputMacroLastYearPlainWithEra()
+      : InputMacroYear("MACRO@LAST_YEAR_PLAIN_WITH_ERA", "", -1, "Gy") {}
+};
+
+class InputMacroLastYearRoc : public InputMacroYear {
+  public:
+  InputMacroLastYearRoc()
+      : InputMacroYear("MACRO@LAST_YEAR_ROC", "roc", -1, "Gy") {}
+};
+
+class InputMacroLastYearJapanese : public InputMacroYear {
+  public:
+  InputMacroLastYearJapanese()
+      : InputMacroYear("MACRO@LAST_YEAR_JAPANESE", "japanese", -1, "Gy") {}
+};
+
+class InputMacroNextYearPlain : public InputMacroYear {
+  public:
+  InputMacroNextYearPlain()
+      : InputMacroYear("MACRO@NEXT_YEAR_PLAIN", "", 1, "y") {}
+};
+
+class InputMacroNextYearPlainWithEra : public InputMacroYear {
+  public:
+  InputMacroNextYearPlainWithEra()
+      : InputMacroYear("MACRO@NEXT_YEAR_PLAIN_WITH_ERA", "", 1, "Gy") {}
+};
+
+class InputMacroNextYearRoc : public InputMacroYear {
+  public:
+  InputMacroNextYearRoc()
+      : InputMacroYear("MACRO@NEXT_YEAR_ROC", "roc", 1, "Gy") {}
+};
+
+class InputMacroNextYearJapanese : public InputMacroYear {
+  public:
+  InputMacroNextYearJapanese()
+      : InputMacroYear("MACRO@NEXT_YEAR_JAPANESE", "japanese", 1, "Gy") {}
+};
+
 class InputMacroDateTimeNowShort : public InputMacroDateTime {
   public:
   InputMacroDateTimeNowShort()
@@ -282,6 +375,18 @@ InputMacroController::InputMacroController() {
   AddMacro(macros_, std::make_unique<InputMacroDateTodayMediumRoc>());
   AddMacro(macros_, std::make_unique<InputMacroDateTodayMediumChinese>());
   AddMacro(macros_, std::make_unique<InputMacroDateTodayMediumJapanese>());
+  AddMacro(macros_, std::make_unique<InputMacroThisYearPlain>());
+  AddMacro(macros_, std::make_unique<InputMacroThisYearPlainWithEra>());
+  AddMacro(macros_, std::make_unique<InputMacroThisYearRoc>());
+  AddMacro(macros_, std::make_unique<InputMacroThisYearJapanese>());
+  AddMacro(macros_, std::make_unique<InputMacroLastYearPlain>());
+  AddMacro(macros_, std::make_unique<InputMacroLastYearPlainWithEra>());
+  AddMacro(macros_, std::make_unique<InputMacroLastYearRoc>());
+  AddMacro(macros_, std::make_unique<InputMacroLastYearJapanese>());
+  AddMacro(macros_, std::make_unique<InputMacroNextYearPlain>());
+  AddMacro(macros_, std::make_unique<InputMacroNextYearPlainWithEra>());
+  AddMacro(macros_, std::make_unique<InputMacroNextYearRoc>());
+  AddMacro(macros_, std::make_unique<InputMacroNextYearJapanese>());
   AddMacro(macros_, std::make_unique<InputMacroDateYesterdayShort>());
   AddMacro(macros_, std::make_unique<InputMacroDateYesterdayMedium>());
   AddMacro(macros_, std::make_unique<InputMacroDateYesterdayMediumRoc>());
@@ -314,47 +419,70 @@ std::string InputMacroController::handle(std::string input) {
   return input;
 }
 
-std::string formatDate(std::string calendarName, int DayOffset,
-                       icu::DateFormat::EStyle dateStyle) {
-  UErrorCode status = U_ZERO_ERROR;
-  icu::TimeZone* timezone = icu::TimeZone::createDefault();
+icu::Locale createLocale(std::string calendarName) {
   std::string calendarNameBase =
       calendarName == "japanese" ? "ja_JP" : "zh_Hant_TW";
   if (!calendarName.empty()) {
     calendarNameBase += "@calendar=" + calendarName;
   }
+  return icu::Locale::createCanonical(calendarNameBase.c_str());
+}
 
-  const icu::Locale locale =
-      icu::Locale::createCanonical(calendarNameBase.c_str());
+std::unique_ptr<icu::Calendar> createCalendar(icu::Locale locale) {
+  UErrorCode status = U_ZERO_ERROR;
+  icu::TimeZone* timezone = icu::TimeZone::createDefault();
   std::unique_ptr<icu::Calendar> calendar(icu::Calendar::createInstance(timezone, locale, status));
   calendar->setTime(icu::Calendar::getNow(), status);
-  calendar->add(icu::Calendar::DATE, DayOffset, status);
+  return calendar;
+}
+
+std::string formatWithStyle(std::string calendarName, int yearOffset, int dayOffset,
+                           icu::DateFormat::EStyle dateStyle,
+                           icu::DateFormat::EStyle timeStyle) {
+  UErrorCode status = U_ZERO_ERROR;
+
+  const icu::Locale locale = createLocale(calendarName);
+  std::unique_ptr<icu::Calendar> calendar = createCalendar(locale);
+
+  calendar->add(icu::Calendar::YEAR, yearOffset, status);
+  calendar->add(icu::Calendar::DATE, dayOffset, status);
+
   std::unique_ptr<icu::DateFormat> dateFormatter(icu::DateFormat::createDateTimeInstance(
-      dateStyle, icu::DateFormat::EStyle::kNone, locale));
+      dateStyle, timeStyle, locale));
   icu::UnicodeString formattedDate;
   icu::FieldPosition fieldPosition;
   dateFormatter->format(*calendar, formattedDate, fieldPosition);
+
   std::string output;
   formattedDate.toUTF8String(output);
   return output;
 }
 
-std::string formatTime(icu::DateFormat::EStyle timeStyle) {
+std::string formatWithPattern(std::string calendarName, int yearOffset, int dateOffset, icu::UnicodeString pattern) {
   UErrorCode status = U_ZERO_ERROR;
-  icu::TimeZone* timezone = icu::TimeZone::createDefault();
-  std::string calendarNameBase = "zh_Hant_TW";
-  const icu::Locale locale =
-      icu::Locale::createCanonical(calendarNameBase.c_str());
-  std::unique_ptr<icu::Calendar> calendar(icu::Calendar::createInstance(timezone, locale, status));
-  calendar->setTime(icu::Calendar::getNow(), status);
-  std::unique_ptr<icu::DateFormat> dateFormatter(icu::DateFormat::createDateTimeInstance(
-      icu::DateFormat::EStyle::kNone, timeStyle, locale));
+
+  const icu::Locale locale = createLocale(calendarName);
+  std::unique_ptr<icu::Calendar> calendar = createCalendar(locale);
+
+  calendar->add(icu::Calendar::YEAR, yearOffset, status);
+  calendar->add(icu::Calendar::DATE, dateOffset, status);
+
+  icu::SimpleDateFormat dateFormatter(pattern, locale, status);
   icu::UnicodeString formattedDate;
-  icu::FieldPosition fieldPosition;
-  dateFormatter->format(*calendar, formattedDate, fieldPosition);
+  dateFormatter.format(calendar->getTime(status), formattedDate, status);
+
   std::string output;
   formattedDate.toUTF8String(output);
   return output;
+}
+
+std::string formatDate(std::string calendarName, int dayOffset,
+                       icu::DateFormat::EStyle dateStyle) {
+  return formatWithStyle(calendarName, /*yearOffset*/ 0, dayOffset, dateStyle, /*timeStyle*/ icu::DateFormat::EStyle::kNone);
+}
+
+std::string formatTime(icu::DateFormat::EStyle timeStyle) {
+  return formatWithStyle(/*calendarName*/ "", /*yearOffset*/ 0, /*dayOffset*/ 0, /*dateStyle*/ icu::DateFormat::EStyle::kNone, timeStyle);
 }
 
 std::string formatTimeZone(icu::TimeZone::EDisplayType type) {

--- a/src/InputMacro.cpp
+++ b/src/InputMacro.cpp
@@ -60,6 +60,25 @@ class InputMacroYear : public InputMacro {
   icu::UnicodeString pattern_;
 };
 
+class InputMacroDayOfTheWeek : public InputMacro {
+ public:
+  InputMacroDayOfTheWeek(std::string macroName, std::string calendar, int offset, icu::UnicodeString pattern)
+      : name_(macroName),
+        calendarName_(calendar),
+        dayOffset_(offset),
+        pattern_(pattern) {}
+  std::string name() const override { return name_; }
+  std::string replacement() const override {
+    return formatWithPattern(calendarName_, /*yearOffset*/ 0, dayOffset_, pattern_);
+  }
+
+ private:
+  std::string name_;
+  std::string calendarName_;
+  int dayOffset_;
+  icu::UnicodeString pattern_;
+};
+
 class InputMacroDateTime : public InputMacro {
  public:
   InputMacroDateTime(std::string macroName, icu::DateFormat::EStyle style)
@@ -297,6 +316,97 @@ class InputMacroNextYearJapanese : public InputMacroYear {
       : InputMacroYear("MACRO@NEXT_YEAR_JAPANESE", "japanese", 1, "Gy") {}
 };
 
+std::string convertWeekdayUnit(std::string& original) {
+  // s/星期/禮拜/
+  std::string src = "星期";
+  std::string dst = "禮拜";
+  return original.replace(original.find(src), src.length(), dst);
+}
+
+class InputMacroWeekdayTodayShort : public InputMacroDayOfTheWeek {
+  public:
+  InputMacroWeekdayTodayShort()
+      : InputMacroDayOfTheWeek("MACRO@DATE_TODAY_WEEKDAY_SHORT", "", 0, "E") {}
+};
+
+class InputMacroWeekdayToday : public InputMacroDayOfTheWeek {
+  public:
+  InputMacroWeekdayToday()
+      : InputMacroDayOfTheWeek("MACRO@DATE_TODAY_WEEKDAY", "", 0, "EEEE") {}
+};
+
+class InputMacroWeekdayToday2 : public InputMacroDayOfTheWeek {
+  public:
+  InputMacroWeekdayToday2()
+      : InputMacroDayOfTheWeek("MACRO@DATE_TODAY2_WEEKDAY", "", 0, "EEEE") {}
+  std::string replacement () const override {
+    std::string original(InputMacroDayOfTheWeek::replacement());
+    return convertWeekdayUnit(original);
+  }
+};
+
+class InputMacroWeekdayTodayJapanese : public InputMacroDayOfTheWeek {
+  public:
+  InputMacroWeekdayTodayJapanese()
+      : InputMacroDayOfTheWeek("MACRO@DATE_TODAY_WEEKDAY_JAPANESE", "japanese", 0, "EEEE") {}
+};
+
+class InputMacroWeekdayYesterdayShort : public InputMacroDayOfTheWeek {
+  public:
+  InputMacroWeekdayYesterdayShort()
+      : InputMacroDayOfTheWeek("MACRO@DATE_YESTERDAY_WEEKDAY_SHORT", "", -1, "E") {}
+};
+
+class InputMacroWeekdayYesterday : public InputMacroDayOfTheWeek {
+  public:
+  InputMacroWeekdayYesterday()
+      : InputMacroDayOfTheWeek("MACRO@DATE_YESTERDAY_WEEKDAY", "", -1, "EEEE") {}
+};
+
+class InputMacroWeekdayYesterday2 : public InputMacroDayOfTheWeek {
+  public:
+  InputMacroWeekdayYesterday2()
+      : InputMacroDayOfTheWeek("MACRO@DATE_YESTERDAY2_WEEKDAY", "", -1, "EEEE") {}
+  std::string replacement () const override {
+    std::string original(InputMacroDayOfTheWeek::replacement());
+    return convertWeekdayUnit(original);
+  }
+};
+
+class InputMacroWeekdayYesterdayJapanese : public InputMacroDayOfTheWeek {
+  public:
+  InputMacroWeekdayYesterdayJapanese()
+      : InputMacroDayOfTheWeek("MACRO@DATE_YESTERDAY_WEEKDAY_JAPANESE", "japanese", -1, "EEEE") {}
+};
+
+class InputMacroWeekdayTomorrowShort : public InputMacroDayOfTheWeek {
+  public:
+  InputMacroWeekdayTomorrowShort()
+      : InputMacroDayOfTheWeek("MACRO@DATE_TOMORROW_WEEKDAY_SHORT", "", 1, "E") {}
+};
+
+class InputMacroWeekdayTomorrow : public InputMacroDayOfTheWeek {
+  public:
+  InputMacroWeekdayTomorrow()
+      : InputMacroDayOfTheWeek("MACRO@DATE_TOMORROW_WEEKDAY", "", 1, "EEEE") {}
+};
+
+class InputMacroWeekdayTomorrow2 : public InputMacroDayOfTheWeek {
+  public:
+  InputMacroWeekdayTomorrow2()
+      : InputMacroDayOfTheWeek("MACRO@DATE_TOMORROW2_WEEKDAY", "", 1, "EEEE") {}
+  std::string replacement () const override {
+    std::string original(InputMacroDayOfTheWeek::replacement());
+    return convertWeekdayUnit(original);
+  }
+};
+
+class InputMacroWeekdayTomorrowJapanese : public InputMacroDayOfTheWeek {
+  public:
+  InputMacroWeekdayTomorrowJapanese()
+      : InputMacroDayOfTheWeek("MACRO@DATE_TOMORROW_WEEKDAY_JAPANESE", "japanese", 1, "EEEE") {}
+};
+
 class InputMacroDateTimeNowShort : public InputMacroDateTime {
   public:
   InputMacroDateTimeNowShort()
@@ -387,6 +497,18 @@ InputMacroController::InputMacroController() {
   AddMacro(macros_, std::make_unique<InputMacroNextYearPlainWithEra>());
   AddMacro(macros_, std::make_unique<InputMacroNextYearRoc>());
   AddMacro(macros_, std::make_unique<InputMacroNextYearJapanese>());
+  AddMacro(macros_, std::make_unique<InputMacroWeekdayTodayShort>());
+  AddMacro(macros_, std::make_unique<InputMacroWeekdayToday>());
+  AddMacro(macros_, std::make_unique<InputMacroWeekdayToday2>());
+  AddMacro(macros_, std::make_unique<InputMacroWeekdayTodayJapanese>());
+  AddMacro(macros_, std::make_unique<InputMacroWeekdayYesterdayShort>());
+  AddMacro(macros_, std::make_unique<InputMacroWeekdayYesterday>());
+  AddMacro(macros_, std::make_unique<InputMacroWeekdayYesterday2>());
+  AddMacro(macros_, std::make_unique<InputMacroWeekdayYesterdayJapanese>());
+  AddMacro(macros_, std::make_unique<InputMacroWeekdayTomorrowShort>());
+  AddMacro(macros_, std::make_unique<InputMacroWeekdayTomorrow>());
+  AddMacro(macros_, std::make_unique<InputMacroWeekdayTomorrow2>());
+  AddMacro(macros_, std::make_unique<InputMacroWeekdayTomorrowJapanese>());
   AddMacro(macros_, std::make_unique<InputMacroDateYesterdayShort>());
   AddMacro(macros_, std::make_unique<InputMacroDateYesterdayMedium>());
   AddMacro(macros_, std::make_unique<InputMacroDateYesterdayMediumRoc>());

--- a/src/InputMacro.h
+++ b/src/InputMacro.h
@@ -1,5 +1,5 @@
-#ifndef INPUTMACRO
-#define INPUTMACRO
+#ifndef SRC_INPUTMACRO_H_
+#define SRC_INPUTMACRO_H_
 
 #include <memory>
 #include <string>
@@ -8,6 +8,8 @@
 namespace McBopomofo {
 class InputMacro {
  public:
+  virtual ~InputMacro() = default;
+
   virtual std::string name() const = 0;
   virtual std::string replacement() const = 0;
 };
@@ -24,4 +26,4 @@ class InputMacroController {
 
 }  // namespace McBopomofo
 
-#endif /* INPUTMACRO */
+#endif /* SRC_INPUTMACRO_H_ */


### PR DESCRIPTION
This commit introduces a few InputMacro classes to avoid repetitive
code. Most of the replacement functions are doing the same with different
set of parameters, we can move them to a parent class.

* Use vector.size() to avoid a few magic numbers.
* Use std::unique_ptr for icu objects
* Mark virtual method overrides properly.
* Add clang-tidy checks to catch virtual function issues.

Add short keywords for the time macros as discussed in 
https://github.com/openvanilla/fcitx5-mcbopomofo/pull/98#issuecomment-1857094043

refactor(InputMacro): provide formatWithPattern and formatWithStyle

* extract common tasks from formatDate and formatTime into formatWithStyle
  for more generic formatting.
* add a new formatWithPattern helper to format datetime with patterns
* implement THIS_YEAR/LAST_YEAR/NEXT_YEAR macros with formatWithPattern

feat(InputMacro): implement weekday macros