### PR TITLE
Asks the input method to use the vertical candidate window when there is a long candidate.

### DIFF
--- a/src/McBopomofo.cpp
+++ b/src/McBopomofo.cpp
@@ -747,13 +747,9 @@ fcitx::CandidateLayoutHint McBopomofoEngine::getCandidateLayoutHint() const {
   if (choosingCandidate != nullptr) {
     auto candidates = choosingCandidate->candidates;
     for (auto candidate : candidates) {
-      if (candidate.value.length() > 8) {
-        return fcitx::CandidateLayoutHint::Vertical;
-      }
-    }
-    if (candidates.size() > 0) {
-      auto firstCandidate = candidates[0];
-      if (firstCandidate.value.length() > 8) {
+      std::wstring_convert<std::codecvt_utf8<char32_t>, char32_t> conv;
+      auto u32 = conv.from_bytes(candidate.value);
+      if (u32.size() > 8) {
         return fcitx::CandidateLayoutHint::Vertical;
       }
     }

--- a/src/McBopomofo.cpp
+++ b/src/McBopomofo.cpp
@@ -37,6 +37,7 @@
 
 #include "Key.h"
 #include "Log.h"
+#include "UTF8Helper.h"
 
 namespace McBopomofo {
 
@@ -746,10 +747,9 @@ fcitx::CandidateLayoutHint McBopomofoEngine::getCandidateLayoutHint() const {
       dynamic_cast<InputStates::ChoosingCandidate*>(state_.get());
   if (choosingCandidate != nullptr) {
     auto candidates = choosingCandidate->candidates;
-    for (auto candidate : candidates) {
-      std::wstring_convert<std::codecvt_utf8<char32_t>, char32_t> conv;
-      auto u32 = conv.from_bytes(candidate.value);
-      if (u32.size() > 8) {
+    for (InputStates::ChoosingCandidate::Candidate candidate : candidates) {
+      std::string value = candidate.value;
+      if (McBopomofo::CodePointCount(value) > 8) {
         return fcitx::CandidateLayoutHint::Vertical;
       }
     }

--- a/src/McBopomofo.cpp
+++ b/src/McBopomofo.cpp
@@ -741,6 +741,24 @@ void McBopomofoEngine::handleMarkingState(fcitx::InputContext* context,
 
 fcitx::CandidateLayoutHint McBopomofoEngine::getCandidateLayoutHint() const {
   fcitx::CandidateLayoutHint layoutHint = fcitx::CandidateLayoutHint::NotSet;
+
+  auto choosingCandidate =
+      dynamic_cast<InputStates::ChoosingCandidate*>(state_.get());
+  if (choosingCandidate != nullptr) {
+    auto candidates = choosingCandidate->candidates;
+    for (auto candidate : candidates) {
+      if (candidate.value.length() > 8) {
+        return fcitx::CandidateLayoutHint::Vertical;
+      }
+    }
+    if (candidates.size() > 0) {
+      auto firstCandidate = candidates[0];
+      if (firstCandidate.value.length() > 8) {
+        return fcitx::CandidateLayoutHint::Vertical;
+      }
+    }
+  }
+
   switch (config_.candidateLayout.value()) {
     case McBopomofo::CandidateLayoutHint::Vertical:
       layoutHint = fcitx::CandidateLayoutHint::Vertical;


### PR DESCRIPTION
Recently we added the input macro feature. It may cause longer candidates appearing in the candidate window, and it could be hard to use when the window stays horizontal.

The PR lets the candidate to be always vertical when there is a candidate whose length is larger than 8.