### PR TITLE
Fix clang-tidy warnings after recent changes

### DIFF
--- a/src/DictionaryService.cpp
+++ b/src/DictionaryService.cpp
@@ -40,7 +40,7 @@ class CharacterInfoService : public McBopomofo::DictionaryService {
   void lookup(std::string phrase, McBopomofo::InputState* state,
               size_t /*Unused*/,
               const McBopomofo::StateCallback& stateCallback) override {
-    auto selecting =
+    auto* selecting =
         dynamic_cast<McBopomofo::InputStates::SelectingDictionary*>(state);
     if (selecting != nullptr) {
       auto copy =
@@ -95,7 +95,7 @@ void McBopomofo::DictionaryServices::lookup(
   if (serviceIndex >= services_.size()) {
     return;
   }
-  auto service = services_[serviceIndex].get();
+  auto* service = services_[serviceIndex].get();
   service->lookup(std::move(phrase), state, serviceIndex, stateCallback);
 }
 

--- a/src/DictionaryService.h
+++ b/src/DictionaryService.h
@@ -18,10 +18,11 @@ using StateCallback =
  */
 class DictionaryService {
  public:
-  virtual ~DictionaryService() {};
+  virtual ~DictionaryService(){};
 
   virtual std::string name() const = 0;
-  virtual void lookup(std::string phrase, InputState* state, size_t serviceIndex,
+  virtual void lookup(std::string phrase, InputState* state,
+                      size_t serviceIndex,
                       const StateCallback& stateCallback) = 0;
   virtual std::string textForMenu(std::string selectedString) const = 0;
 };

--- a/src/Engine/gramambular2/reading_grid_test.cpp
+++ b/src/Engine/gramambular2/reading_grid_test.cpp
@@ -210,8 +210,8 @@ TEST(ReadingGridTest, Span) {
   auto n10 = std::make_shared<ReadingGrid::Node>("", 10, lm.getUnigrams(""));
   ASSERT_DEATH({ (void)span.add(n10); }, "Assertion");
   ASSERT_DEATH({ (void)span.nodeOf(0); }, "Assertion");
-  ASSERT_DEATH(
-      { (void)span.nodeOf(ReadingGrid::kMaximumSpanLength + 1); }, "Assertion");
+  ASSERT_DEATH({ (void)span.nodeOf(ReadingGrid::kMaximumSpanLength + 1); },
+               "Assertion");
 #endif
 }
 
@@ -741,4 +741,3 @@ TEST(ReadingGridTest, FindInSpan2) {
 }
 
 }  // namespace Formosa::Gramambular2
-

--- a/src/KeyHandler.cpp
+++ b/src/KeyHandler.cpp
@@ -286,7 +286,7 @@ bool KeyHandler::handle(Key key, McBopomofo::InputState* state,
         errorCallback();
         return true;
       }
-      auto inputting = dynamic_cast<InputStates::Inputting*>(state);
+      auto* inputting = dynamic_cast<InputStates::Inputting*>(state);
       if (inputting != nullptr) {
         std::string composerBuffer = inputting->composingBuffer;
         std::string characterBeforeCursor =

--- a/src/McBopomofo.cpp
+++ b/src/McBopomofo.cpp
@@ -569,17 +569,14 @@ bool McBopomofoEngine::handleCandidateKeyEvent(
         enterNewState(context, std::move(state));
         return true;
       }
-    } else if (selectingDictionary != nullptr) {
-      // Leave selecting dictionary service state.
-      keyIsCancel = true;
-    } else if (showingCharInfo != nullptr) {
+    } else if (selectingDictionary != nullptr || showingCharInfo != nullptr) {
       // Leave selecting dictionary service state.
       keyIsCancel = true;
     }
   }
 
   if (keyHandler_->inputMode() == McBopomofo::InputMode::McBopomofo &&
-      config_.associatedPhrasesEnabled.value() == true &&
+      config_.associatedPhrasesEnabled.value() &&
       origKey.code() == 36 && (origKey.states() & fcitx::KeyState::Shift)) {
     int idx = candidateList->cursorIndex();
     if (idx < candidateList->size()) {
@@ -901,7 +898,7 @@ void McBopomofoEngine::handleCandidatesState(fcitx::InputContext* context,
   selectionKeys_.clear();
 
   if (dynamic_cast<InputStates::AssociatedPhrasesPlain*>(state_.get()) !=
-      nullptr) {
+      nullptr) {  // NOLINT(bugprone-branch-clone)
     selectionKeys_.emplace_back(FcitxKey_1);
     selectionKeys_.emplace_back(FcitxKey_2);
     selectionKeys_.emplace_back(FcitxKey_3);

--- a/src/McBopomofo.cpp
+++ b/src/McBopomofo.cpp
@@ -545,11 +545,11 @@ bool McBopomofoEngine::handleCandidateKeyEvent(
   // dictionaries.
   if (keyHandler_->inputMode() == McBopomofo::InputMode::McBopomofo &&
       key.check(FcitxKey_question)) {
-    auto choosingCandidate =
+    auto* choosingCandidate =
         dynamic_cast<InputStates::ChoosingCandidate*>(state_.get());
-    auto selectingDictionary =
+    auto* selectingDictionary =
         dynamic_cast<InputStates::SelectingDictionary*>(state_.get());
-    auto showingCharInfo =
+    auto* showingCharInfo =
         dynamic_cast<InputStates::ShowingCharInfo*>(state_.get());
 
     if (choosingCandidate != nullptr) {
@@ -625,7 +625,7 @@ bool McBopomofoEngine::handleCandidateKeyEvent(
     auto* showingCharInfo =
         dynamic_cast<InputStates::ShowingCharInfo*>(state_.get());
     if (showingCharInfo != nullptr) {
-      auto previous = showingCharInfo->previousState.get();
+      auto* previous = showingCharInfo->previousState.get();
       auto copy = std::make_unique<InputStates::SelectingDictionary>(*previous);
       stateCallback(std::move(copy));
       return true;
@@ -634,7 +634,7 @@ bool McBopomofoEngine::handleCandidateKeyEvent(
     auto* selecting =
         dynamic_cast<InputStates::SelectingDictionary*>(state_.get());
     if (selecting != nullptr) {
-      auto previous = selecting->previousState.get();
+      auto* previous = selecting->previousState.get();
       auto* choosing = dynamic_cast<InputStates::ChoosingCandidate*>(previous);
       if (choosing != nullptr) {
         auto copy = std::make_unique<InputStates::ChoosingCandidate>(*choosing);
@@ -662,7 +662,7 @@ bool McBopomofoEngine::handleCandidateKeyEvent(
     auto* associatedPhrases =
         dynamic_cast<InputStates::AssociatedPhrases*>(state_.get());
     if (associatedPhrases != nullptr) {
-      auto previous = associatedPhrases->previousState.get();
+      auto* previous = associatedPhrases->previousState.get();
       auto* choosing = dynamic_cast<InputStates::ChoosingCandidate*>(previous);
       auto* inputting = dynamic_cast<InputStates::Inputting*>(previous);
       if (choosing != nullptr) {
@@ -954,13 +954,13 @@ void McBopomofoEngine::handleCandidatesState(fcitx::InputContext* context,
         enterNewState(context, std::move(next));
       };
 
-  auto choosing = dynamic_cast<InputStates::ChoosingCandidate*>(current);
-  auto selectingDictionary =
+  auto* choosing = dynamic_cast<InputStates::ChoosingCandidate*>(current);
+  auto* selectingDictionary =
       dynamic_cast<InputStates::SelectingDictionary*>(current);
-  auto showingCharInfo = dynamic_cast<InputStates::ShowingCharInfo*>(current);
-  auto associatedPhrases =
+  auto* showingCharInfo = dynamic_cast<InputStates::ShowingCharInfo*>(current);
+  auto* associatedPhrases =
       dynamic_cast<InputStates::AssociatedPhrases*>(current);
-  auto associatedPhrasesPlain =
+  auto* associatedPhrasesPlain =
       dynamic_cast<InputStates::AssociatedPhrasesPlain*>(current);
 
   if (choosing != nullptr) {
@@ -1112,7 +1112,7 @@ fcitx::CandidateLayoutHint McBopomofoEngine::getCandidateLayoutHint() const {
     return fcitx::CandidateLayoutHint::Vertical;
   }
 
-  auto choosingCandidate =
+  auto* choosingCandidate =
       dynamic_cast<InputStates::ChoosingCandidate*>(state_.get());
   if (choosingCandidate != nullptr) {
     auto candidates = choosingCandidate->candidates;

--- a/src/McBopomofo.cpp
+++ b/src/McBopomofo.cpp
@@ -576,8 +576,8 @@ bool McBopomofoEngine::handleCandidateKeyEvent(
   }
 
   if (keyHandler_->inputMode() == McBopomofo::InputMode::McBopomofo &&
-      config_.associatedPhrasesEnabled.value() &&
-      origKey.code() == 36 && (origKey.states() & fcitx::KeyState::Shift)) {
+      config_.associatedPhrasesEnabled.value() && origKey.code() == 36 &&
+      (origKey.states() & fcitx::KeyState::Shift)) {
     int idx = candidateList->cursorIndex();
     if (idx < candidateList->size()) {
       auto* choosingCandidate =


### PR DESCRIPTION
This PR fixes the warnings from `clang-tidy`. 

----

@lukhnos @zonble, I feel the `cert-err33-c` and `readability-magic-numbers` warnings from the following should be fixed to avoid bugs/improve readability, but can be a bit subjected, so I didn't touch those. Please kindly let me know how you'd like to fix these.

```
$ ninja
[30/42] Building CXX object src/CMakeFiles/McBopomofoLib.dir/DictionaryService.cpp.o
fcitx5-mcbopomofo/src/DictionaryService.cpp:124:3: warning: the value returned by this function should be used [cert-err33-c]
  fseek(file, 0, SEEK_END);
  ^~~~~~~~~~~~~~~~~~~~~~~~
fcitx5-mcbopomofo/src/DictionaryService.cpp:124:3: note: cast the expression to void to silence this warning
fcitx5-mcbopomofo/src/DictionaryService.cpp:126:3: warning: the value returned by this function should be used [cert-err33-c]
  fseek(file, 0, SEEK_SET);
  ^~~~~~~~~~~~~~~~~~~~~~~~
fcitx5-mcbopomofo/src/DictionaryService.cpp:126:3: note: cast the expression to void to silence this warning
fcitx5-mcbopomofo/src/DictionaryService.cpp:128:3: warning: the value returned by this function should be used [cert-err33-c]
  fread(json_data.get(), 1, file_size, file);
  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
fcitx5-mcbopomofo/src/DictionaryService.cpp:128:3: note: cast the expression to void to silence this warning
fcitx5-mcbopomofo/src/DictionaryService.cpp:129:3: warning: the value returned by this function should be used [cert-err33-c]
  fclose(file);
  ^~~~~~~~~~~~
fcitx5-mcbopomofo/src/DictionaryService.cpp:129:3: note: cast the expression to void to silence this warning
[35/42] Building CXX object src/CMakeFiles/mcbopomofo.dir/McBopomofo.cpp.o
fcitx5-mcbopomofo/src/McBopomofo.cpp:515:64: warning: 10 is a magic number; consider replacing it with a named constant [readability-magic-numbers]
    if ((origKey.states() & fcitx::KeyState::Shift) && code >= 10 &&
                                                               ^
fcitx5-mcbopomofo/src/McBopomofo.cpp:516:17: warning: 19 is a magic number; consider replacing it with a named constant [readability-magic-numbers]
        code <= 19) {
                ^
fcitx5-mcbopomofo/src/McBopomofo.cpp:517:24: warning: 10 is a magic number; consider replacing it with a named constant [readability-magic-numbers]
      int idx = code - 10;
                       ^
fcitx5-mcbopomofo/src/McBopomofo.cpp:580:25: warning: 36 is a magic number; consider replacing it with a named constant [readability-magic-numbers]
      origKey.code() == 36 && (origKey.states() & fcitx::KeyState::Shift)) {
                        ^
fcitx5-mcbopomofo/src/McBopomofo.cpp:1119:47: warning: 8 is a magic number; consider replacing it with a named constant [readability-magic-numbers]
      if (McBopomofo::CodePointCount(value) > 8) {
                                              ^
[42/42] Linking CXX shared module src/mcbopomofo.so
```