### PR TITLE
Improve macro handling of McBopomofoLM and expand test coverage

### DIFF
--- a/src/Engine/CMakeLists.txt
+++ b/src/Engine/CMakeLists.txt
@@ -43,6 +43,7 @@ if (ENABLE_TEST)
         add_executable(McBopomofoLMLibTest
                 AssociatedPhrasesV2Test.cpp
                 KeyValueBlobReaderTest.cpp
+                McBopomofoLMTest.cpp
                 MemoryMappedFileTest.cpp
                 ParselessLMTest.cpp
                 ParselessPhraseDBTest.cpp

--- a/src/Engine/KeyValueBlobReader.h
+++ b/src/Engine/KeyValueBlobReader.h
@@ -74,6 +74,11 @@ class KeyValueBlobReader {
   KeyValueBlobReader(const char* blob, size_t size)
       : current_(blob), end_(blob + size) {}
 
+  KeyValueBlobReader(const KeyValueBlobReader&) = delete;
+  KeyValueBlobReader(KeyValueBlobReader&&) = delete;
+  KeyValueBlobReader& operator=(const KeyValueBlobReader&) = delete;
+  KeyValueBlobReader& operator=(KeyValueBlobReader&&) = delete;
+
   // Parse the next key-value pair and return the state of the reader. If
   // `out` is passed, out will be set to the produced key-value pair if there
   // is one.

--- a/src/Engine/McBopomofoLM.cpp
+++ b/src/Engine/McBopomofoLM.cpp
@@ -245,7 +245,7 @@ McBopomofoLM::filterAndTransformUnigrams(
         value = replacement;
       }
     }
-    if (macroConverter_) {
+    if (macroConverter_ != nullptr) {
       std::string replacement = macroConverter_(value);
       value = replacement;
     }
@@ -256,7 +256,7 @@ McBopomofoLM::filterAndTransformUnigrams(
       continue;
     }
 
-    if (externalConverterEnabled_ && externalConverter_) {
+    if (externalConverterEnabled_ && externalConverter_ != nullptr) {
       std::string replacement = externalConverter_(value);
       value = replacement;
     }

--- a/src/Engine/McBopomofoLM.h
+++ b/src/Engine/McBopomofoLM.h
@@ -24,8 +24,8 @@
 #ifndef SRC_ENGINE_MCBOPOMOFOLM_H_
 #define SRC_ENGINE_MCBOPOMOFOLM_H_
 
-#include <cstdio>
 #include <functional>
+#include <memory>
 #include <string>
 #include <unordered_set>
 #include <vector>
@@ -38,99 +38,85 @@
 
 namespace McBopomofo {
 
-/// McBopomofoLM is a facade for managing a set of models including
-/// the input method language model, user phrases and excluded phrases.
-///
-/// It is the primary model class that the input controller and grammar builder
-/// of McBopomofo talks to. When the grammar builder starts to build a sentence
-/// from a series of BPMF readings, it passes the readings to the model to see
-/// if there are valid unigrams, and use returned unigrams to produce the final
-/// results.
-///
-/// McBopomofoLM combine and transform the unigrams from the primary language
-/// model and user phrases. The process is
-///
-/// 1) Get the original unigrams.
-/// 2) Drop the unigrams whose value is contained in the exclusion map.
-/// 3) Replace the values of the unigrams using the phrase replacement map.
-/// 4) Replace the values of the unigrams using an external converter lambda.
-/// 5) Drop the duplicated phrases.
-///
-/// The controller can ask the model to load the primary input method language
-/// model while launching and to load the user phrases anytime if the custom
-/// files are modified. It does not keep the reference of the data paths but
-/// you have to pass the paths when you ask it to do loading.
+// McBopomofoLM manages the input method's language models and performs text
+// and macro conversions.
+//
+// When the reading grid requests unigrams from McBopomofoLM, the LM combines
+// and transforms the unigrams from the primary language model and user phrases.
+// The process is
+//
+// 1. Get the original unigrams.
+// 2. Drop the unigrams from the user-exclusion list.
+// 3. Replace the unigram values specified by the user phrase replacement map.
+// 4. Transform the unigram values with an external converter, if supplied.
+// 5. Remove any duplicates.
+//
+// McBopomofoLM itself is not responsible for reloading custom models (user
+// phrases, excluded phrases, and replacement map). The LM's owner, usually the
+// input method controller, needs to take care of checking for updates and
+// telling McBopomofoLM to reload as needed.
 class McBopomofoLM : public Formosa::Gramambular2::LanguageModel {
  public:
-  McBopomofoLM();
-  ~McBopomofoLM() override;
+  McBopomofoLM() = default;
 
-  /// Asks to load the primary language model at the given path.
-  /// @param languageModelPath The path of the language model.
+  McBopomofoLM(const McBopomofoLM&) = delete;
+  McBopomofoLM(McBopomofoLM&&) = delete;
+  McBopomofoLM& operator=(const McBopomofoLM&) = delete;
+  McBopomofoLM& operator=(McBopomofoLM&&) = delete;
+
+  // Loads (or reloads, if already loaded) the primary language model data file.
   void loadLanguageModel(const char* languageModelDataPath);
-  /// If the data model is already loaded.
+
   bool isDataModelLoaded();
 
-  /// Asks to load the associated phrases at the given path.
-  /// @param associatedPhrasesPath The path of the associated phrases.
-  void loadAssociatedPhrases(const char* associatedPhrasesPath);
-
-  /// If the associated phrases already loaded.
-  bool isAssociatedPhrasesLoaded();
-
+  // Loads (or reloads if already loaded) the associated phrases data file.
   void loadAssociatedPhrasesV2(const char* associatedPhrasesPath);
 
-  /// Asks to load the user phrases and excluded phrases at the given path.
-  /// @param userPhrasesPath The path of user phrases.
-  /// @param excludedPhrasesPath The path of excluded phrases.
+  // Loads (or reloads if already loaded) both the user phrases and the excluded
+  // phrases files. If one argument is passed a nullptr, that file will not
+  // be loaded or reloaded.
   void loadUserPhrases(const char* userPhrasesDataPath,
                        const char* excludedPhrasesDataPath);
-  /// Asks to load th phrase replacement table at the given path.
-  /// @param phraseReplacementPath The path of the phrase replacement table.
+
+  // Loads (or reloads if already loaded) the phrase replacement mapping file.
   void loadPhraseReplacementMap(const char* phraseReplacementPath);
 
-  /// Returns a list of available unigram for the given key.
-  /// @param key A string represents the BPMF reading or a symbol key. For
-  ///     example, it you pass "ㄇㄚ", it returns "嗎", "媽", and so on.
+  // Returns a list of unigrams for the reading. For example, if the reading is
+  // "ㄇㄚ", the return may be [unigram("嗎"), unigram("媽") and so on.
   std::vector<Formosa::Gramambular2::LanguageModel::Unigram> getUnigrams(
       const std::string& key) override;
-  /// If the model has unigrams for the given key.
-  /// @param key The key.
+
   bool hasUnigrams(const std::string& key) override;
 
-  /// Enables or disables phrase replacement.
-  void setPhraseReplacementEnabled(bool enabled);
-  /// If phrase replacement is enabled or not.
-  bool phraseReplacementEnabled() const;
-
-  /// Enables or disables the external converter.
-  void setExternalConverterEnabled(bool enabled);
-  /// If the external converted is enabled or not.
-  bool externalConverterEnabled() const;
-  /// Sets a lambda to let the values of unigrams could be converted by it.
-  void setExternalConverter(
-      std::function<std::string(const std::string&)> externalConverter);
-
-  /// Sets a lambda to convert the macro to a string.
-  void setMacroConverter(
-      std::function<std::string(const std::string&)> macroConverter);
-  std::string convertMacro(const std::string& input);
+  std::string getReading(const std::string& value) const;
 
   std::vector<AssociatedPhrasesV2::Phrase> findAssociatedPhrasesV2(
       const std::string& prefixValue,
       const std::vector<std::string>& prefixReadings) const;
 
-  /// Returns the top-scored reading from the base model, given the value.
-  std::string getReading(const std::string& value);
+  void setPhraseReplacementEnabled(bool enabled);
+  bool phraseReplacementEnabled() const;
+
+  void setExternalConverterEnabled(bool enabled);
+  bool externalConverterEnabled() const;
+  void setExternalConverter(
+      std::function<std::string(const std::string&)> externalConverter);
+
+  void setMacroConverter(
+      std::function<std::string(const std::string&)> macroConverter);
+  std::string convertMacro(const std::string& input);
+
+  // Methods to allow loading in-memory data for testing purposes.
+  void loadLanguageModel(std::unique_ptr<ParselessPhraseDB> db);
+  void loadAssociatedPhrasesV2(std::unique_ptr<ParselessPhraseDB> db);
+  void loadUserPhrases(const char* data, size_t length);
+  void loadExcludedPhrases(const char* data, size_t length);
+  void loadPhraseReplacementMap(const char* data, size_t length);
 
  protected:
-  /// Filters and converts the input unigrams and return a new list of unigrams.
-  ///
-  /// @param unigrams The unigrams to be processed.
-  /// @param excludedValues The values to excluded unigrams.
-  /// @param insertedValues The values for unigrams already in the results.
-  ///   It helps to prevent duplicated unigrams. Please note that the method
-  ///   has a side effect that it inserts values to `insertedValues`.
+  // Filters and converts the input unigrams and returns a new list of unigrams.
+  // Unigrams whose values are found in `excludedValues` are removed, and the
+  // kept values will be inserted to the `insertedValues` set.
   std::vector<Formosa::Gramambular2::LanguageModel::Unigram>
   filterAndTransformUnigrams(
       const std::vector<Formosa::Gramambular2::LanguageModel::Unigram> unigrams,
@@ -143,11 +129,14 @@ class McBopomofoLM : public Formosa::Gramambular2::LanguageModel {
   PhraseReplacementMap phraseReplacement_;
   AssociatedPhrasesV2 associatedPhrasesV2_;
 
-  std::function<std::string(const std::string&)> macroConverter_;
-  bool phraseReplacementEnabled_;
-  bool externalConverterEnabled_;
+  bool phraseReplacementEnabled_ = false;
+
+  bool externalConverterEnabled_ = false;
   std::function<std::string(const std::string&)> externalConverter_;
+
+  std::function<std::string(const std::string&)> macroConverter_;
 };
+
 }  // namespace McBopomofo
 
 #endif  // SRC_ENGINE_MCBOPOMOFOLM_H_

--- a/src/Engine/McBopomofoLMTest.cpp
+++ b/src/Engine/McBopomofoLMTest.cpp
@@ -1,0 +1,284 @@
+// Copyright (c) 2024 and onwards The McBopomofo Authors.
+//
+// Permission is hereby granted, free of charge, to any person
+// obtaining a copy of this software and associated documentation
+// files (the "Software"), to deal in the Software without
+// restriction, including without limitation the rights to use,
+// copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following
+// conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+// OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+// HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+// OTHER DEALINGS IN THE SOFTWARE.
+
+#include <cmath>
+#include <string>
+
+#include "McBopomofoLM.h"
+#include "gtest/gtest.h"
+
+namespace McBopomofo {
+
+constexpr char kPrimaryLMData[] = R"(
+# format org.openvanilla.mcbopomofo.sorted
+ㄇㄧㄥˊ 明 -3.07936356
+ㄇㄧㄥˊ 名 -3.12166252
+ㄇㄧㄥˊ 銘 -4.43019121
+ㄇㄧㄥˊ-ㄘˊ 名詞 -4.61364867
+ㄇㄧㄥˊ-ㄘˋ 名次 -5.47446950
+ㄉㄨㄥˋ 動 -2.83459585
+ㄉㄨㄥˋ 洞 -4.31757780
+ㄉㄨㄥˋ-ㄗㄨㄛˋ 動作 -4.17449149
+ㄐㄧㄣ-ㄊㄧㄢ 今天 -3.28959497
+ㄐㄧㄣ-ㄊㄧㄢ MACRO@DATE_TODAY_SHORT -8
+ㄐㄧㄣ-ㄊㄧㄢ MACRO@DATE_TODAY_MEDIUM -8
+ㄔㄥˊ-ㄕˋ 城市 -3.98856498
+ㄔㄥˊ-ㄕˋ 程式 -4.07624939
+ㄔㄥˊ-ㄕˋ 成事 -5.88664994
+ㄙㄜˋ-ㄍㄨˇ 澀谷 -6.78973993
+ㄙㄜˋ-ㄍㄨˇ 渋谷 -6.78973993
+)";
+
+constexpr char kAssociatedPhrasesV2Data[] = R"(
+# format org.openvanilla.mcbopomofo.sorted
+名-ㄇㄧㄥˊ-下-ㄒㄧㄚˋ -5.7106
+名-ㄇㄧㄥˊ-不-ㄅㄨˊ-見-ㄐㄧㄢˋ-經-ㄐㄧㄥ-傳-ㄓㄨㄢˋ -5.9904
+)";
+
+constexpr char kUserPhrasesData[] = R"(
+茗 ㄇㄧㄥˊ
+丼 ㄉㄨㄥˋ
+名刺 ㄇㄧㄥˊ-ㄘˋ
+程式 ㄔㄥˊ-ㄕˋ
+)";
+
+constexpr char kExcludedPhrasesData[] = R"(
+動作 ㄉㄨㄥˋ-ㄗㄨㄛˋ
+)";
+
+constexpr char kPhreaseReplacementMapData[] = R"(
+動作 动作
+澀谷 渋谷
+)";
+
+TEST(McBopomofoLMTest, PrimaryLanguageModel) {
+  McBopomofoLM lm;
+  auto db = std::make_unique<ParselessPhraseDB>(kPrimaryLMData,
+                                                sizeof(kPrimaryLMData));
+  lm.loadLanguageModel(std::move(db));
+
+  EXPECT_TRUE(lm.hasUnigrams("ㄇㄧㄥˊ-ㄘˊ"));
+  EXPECT_FALSE(lm.hasUnigrams("ㄉㄨㄥˋ-ㄘˊ"));
+  auto unigrams = lm.getUnigrams("ㄇㄧㄥˊ-ㄘˊ");
+  ASSERT_FALSE(unigrams.empty());
+  EXPECT_EQ(unigrams[0].value(), "名詞");
+  EXPECT_LT(unigrams[0].score(), 0);
+}
+
+TEST(McBopomofoLMTest, AssociatedPhrasesV2) {
+  McBopomofoLM lm;
+  auto db = std::make_unique<ParselessPhraseDB>(
+      kAssociatedPhrasesV2Data, sizeof(kAssociatedPhrasesV2Data));
+  lm.loadAssociatedPhrasesV2(std::move(db));
+
+  auto phrases = lm.findAssociatedPhrasesV2("名", {"ㄇㄧㄥˊ"});
+  EXPECT_FALSE(phrases.empty());
+  EXPECT_EQ(phrases[0].value, "名下");
+  EXPECT_EQ(phrases[0].readings,
+            (std::vector<std::string>{"ㄇㄧㄥˊ", "ㄒㄧㄚˋ"}));
+
+  EXPECT_TRUE(lm.findAssociatedPhrasesV2("銘", {"ㄇㄧㄥˊ"}).empty());
+}
+
+TEST(McBopomofoLMTest, UserPhrases) {
+  McBopomofoLM lm;
+  auto db = std::make_unique<ParselessPhraseDB>(kPrimaryLMData,
+                                                sizeof(kPrimaryLMData));
+  lm.loadLanguageModel(std::move(db));
+  lm.loadUserPhrases(kUserPhrasesData, sizeof(kUserPhrasesData));
+
+  auto unigrams = lm.getUnigrams("ㄇㄧㄥˊ");
+  ASSERT_FALSE(unigrams.empty());
+  EXPECT_EQ(unigrams[0].value(), "茗");
+}
+
+TEST(McBopomofoLMTest, ExcludedPhrases) {
+  McBopomofoLM lm;
+  auto db = std::make_unique<ParselessPhraseDB>(kPrimaryLMData,
+                                                sizeof(kPrimaryLMData));
+  lm.loadLanguageModel(std::move(db));
+
+  auto unigrams = lm.getUnigrams("ㄉㄨㄥˋ-ㄗㄨㄛˋ");
+  EXPECT_FALSE(unigrams.empty());
+
+  lm.loadExcludedPhrases(kExcludedPhrasesData, sizeof(kExcludedPhrasesData));
+  unigrams = lm.getUnigrams("ㄉㄨㄥˋ-ㄗㄨㄛˋ");
+  EXPECT_TRUE(unigrams.empty());
+}
+
+TEST(McBopomofoLMTest, PhraseReplacementMap) {
+  McBopomofoLM lm;
+  auto db = std::make_unique<ParselessPhraseDB>(kPrimaryLMData,
+                                                sizeof(kPrimaryLMData));
+  lm.loadLanguageModel(std::move(db));
+  lm.loadPhraseReplacementMap(kPhreaseReplacementMapData,
+                              sizeof(kPhreaseReplacementMapData));
+  auto unigrams = lm.getUnigrams("ㄉㄨㄥˋ-ㄗㄨㄛˋ");
+  ASSERT_FALSE(unigrams.empty());
+  EXPECT_EQ(unigrams[0].value(), "動作");
+
+  lm.setPhraseReplacementEnabled(true);
+  unigrams = lm.getUnigrams("ㄉㄨㄥˋ-ㄗㄨㄛˋ");
+  ASSERT_FALSE(unigrams.empty());
+  EXPECT_EQ(unigrams[0].value(), "动作");
+}
+
+TEST(McBopomofoLMTest, PhraseReplacementMapDeduplicates) {
+  McBopomofoLM lm;
+  auto db = std::make_unique<ParselessPhraseDB>(kPrimaryLMData,
+                                                sizeof(kPrimaryLMData));
+  lm.loadLanguageModel(std::move(db));
+  lm.loadPhraseReplacementMap(kPhreaseReplacementMapData,
+                              sizeof(kPhreaseReplacementMapData));
+  auto unigrams = lm.getUnigrams("ㄙㄜˋ-ㄍㄨˇ");
+  EXPECT_EQ(unigrams.size(), 2);
+
+  lm.setPhraseReplacementEnabled(true);
+  unigrams = lm.getUnigrams("ㄙㄜˋ-ㄍㄨˇ");
+  ASSERT_EQ(unigrams.size(), 1);
+  EXPECT_EQ(unigrams[0].value(), "渋谷");
+}
+
+TEST(McBopomofoLMTest, UserPhrasesOverrideDefaultLanguageModelPhrases) {
+  McBopomofoLM lm;
+  auto db = std::make_unique<ParselessPhraseDB>(kPrimaryLMData,
+                                                sizeof(kPrimaryLMData));
+  lm.loadLanguageModel(std::move(db));
+  auto unigrams = lm.getUnigrams("ㄔㄥˊ-ㄕˋ");
+  ASSERT_FALSE(unigrams.empty());
+  EXPECT_EQ(unigrams[0].value(), "城市");
+
+  lm.loadUserPhrases(kUserPhrasesData, sizeof(kUserPhrasesData));
+  unigrams = lm.getUnigrams("ㄔㄥˊ-ㄕˋ");
+  ASSERT_FALSE(unigrams.empty());
+  EXPECT_EQ(unigrams[0].value(), "程式");
+}
+
+TEST(McBopomofoLMTest, MonoSyllableUserPhrasesNeedRewrite) {
+  McBopomofoLM lm;
+  auto db = std::make_unique<ParselessPhraseDB>(kPrimaryLMData,
+                                                sizeof(kPrimaryLMData));
+  lm.loadLanguageModel(std::move(db));
+  lm.loadUserPhrases(kUserPhrasesData, sizeof(kUserPhrasesData));
+
+  auto unigrams = lm.getUnigrams("ㄉㄨㄥˋ");
+  ASSERT_FALSE(unigrams.empty());
+  EXPECT_EQ(unigrams[0].value(), "丼");
+  EXPECT_LT(unigrams[0].score(), 0);  // note: this is not 0!
+  EXPECT_GT(unigrams[0].score(), unigrams[1].score());
+  // The delta between the two should be miniscule.
+  EXPECT_LT(std::abs(unigrams[0].score() - unigrams[1].score()), 0.000001);
+}
+
+TEST(McBopomofoLMTest, MultipleSyllableUserPhrasesNeedNoRewrite) {
+  McBopomofoLM lm;
+  auto db = std::make_unique<ParselessPhraseDB>(kPrimaryLMData,
+                                                sizeof(kPrimaryLMData));
+  lm.loadLanguageModel(std::move(db));
+  lm.loadUserPhrases(kUserPhrasesData, sizeof(kUserPhrasesData));
+
+  auto unigrams = lm.getUnigrams("ㄇㄧㄥˊ-ㄘˋ");
+  ASSERT_FALSE(unigrams.empty());
+  EXPECT_EQ(unigrams[0].value(), "名刺");
+  EXPECT_EQ(unigrams[0].score(), 0);  // note: this is 0!
+  EXPECT_EQ(unigrams[1].value(), "名次");
+  EXPECT_LT(unigrams[1].score(), 0);
+}
+
+TEST(McBopomofoLMTest, ExternalConverterWhenNotSetThenEnablingItIsNoOp) {
+  McBopomofoLM lm;
+  auto db = std::make_unique<ParselessPhraseDB>(kPrimaryLMData,
+                                                sizeof(kPrimaryLMData));
+  lm.loadLanguageModel(std::move(db));
+  lm.setExternalConverterEnabled(true);
+
+  auto unigrams = lm.getUnigrams("ㄇㄧㄥˊ-ㄘˊ");
+  ASSERT_FALSE(unigrams.empty());
+  EXPECT_EQ(unigrams[0].value(), "名詞");
+}
+
+TEST(McBopomofoLMTest, ExternalConverter) {
+  McBopomofoLM lm;
+  auto db = std::make_unique<ParselessPhraseDB>(kPrimaryLMData,
+                                                sizeof(kPrimaryLMData));
+  lm.loadLanguageModel(std::move(db));
+
+  auto unigrams = lm.getUnigrams("ㄇㄧㄥˊ-ㄘˊ");
+  ASSERT_FALSE(unigrams.empty());
+  EXPECT_EQ(unigrams[0].value(), "名詞");
+
+  lm.setExternalConverterEnabled(true);
+  lm.setExternalConverter([](const auto& value) { return value + "!"; });
+
+  unigrams = lm.getUnigrams("ㄇㄧㄥˊ-ㄘˊ");
+  ASSERT_FALSE(unigrams.empty());
+  EXPECT_EQ(unigrams[0].value(), "名詞!");
+}
+
+TEST(McBopomofoLMTest, ExternalConverterConversionResultsAreDeduplicated) {
+  McBopomofoLM lm;
+  auto db = std::make_unique<ParselessPhraseDB>(kPrimaryLMData,
+                                                sizeof(kPrimaryLMData));
+  lm.loadLanguageModel(std::move(db));
+
+  auto unigrams = lm.getUnigrams("ㄇㄧㄥˊ");
+  ASSERT_GT(unigrams.size(), 1);
+
+  lm.setExternalConverterEnabled(true);
+  lm.setExternalConverter([](const auto&) { return "!"; });
+
+  unigrams = lm.getUnigrams("ㄇㄧㄥˊ");
+  ASSERT_EQ(unigrams.size(), 1);
+  EXPECT_EQ(unigrams[0].value(), "!");
+}
+
+TEST(McBopomofoLMTest, DefaultMacroConverterIsNoOp) {
+  McBopomofoLM lm;
+  auto db = std::make_unique<ParselessPhraseDB>(kPrimaryLMData,
+                                                sizeof(kPrimaryLMData));
+  lm.loadLanguageModel(std::move(db));
+
+  ASSERT_EQ(lm.convertMacro("MACRO@DATE_TODAY_SHORT"),
+            "MACRO@DATE_TODAY_SHORT");
+}
+
+TEST(McBopomofoLMTest, MacroValueNotRecognizedByMacroConverterIsFiltered) {
+  McBopomofoLM lm;
+  auto db = std::make_unique<ParselessPhraseDB>(kPrimaryLMData,
+                                                sizeof(kPrimaryLMData));
+  lm.loadLanguageModel(std::move(db));
+
+  lm.setMacroConverter([](const std::string& macro) {
+    if (macro == "MACRO@DATE_TODAY_SHORT") {
+      return std::string("6/10/21");
+    }
+    return macro;
+  });
+
+  auto unigrams = lm.getUnigrams("ㄐㄧㄣ-ㄊㄧㄢ");
+  ASSERT_EQ(unigrams.size(), 2);  // only one macro is supported
+  EXPECT_EQ(unigrams[0].value(), "今天");
+  EXPECT_EQ(unigrams[1].value(), "6/10/21");
+}
+
+}  // namespace McBopomofo

