### PR TITLE
Update Archlinux PKGBUILD

### DIFF
--- a/distro/archlinux/PKGBUILD
+++ b/distro/archlinux/PKGBUILD
@@ -2,7 +2,7 @@
 # Contributor: xatier
 _pkgname=fcitx5-mcbopomofo
 pkgname=fcitx5-mcbopomofo-git
-pkgver=2.5.2.r176.gf1aab54
+pkgver=2.7.r0.g6e3ab94
 pkgrel=1
 pkgdesc="McBopomofo for fcitx5"
 arch=('x86_64')


### PR DESCRIPTION
@xatier this is effectively the same as https://github.com/openvanilla/fcitx5-mcbopomofo/pull/136 just that it now uses the 2.7 release tag. PTAL, thanks!
