### PR TITLE
Skip an assertion test when built as Release

### DIFF
--- a/src/Engine/ParselessPhraseDBTest.cpp
+++ b/src/Engine/ParselessPhraseDBTest.cpp
@@ -119,6 +119,10 @@ TEST(ParselessPhraseDBTest, FindFirstMatchingLineLongerExample) {
 }
 
 TEST(ParselessPhraseDBTest, InvalidConstructorArguments) {
+#ifdef NDEBUG
+  GTEST_SKIP();
+#endif
+
   EXPECT_DEATH((ParselessPhraseDB{nullptr, 1}), "buf != nullptr");
   EXPECT_DEATH((ParselessPhraseDB{nullptr, 0}), "buf != nullptr");
   EXPECT_DEATH((ParselessPhraseDB{"", 0}), "length > 0");


### PR DESCRIPTION
For the longest time this test failed if the binary was built as release, since C `assert` is no-op when `NDEBUG` is defined. Our CI action runs the tests with the Debug build. This just removes a minor annoyance when we try to run `ctest` with a release build.
