### PR TITLE
Fix a few typos

### DIFF
--- a/src/DictionaryService.cpp
+++ b/src/DictionaryService.cpp
@@ -159,7 +159,7 @@ void McBopomofo::DictionaryServices::load() {
   long file_size = ftell(file);
   if (file_size == -1) {
     FCITX_MCBOPOMOFO_ERROR()
-        << "Error ftelling dictionary service file: " << dictionaryServicesPath;
+        << "Error telling dictionary service file: " << dictionaryServicesPath;
     (void)fclose(file);
     return;
   }

--- a/src/UTF8HelperTest.cpp
+++ b/src/UTF8HelperTest.cpp
@@ -35,7 +35,7 @@ TEST(UTF8HelperTest, CountingAndClampingEmptyString) {
   ASSERT_EQ(SubstringToCodePoints(s, 1), s);
 }
 
-TEST(UTF8HelperTest, CountingAndClapmingAsciiStrings) {
+TEST(UTF8HelperTest, CountingAndClampingAsciiStrings) {
   std::string s = "hello, world!";
   ASSERT_EQ(CodePointCount(s), 13);
   ASSERT_EQ(SubstringToCodePoints(s, 0), "");
@@ -44,7 +44,7 @@ TEST(UTF8HelperTest, CountingAndClapmingAsciiStrings) {
 }
 // 🂡
 
-TEST(UTF8HelperTest, CountingAndClapmingStrings) {
+TEST(UTF8HelperTest, CountingAndClampingStrings) {
   std::string s = "café🂡火";
   ASSERT_EQ(CodePointCount(s), 6);
   ASSERT_EQ(SubstringToCodePoints(s, 0), "");
@@ -56,7 +56,7 @@ TEST(UTF8HelperTest, CountingAndClapmingStrings) {
   ASSERT_EQ(SubstringToCodePoints(s, 8), s);
 }
 
-TEST(UTF8HelperTest, CountingAndClapmingInvalidStrings) {
+TEST(UTF8HelperTest, CountingAndClampingInvalidStrings) {
   // Mangled UTF-8 sequence: \xc3\xa9 = é;
   std::string s = "caf🂡\xa9\xc3火";
   ASSERT_EQ(CodePointCount(s), 4);
@@ -69,7 +69,7 @@ TEST(UTF8HelperTest, CountingAndClapmingInvalidStrings) {
   ASSERT_EQ(SubstringToCodePoints(s, 8), "caf🂡");
 }
 
-TEST(UTF8HelperTest, CountingAndClapmingPrematurelyTerminatingSequence) {
+TEST(UTF8HelperTest, CountingAndClampingPrematurelyTerminatingSequence) {
   // \xc3\xa9 = é;
   std::string s = "\xc3";
   ASSERT_EQ(CodePointCount(s), 0);


### PR DESCRIPTION
* use `telling` for consistency (`fseek` -> "seeking", `fread` -> "reading").
* `clapm` -> `clamp`