--- a/src/Engine/McBopomofoLMTest.cpp
+++ b/src/Engine/McBopomofoLMTest.cpp
@@ -184,9 +184,10 @@ TEST(McBopomofoLMTest, MonoSyllableUserPhrasesNeedRewrite) {
   auto unigrams = lm.getUnigrams("ㄉㄨㄥˋ");
   ASSERT_FALSE(unigrams.empty());
   EXPECT_EQ(unigrams[0].value(), "丼");
-  EXPECT_LT(unigrams[0].score(), 0);  // note: this is not 0!
+  // This user unigram's score is recomputed and must be < kUserUnigramScore.
+  EXPECT_LT(unigrams[0].score(), UserPhrasesLM::kUserUnigramScore);
   EXPECT_GT(unigrams[0].score(), unigrams[1].score());
-  // The delta between the two should be miniscule.
+  // The delta between the two should be minuscule.
   EXPECT_LT(std::abs(unigrams[0].score() - unigrams[1].score()), 0.000001);
 }
 
@@ -200,7 +201,8 @@ TEST(McBopomofoLMTest, MultipleSyllableUserPhrasesNeedNoRewrite) {
   auto unigrams = lm.getUnigrams("ㄇㄧㄥˊ-ㄘˋ");
   ASSERT_FALSE(unigrams.empty());
   EXPECT_EQ(unigrams[0].value(), "名刺");
-  EXPECT_EQ(unigrams[0].score(), 0);  // note: this is 0!
+  // This user unigram's score is not recomputed, so is still kUserUnigramScore.
+  EXPECT_EQ(unigrams[0].score(), UserPhrasesLM::kUserUnigramScore);
   EXPECT_EQ(unigrams[1].value(), "名次");
   EXPECT_LT(unigrams[1].score(), 0);
 }

