### PR TITLE
Initialize NodeInSpan struct members properly

### DIFF
--- a/src/Engine/gramambular2/reading_grid.h
+++ b/src/Engine/gramambular2/reading_grid.h
@@ -268,7 +268,7 @@ class ReadingGrid {
 
   struct NodeInSpan {
     NodePtr node;
-    size_t spanIndex;
+    size_t spanIndex = 0;
   };
 
   // Find all nodes that overlap with the location. The return value is a list


### PR DESCRIPTION
This PR fixes the uninitialized members in `struct NodeInSpan`.

----

I was running [facebook/infer](https://github.com/facebook/infer) for fun, with instructions in [1] [2].

```
make build
cd build
cmake -DCMAKE_EXPORT_COMPILE_COMMANDS=1 -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_BUILD_TYPE=Release ..
cd ..
infer run --compilation-database build/compile_commands.json
```

The tool generated the following report.

```
src/Engine/gramambular2/reading_grid.cpp:469: error: Uninitialized Value
  The value read from overridden.spanIndex was never initialized.
  467.   }
  468. 
  469.   for (size_t i = overridden.spanIndex;
              ^
  470.        i < overridden.spanIndex + overridden.node->spanningLength() &&
  471.        i < spans_.size();

src/Engine/gramambular2/reading_grid.cpp:470: error: Uninitialized Value
  The value read from overridden.spanIndex was never initialized.
  468. 
  469.   for (size_t i = overridden.spanIndex;
  470.        i < overridden.spanIndex + overridden.node->spanningLength() &&
              ^
  471.        i < spans_.size();
  472.        ++i) {

src/Engine/Mandarin/Mandarin.cpp:593: error: Dead Store
  The value written to &utf8_length (type long) is never used.
  591.     }
  592. 
  593.     std::string::difference_type utf8_length = -1;
           ^
  594. 
  595.     // These are the code points for the tone markers.


Found 3 issues
                Issue Type(ISSUED_TYPE_ID): #
  Uninitialized Value(UNINITIALIZED_VALUE): 2
                    Dead Store(DEAD_STORE): 1
```

Since a `shared_ptr` will have `nullptr` by default implicitly, the if block at L464 should guarantee that `overridden.spanIndex` is coming from some `nis` during the for-loop (L459), I believe it is still a good practice to set the struct members with explicit zero values.

https://github.com/openvanilla/fcitx5-mcbopomofo/blob/master/src/Engine/gramambular2/reading_grid.cpp#L452

----

Unfortunately, I wasn't able to spot issues with the dead store one though, not sure if that's a false positive from the static analysis tool.

[1] https://fbinfer.com/docs/infer-workflow
[2] https://fbinfer.com/docs/analyzing-apps-or-projects#cmake