### PR TITLE
Support phrases replacement

### DIFF
--- a/src/Engine/PhraseReplacementMap.cpp
+++ b/src/Engine/PhraseReplacementMap.cpp
@@ -49,11 +49,6 @@ void PhraseReplacementMap::close() {
 }
 
 bool PhraseReplacementMap::load(const char* data, size_t length) {
-  if (mmapedFile_.data() != nullptr) {
-    // Cannot load while mmapedFile_ is already open.
-    return false;
-  }
-
   if (data == nullptr || length == 0) {
     return false;
   }

--- a/src/LanguageModelLoader.h
+++ b/src/LanguageModelLoader.h
@@ -76,6 +76,8 @@ class LanguageModelLoader : public UserPhraseAdder {
   std::filesystem::file_time_type userPhrasesTimestamp_;
   std::string excludedPhrasesPath_;
   std::filesystem::file_time_type excludedPhrasesTimestamp_;
+  std::string phrasesReplacementPath_;
+  std::filesystem::file_time_type phrasesReplacementTimestamp_;
   McBopomofo::InputMacroController inputMacroController_;
 
  public:


### PR DESCRIPTION
In fcitx5-mcbopomofo, phrases replacement is enabled if `phrases-replacement.txt` exists in the user's data path, usually `$HOME/.local/share/fcitx5/mcbopomofo/phrases-replacement.txt`, and it's disabled if the file does not exist or is removed.
    
fcitx5-mcbopomofo does not populate the file with a template; this is different from the behavior of the macOS version.

This feature is introduced to be in sync with the macOS version. It's also motivated by https://github.com/openvanilla/McBopomofo/issues/458, which can be solved by phrases replacement.

