### PR TITLE
Put cursor at the back after marking backwards

### DIFF
--- a/src/KeyHandler.cpp
+++ b/src/KeyHandler.cpp
@@ -300,6 +300,14 @@ bool KeyHandler::handle(Key key, McBopomofo::InputState* state,
       if (marking->acceptable) {
         userPhraseAdder_->addUserPhrase(marking->reading, marking->markedText);
         onAddNewPhrase_(marking->markedText);
+
+        // If the cursor was at the end of the buffer when the marking started,
+        // move back.
+        if (marking->markStartGridCursorIndex == grid_.length() &&
+            grid_.cursor() < marking->markStartGridCursorIndex) {
+          grid_.setCursor(grid_.length());
+        }
+
         stateCallback(buildInputtingState());
       } else {
         errorCallback();
@@ -539,7 +547,7 @@ bool KeyHandler::handleTabKey(Key key, McBopomofo::InputState* state,
     errorCallback();
     return true;
   }
-  Formosa::Gramambular2::ReadingGrid::NodePtr currentNode = *nodeIter;
+  const Formosa::Gramambular2::ReadingGrid::NodePtr& currentNode = *nodeIter;
 
   size_t currentIndex = 0;
   if (!currentNode->isOverridden()) {
@@ -953,7 +961,7 @@ void KeyHandler::pinNode(
   if (nodeIter == latestWalk_.nodes.cend()) {
     return;
   }
-  Formosa::Gramambular2::ReadingGrid::NodePtr currentNode = *nodeIter;
+  const Formosa::Gramambular2::ReadingGrid::NodePtr& currentNode = *nodeIter;
 
   if (currentNode != nullptr &&
       currentNode->currentUnigram().score() > kNoOverrideThreshold) {


### PR DESCRIPTION
Small usability improvement when we start to add a phrase by moving the cursor backwards from the end of the composing buffer. After this PR, the cursor is placed at the end of the buffer again.

Also use const references in two NodePtr use sites.