--- a/src/Engine/MemoryMappedFile.cpp
+++ b/src/Engine/MemoryMappedFile.cpp
@@ -28,7 +28,23 @@
 #include <sys/stat.h>
 #include <unistd.h>
 
+#include <utility>
+
 namespace McBopomofo {
+
+MemoryMappedFile::MemoryMappedFile(MemoryMappedFile&& other) noexcept
+    : fd_(std::exchange(other.fd_, -1)),
+      data_(std::exchange(other.data_, nullptr)),
+      length_(std::exchange(other.length_, -1)) {}
+
+MemoryMappedFile& MemoryMappedFile::operator=(
+    MemoryMappedFile&& other) noexcept {
+  close();
+  fd_ = std::exchange(other.fd_, -1);
+  data_ = std::exchange(other.data_, nullptr);
+  length_ = std::exchange(other.length_, 0);
+  return *this;
+}
 
 MemoryMappedFile::~MemoryMappedFile() { close(); }
 

--- a/src/Engine/MemoryMappedFile.h
+++ b/src/Engine/MemoryMappedFile.h
@@ -28,9 +28,22 @@
 
 namespace McBopomofo {
 
-// A wrapper for managing a memory-mapped file. Access is read-only.
+// A wrapper for managing a memory-mapped file.
+//
+// On POSIX systems, we obtain a readable (PROT_READ) shared page (MAP_SHARED),
+// and *file content* changes are reflected in the mapped memory. This class
+// does not track the underlying file: it is up to the user of this class to
+// decide what to do when the underlying file gets updated, resized, or removed.
 class MemoryMappedFile {
  public:
+  MemoryMappedFile() = default;
+  MemoryMappedFile(MemoryMappedFile&& other) noexcept;
+  MemoryMappedFile& operator=(MemoryMappedFile&& other) noexcept;
+
+  // Forbids copying.
+  MemoryMappedFile& operator=(const MemoryMappedFile&) = delete;
+  MemoryMappedFile(const MemoryMappedFile&) = delete;
+
   ~MemoryMappedFile();
   bool open(const char* path);
   void close();

--- a/src/Engine/ParselessLM.h
+++ b/src/Engine/ParselessLM.h
@@ -36,9 +36,18 @@ namespace McBopomofo {
 
 class ParselessLM : public Formosa::Gramambular2::LanguageModel {
  public:
+  ParselessLM() = default;
+  ParselessLM(const ParselessLM&) = delete;
+  ParselessLM(ParselessLM&&) = delete;
+  ParselessLM& operator=(const ParselessLM&) = delete;
+  ParselessLM& operator=(ParselessLM&&) = delete;
+
   bool isLoaded();
   bool open(const char* path);
   void close();
+
+  // Allows the use of existing in-memory db.
+  bool open(std::unique_ptr<ParselessPhraseDB> db);
 
   std::vector<Formosa::Gramambular2::LanguageModel::Unigram> getUnigrams(
       const std::string& key) override;
@@ -50,7 +59,7 @@ class ParselessLM : public Formosa::Gramambular2::LanguageModel {
   };
 
   // Look up reading by value. This is specific to ParselessLM only.
-  std::vector<FoundReading> getReadings(const std::string& value);
+  std::vector<FoundReading> getReadings(const std::string& value) const;
 
  private:
   MemoryMappedFile mmapedFile_;

--- a/src/Engine/ParselessPhraseDB.h
+++ b/src/Engine/ParselessPhraseDB.h
@@ -43,6 +43,11 @@ class ParselessPhraseDB {
   ParselessPhraseDB(const char* buf, size_t length,
                     bool validate_pragma = false);
 
+  ParselessPhraseDB(const ParselessPhraseDB&) = delete;
+  ParselessPhraseDB(ParselessPhraseDB&&) = delete;
+  ParselessPhraseDB& operator=(const ParselessPhraseDB&) = delete;
+  ParselessPhraseDB& operator=(ParselessPhraseDB&&) = delete;
+
   // Find the rows that match the key. Note that prefix match is used. If you
   // need exact match, the key will need to have a delimiter (usually a space)
   // at the end.

--- a/src/Engine/PhraseReplacementMap.h
+++ b/src/Engine/PhraseReplacementMap.h
@@ -34,8 +34,19 @@ namespace McBopomofo {
 
 class PhraseReplacementMap {
  public:
+  PhraseReplacementMap() = default;
+  PhraseReplacementMap(const PhraseReplacementMap&) = delete;
+  PhraseReplacementMap(PhraseReplacementMap&&) = delete;
+  PhraseReplacementMap& operator=(const PhraseReplacementMap&) = delete;
+  PhraseReplacementMap& operator=(PhraseReplacementMap&&) = delete;
+
   bool open(const char* path);
   void close();
+
+  // Allows loading existing in-memory data. It's the caller's responsibility
+  // to make sure that data outlives this instance.
+  bool load(const char* data, size_t length);
+
   std::string valueForKey(const std::string& key) const;
 
  protected:

--- a/src/Engine/PhraseReplacementMapTest.cpp
+++ b/src/Engine/PhraseReplacementMapTest.cpp
@@ -31,27 +31,15 @@
 namespace McBopomofo {
 
 TEST(PhraseReplacementMapTest, LenientReading) {
-  std::string tmp_name =
-      std::string(std::filesystem::temp_directory_path() / "test.txt");
-  FILE* f = fopen(tmp_name.c_str(), "w");
-  ASSERT_NE(f, nullptr);
-
-  fprintf(f, "key value\n");
-  fprintf(f, "key2\n");  // error line
-  fprintf(f, "key3 value2\n");
-  int r = fclose(f);
-  ASSERT_EQ(r, 0);
+  constexpr char kTestData[] = "key value\nkey2\nkey3 value3";
 
   PhraseReplacementMap map;
-  map.open(tmp_name.c_str());
+  ASSERT_TRUE(map.load(kTestData, sizeof(kTestData)));
   ASSERT_EQ(map.valueForKey("key"), "value");
-  ASSERT_EQ(map.valueForKey("key2"), "");
+  ASSERT_TRUE(map.valueForKey("key2").empty());
 
   // key2 causes parsing error, and the line that has key3 won't be parsed.
-  ASSERT_EQ(map.valueForKey("key3"), "");
-
-  r = remove(tmp_name.c_str());
-  ASSERT_EQ(r, 0);
+  ASSERT_TRUE(map.valueForKey("key3").empty());
 }
 
 }  // namespace McBopomofo

--- a/src/Engine/UserPhrasesLM.cpp
+++ b/src/Engine/UserPhrasesLM.cpp
@@ -40,19 +40,32 @@ bool UserPhrasesLM::open(const char* path) {
     return false;
   }
 
-  KeyValueBlobReader reader(mmapedFile_.data(), mmapedFile_.length());
-  KeyValueBlobReader::KeyValue keyValue;
-  while (reader.Next(&keyValue) == KeyValueBlobReader::State::HAS_PAIR) {
-    // We invert the key and value, since in user phrases, "key" is the phrase
-    // value, and "value" is the BPMF reading.
-    keyRowMap[keyValue.value].emplace_back(keyValue.value, keyValue.key);
-  }
-  return true;
+  // MemoryMappedFile self-closes, and so this is fine.
+  return load(mmapedFile_.data(), mmapedFile_.length());
 }
 
 void UserPhrasesLM::close() {
-  mmapedFile_.close();
   keyRowMap.clear();
+  mmapedFile_.close();
+}
+
+bool UserPhrasesLM::load(const char* data, size_t length) {
+  if (data == nullptr || length == 0) {
+    return false;
+  }
+
+  keyRowMap.clear();
+
+  KeyValueBlobReader reader(data, length);
+  KeyValueBlobReader::KeyValue keyValue;
+  while (reader.Next(&keyValue) == KeyValueBlobReader::State::HAS_PAIR) {
+    // The format of the user phrases files is a bit different. The first column
+    // is the phrase (value) and the second column is the Bopofomo reading. The
+    // KeyValueBlobReader::KeyValue's value is the second column, that's why
+    // it's used as the key of the keyRowMap here.
+    keyRowMap[keyValue.value].emplace_back(keyValue.key);
+  }
+  return true;
 }
 
 std::vector<Formosa::Gramambular2::LanguageModel::Unigram>
@@ -60,9 +73,9 @@ UserPhrasesLM::getUnigrams(const std::string& key) {
   std::vector<Formosa::Gramambular2::LanguageModel::Unigram> v;
   auto iter = keyRowMap.find(key);
   if (iter != keyRowMap.end()) {
-    const std::vector<Row>& rows = iter->second;
-    for (const auto& row : rows) {
-      v.emplace_back(std::string(row.value), 0);
+    const std::vector<std::string_view>& values = iter->second;
+    for (const auto& value : values) {
+      v.emplace_back(std::string(value), kUserUnigramScore);
     }
   }
 

--- a/src/Engine/UserPhrasesLM.h
+++ b/src/Engine/UserPhrasesLM.h
@@ -54,9 +54,9 @@ class UserPhrasesLM : public Formosa::Gramambular2::LanguageModel {
       const std::string& key) override;
   bool hasUnigrams(const std::string& key) override;
 
- protected:
   static constexpr double kUserUnigramScore = 0;
 
+ protected:
   MemoryMappedFile mmapedFile_;
   std::map<std::string_view, std::vector<std::string_view>> keyRowMap;
 };

--- a/src/Engine/UserPhrasesLM.h
+++ b/src/Engine/UserPhrasesLM.h
@@ -37,22 +37,28 @@ namespace McBopomofo {
 
 class UserPhrasesLM : public Formosa::Gramambular2::LanguageModel {
  public:
+  UserPhrasesLM() = default;
+  UserPhrasesLM(const UserPhrasesLM&) = delete;
+  UserPhrasesLM(UserPhrasesLM&&) = delete;
+  UserPhrasesLM& operator=(const UserPhrasesLM&) = delete;
+  UserPhrasesLM& operator=(UserPhrasesLM&&) = delete;
+
   bool open(const char* path);
   void close();
+
+  // Allows loading existing in-memory data. It's the caller's responsibility
+  // to make sure that data outlives this instance.
+  bool load(const char* data, size_t length);
 
   std::vector<Formosa::Gramambular2::LanguageModel::Unigram> getUnigrams(
       const std::string& key) override;
   bool hasUnigrams(const std::string& key) override;
 
  protected:
-  struct Row {
-    Row(std::string_view k, std::string_view v) : key(k), value(v) {}
-    const std::string_view key;
-    const std::string_view value;
-  };
+  static constexpr double kUserUnigramScore = 0;
 
   MemoryMappedFile mmapedFile_;
-  std::map<std::string_view, std::vector<Row>> keyRowMap;
+  std::map<std::string_view, std::vector<std::string_view>> keyRowMap;
 };
 
 }  // namespace McBopomofo

--- a/src/Engine/UserPhrasesLMTest.cpp
+++ b/src/Engine/UserPhrasesLMTest.cpp
@@ -31,28 +31,19 @@
 namespace McBopomofo {
 
 TEST(UserPhrasesLMTest, LenientReading) {
-  std::string tmp_name =
-      std::string(std::filesystem::temp_directory_path() / "test.txt");
-
-  FILE* f = fopen(tmp_name.c_str(), "w");
-  ASSERT_NE(f, nullptr);
-
-  fprintf(f, "value1 reading1\n");
-  fprintf(f, "value2 \n");  // error line
-  fprintf(f, "value3 reading2\n");
-  int r = fclose(f);
-  ASSERT_EQ(r, 0);
+  constexpr char kTestData[] = "value1 reading1\nvalue2 \nvalue3 reading2";
 
   UserPhrasesLM lm;
-  lm.open(tmp_name.c_str());
-  ASSERT_TRUE(lm.hasUnigrams("reading1"));
-  ASSERT_FALSE(lm.hasUnigrams("value2"));
+  ASSERT_TRUE(lm.load(kTestData, sizeof(kTestData)));
+  EXPECT_TRUE(lm.hasUnigrams("reading1"));
+  EXPECT_FALSE(lm.hasUnigrams("value2"));
 
   // Anything after the error won't be parsed, so reading2 won't be found.
-  ASSERT_FALSE(lm.hasUnigrams("reading2"));
+  EXPECT_FALSE(lm.hasUnigrams("reading2"));
 
-  r = remove(tmp_name.c_str());
-  ASSERT_EQ(r, 0);
+  std::vector<Formosa::Gramambular2::LanguageModel::Unigram> results =
+      lm.getUnigrams("reading1");
+  EXPECT_EQ(results[0].value(), "value1");
 }
 
 }  // namespace McBopomofo

--- a/src/Engine/UserPhrasesLMTest.cpp
+++ b/src/Engine/UserPhrasesLMTest.cpp
@@ -44,6 +44,7 @@ TEST(UserPhrasesLMTest, LenientReading) {
   std::vector<Formosa::Gramambular2::LanguageModel::Unigram> results =
       lm.getUnigrams("reading1");
   EXPECT_EQ(results[0].value(), "value1");
+  EXPECT_EQ(results[0].score(), UserPhrasesLM::kUserUnigramScore);
 }
 
 }  // namespace McBopomofo


### PR DESCRIPTION
After this PR, every class in Engine/ will have a test.

Other than that, two notable changes:

1. We now disallow copying and/or moving from many classes, therefore eliminating a source of potential mistakes.
2. If a macro (such as `MACRO@DATE_TODAY_SHORT`) is not handled by the macro converter, we discard the unigram value. This actually implies that it's no longer critical to ensure macros are supported across the board (see #100), as macros not supported/implemented on one platform will simply not be shown as `MACRO@FOOBAR` in the candidate list. @zonble FYI.

I also used the opportunity to audit our mmap and `std::string_view` uses, and have clarified the mmap contract—we map a readable, shared page, but `MemoryMappedFile` class itself does not track and won't be aware of file changes. Not that it would affect McBopomofo's existing behavior, but it's good to state the contract more explicitly.
