### PR TITLE
Fix the two other clang-tidy warnings

### DIFF
--- a/src/DictionaryService.cpp
+++ b/src/DictionaryService.cpp
@@ -118,18 +118,51 @@ void McBopomofo::DictionaryServices::load() {
   FILE* file = fopen(dictionaryServicesPath.c_str(), "r");
   if (!file) {
     FCITX_MCBOPOMOFO_INFO()
-        << "No dictionary service file" << dictionaryServicesPath;
+        << "No dictionary service file: " << dictionaryServicesPath;
     return;
   }
-  fseek(file, 0, SEEK_END);
+  int err = fseek(file, 0, SEEK_END);
+  if (err != 0) {
+    FCITX_MCBOPOMOFO_ERROR()
+        << "Error seeking dictionary service file: " << dictionaryServicesPath;
+    (void)fclose(file);
+    return;
+  }
+
   long file_size = ftell(file);
-  fseek(file, 0, SEEK_SET);
+  if (file_size == -1) {
+    FCITX_MCBOPOMOFO_ERROR()
+        << "Error ftelling dictionary service file: " << dictionaryServicesPath;
+    (void)fclose(file);
+    return;
+  }
+  err = fseek(file, 0, SEEK_SET);
+  if (err != 0) {
+    FCITX_MCBOPOMOFO_ERROR()
+        << "Error seeking dictionary service file: " << dictionaryServicesPath;
+    (void)fclose(file);
+    return;
+  }
+
   std::unique_ptr<char[]> json_data(new char[file_size + 1]);
-  fread(json_data.get(), 1, file_size, file);
-  fclose(file);
+  size_t nchunkread = fread(json_data.get(), file_size, 1, file);
+  if (nchunkread != 1) {
+    FCITX_MCBOPOMOFO_ERROR()
+        << "Error reading dictionary service file: " << dictionaryServicesPath;
+    (void)fclose(file);
+    return;
+  }
+  err = fclose(file);
+  if (err != 0) {
+    FCITX_MCBOPOMOFO_ERROR()
+        << "Error closing dictionary service file: " << dictionaryServicesPath;
+    // Pass through since we've already read the data.
+  }
   json_data[file_size] = '\0';
   struct json_object* json_obj = json_tokener_parse(json_data.get());
   if (json_obj == nullptr) {
+    FCITX_MCBOPOMOFO_WARN()
+        << "Dictionary service file not valid: " << dictionaryServicesPath;
     return;
   }
   struct json_object* servicesArray;

--- a/src/InputState.h
+++ b/src/InputState.h
@@ -85,7 +85,7 @@ struct Inputting : NotEmpty {
             const std::string_view& tooltipText = "")
       : NotEmpty(buf, index, tooltipText) {}
 
-  Inputting(Inputting const& state)
+  Inputting(const Inputting& state)
       : NotEmpty(state.composingBuffer, state.cursorIndex, state.tooltip) {}
 };
 
@@ -97,7 +97,7 @@ struct ChoosingCandidate : NotEmpty {
                     std::vector<Candidate> cs)
       : NotEmpty(buf, index), candidates(std::move(cs)) {}
 
-  ChoosingCandidate(ChoosingCandidate const& state)
+  ChoosingCandidate(const ChoosingCandidate& state)
       : NotEmpty(state.composingBuffer, state.cursorIndex),
         candidates(state.candidates) {}
 
@@ -138,7 +138,7 @@ struct Marking : NotEmpty {
         reading(std::move(readingText)),
         acceptable(canAccept) {}
 
-  Marking(Marking const& state)
+  Marking(const Marking& state)
       : NotEmpty(state.composingBuffer, state.cursorIndex, state.tooltip),
         markStartGridCursorIndex(state.markStartGridCursorIndex),
         head(state.head),
@@ -166,7 +166,7 @@ struct SelectingDictionary : NotEmpty {
         selectedCandidateIndex(selectedIndex),
         menu(std::move(menu)) {}
 
-  SelectingDictionary(SelectingDictionary const& state)
+  SelectingDictionary(const SelectingDictionary& state)
       : NotEmpty(state.previousState->composingBuffer,
                  state.previousState->cursorIndex,
                  state.previousState->tooltip),

--- a/src/Log.h
+++ b/src/Log.h
@@ -28,7 +28,8 @@
 
 FCITX_DECLARE_LOG_CATEGORY(mcbopomofo_log);
 
-#define FCITX_MCBOPOMOFO_WARN() FCITX_LOGC(::mcbopomofo_log, Warn)
+#define FCITX_MCBOPOMOFO_ERROR() FCITX_LOGC(::mcbopomofo_log, Error)
 #define FCITX_MCBOPOMOFO_INFO() FCITX_LOGC(::mcbopomofo_log, Info)
+#define FCITX_MCBOPOMOFO_WARN() FCITX_LOGC(::mcbopomofo_log, Warn)
 
 #endif  // SRC_LOG_H_


### PR DESCRIPTION
This fixes the `cert-err33-c` and `readability-magic-numbers` warnings as the follow-up to @xatier's #109.

Also uses the `const T&` instead of `T const&` parameter type in `InputState.h` to maintain consistency.