### PR TITLE
Refactor LM classes to use MemoryMappedFile

### DIFF
--- a/src/Engine/ParselessLM.cpp
+++ b/src/Engine/ParselessLM.cpp
@@ -32,57 +32,28 @@
 #include <string_view>
 #include <utility>
 
-McBopomofo::ParselessLM::~ParselessLM() { close(); }
+bool McBopomofo::ParselessLM::isLoaded() {
+  return mmapedFile_.data() != nullptr;
+}
 
-bool McBopomofo::ParselessLM::isLoaded() { return data_ != nullptr; }
-
-bool McBopomofo::ParselessLM::open(const std::string_view& path) {
-  if (data_) {
+bool McBopomofo::ParselessLM::open(const char* path) {
+  if (!mmapedFile_.open(path)) {
     return false;
   }
-
-  fd_ = ::open(path.data(), O_RDONLY);
-  if (fd_ == -1) {
-    return false;
-  }
-
-  struct stat sb;
-  if (fstat(fd_, &sb) == -1) {
-    ::close(fd_);
-    fd_ = -1;
-    return false;
-  }
-
-  length_ = static_cast<size_t>(sb.st_size);
-
-  data_ = mmap(NULL, length_, PROT_READ, MAP_SHARED, fd_, 0);
-  if (data_ == nullptr) {
-    ::close(fd_);
-    fd_ = -1;
-    length_ = 0;
-    return false;
-  }
-
   db_ = std::unique_ptr<ParselessPhraseDB>(new ParselessPhraseDB(
-      static_cast<char*>(data_), length_, /*validate_pragma=*/
-      true));
+      mmapedFile_.data(), mmapedFile_.length(), /*validate_pragma=*/true));
   return true;
 }
 
 void McBopomofo::ParselessLM::close() {
-  if (data_ != nullptr) {
-    munmap(data_, length_);
-    ::close(fd_);
-    fd_ = -1;
-    length_ = 0;
-    data_ = nullptr;
-  }
+  mmapedFile_.close();
+  db_ = nullptr;
 }
 
 std::vector<Formosa::Gramambular2::LanguageModel::Unigram>
 McBopomofo::ParselessLM::getUnigrams(const std::string& key) {
   if (db_ == nullptr) {
-    return std::vector<Formosa::Gramambular2::LanguageModel::Unigram>();
+    return {};
   }
 
   std::vector<Formosa::Gramambular2::LanguageModel::Unigram> results;
@@ -139,7 +110,7 @@ bool McBopomofo::ParselessLM::hasUnigrams(const std::string& key) {
 std::vector<McBopomofo::ParselessLM::FoundReading>
 McBopomofo::ParselessLM::getReadings(const std::string& value) {
   if (db_ == nullptr) {
-    return std::vector<McBopomofo::ParselessLM::FoundReading>();
+    return {};
   }
 
   std::vector<McBopomofo::ParselessLM::FoundReading> results;

--- a/src/Engine/ParselessLM.h
+++ b/src/Engine/ParselessLM.h
@@ -28,6 +28,7 @@
 #include <string>
 #include <vector>
 
+#include "MemoryMappedFile.h"
 #include "ParselessPhraseDB.h"
 #include "gramambular2/language_model.h"
 
@@ -35,10 +36,8 @@ namespace McBopomofo {
 
 class ParselessLM : public Formosa::Gramambular2::LanguageModel {
  public:
-  ~ParselessLM() override;
-
   bool isLoaded();
-  bool open(const std::string_view& path);
+  bool open(const char* path);
   void close();
 
   std::vector<Formosa::Gramambular2::LanguageModel::Unigram> getUnigrams(
@@ -47,15 +46,14 @@ class ParselessLM : public Formosa::Gramambular2::LanguageModel {
 
   struct FoundReading {
     std::string reading;
-    double score;
+    double score = 0;
   };
+
   // Look up reading by value. This is specific to ParselessLM only.
   std::vector<FoundReading> getReadings(const std::string& value);
 
  private:
-  int fd_ = -1;
-  void* data_ = nullptr;
-  size_t length_ = 0;
+  MemoryMappedFile mmapedFile_;
   std::unique_ptr<ParselessPhraseDB> db_;
 };
 

--- a/src/Engine/ParselessPhraseDB.cpp
+++ b/src/Engine/ParselessPhraseDB.cpp
@@ -54,7 +54,7 @@ ParselessPhraseDB::ParselessPhraseDB(const char* buf, size_t length,
 }
 
 std::vector<std::string_view> ParselessPhraseDB::findRows(
-    const std::string_view& key) {
+    const std::string_view& key) const {
   std::vector<std::string_view> rows;
 
   const char* ptr = findFirstMatchingLine(key);
@@ -88,7 +88,7 @@ std::vector<std::string_view> ParselessPhraseDB::findRows(
 // less to the key and the current line starts exactly with the key, then
 // the current line is the first matching line.
 const char* ParselessPhraseDB::findFirstMatchingLine(
-    const std::string_view& key) {
+    const std::string_view& key) const {
   if (key.empty()) {
     return begin_;
   }
@@ -162,7 +162,7 @@ const char* ParselessPhraseDB::findFirstMatchingLine(
 }
 
 std::vector<std::string> ParselessPhraseDB::reverseFindRows(
-    const std::string_view& value) {
+    const std::string_view& value) const {
   std::vector<std::string> rows;
 
   const char* recordBegin = begin_;

--- a/src/Engine/ParselessPhraseDB.h
+++ b/src/Engine/ParselessPhraseDB.h
@@ -46,9 +46,9 @@ class ParselessPhraseDB {
   // Find the rows that match the key. Note that prefix match is used. If you
   // need exact match, the key will need to have a delimiter (usually a space)
   // at the end.
-  std::vector<std::string_view> findRows(const std::string_view& key);
+  std::vector<std::string_view> findRows(const std::string_view& key) const;
 
-  const char* findFirstMatchingLine(const std::string_view& key);
+  const char* findFirstMatchingLine(const std::string_view& key) const;
 
   // Find the rows whose text past the key column plus the field separator
   // is a prefix match of the given value. For example, if the row is
@@ -56,7 +56,7 @@ class ParselessPhraseDB {
   // valid prefix matches, whereas the value "barr" isn't. This performs linear
   // scan since, unlike lookup-by-key, it cannot take advantage of the fact that
   // the underlying data is sorted by keys.
-  std::vector<std::string> reverseFindRows(const std::string_view& value);
+  std::vector<std::string> reverseFindRows(const std::string_view& value) const;
 
   static bool ValidatePragma(const char* buf, size_t length);
 

--- a/src/Engine/PhraseReplacementMap.h
+++ b/src/Engine/PhraseReplacementMap.h
@@ -28,22 +28,19 @@
 #include <map>
 #include <string>
 
+#include "MemoryMappedFile.h"
+
 namespace McBopomofo {
 
 class PhraseReplacementMap {
  public:
-  PhraseReplacementMap();
-  ~PhraseReplacementMap();
-
   bool open(const char* path);
   void close();
-  const std::string valueForKey(const std::string& key);
+  std::string valueForKey(const std::string& key) const;
 
  protected:
-  std::map<std::string_view, std::string_view> keyValueMap;
-  int fd;
-  void* data;
-  size_t length;
+  std::map<std::string_view, std::string_view> keyValueMap_;
+  MemoryMappedFile mmapedFile_;
 };
 
 }  // namespace McBopomofo

--- a/src/Engine/UserPhrasesLM.h
+++ b/src/Engine/UserPhrasesLM.h
@@ -30,19 +30,15 @@
 #include <utility>
 #include <vector>
 
+#include "MemoryMappedFile.h"
 #include "gramambular2/language_model.h"
 
 namespace McBopomofo {
 
 class UserPhrasesLM : public Formosa::Gramambular2::LanguageModel {
  public:
-  UserPhrasesLM();
-  ~UserPhrasesLM() override;
-
-  bool isLoaded();
   bool open(const char* path);
   void close();
-  void dump();
 
   std::vector<Formosa::Gramambular2::LanguageModel::Unigram> getUnigrams(
       const std::string& key) override;
@@ -50,16 +46,13 @@ class UserPhrasesLM : public Formosa::Gramambular2::LanguageModel {
 
  protected:
   struct Row {
-    Row(std::string_view k, std::string_view v)
-        : key(std::move(k)), value(std::move(v)) {}
+    Row(std::string_view k, std::string_view v) : key(k), value(v) {}
     const std::string_view key;
     const std::string_view value;
   };
 
+  MemoryMappedFile mmapedFile_;
   std::map<std::string_view, std::vector<Row>> keyRowMap;
-  int fd;
-  void* data;
-  size_t length;
 };
 
 }  // namespace McBopomofo


### PR DESCRIPTION
This removes the duplicated use of the mmap API. Because MemoryMappedFile self-closes, all ctors and dtors in the affected classes are removed.