### PR TITLE
Include sstream for std::basic_stringstream

### DIFF
--- a/src/KeyHandler.cpp
+++ b/src/KeyHandler.cpp
@@ -25,6 +25,7 @@
 
 #include <algorithm>
 #include <chrono>
+#include <sstream>
 #include <utility>
 
 #include "ChineseNumbers/ChineseNumbers.h"


### PR DESCRIPTION
Build with clang version 18.1.4:

```
fcitx5-mcbopomofo/src/KeyHandler.cpp:406:29: error: implicit instantiation of undefined template 'std::basic_stringstream<char>'
  406 |           std::stringstream value;
      |                             ^
/usr/include/c++/v1/__fwd/sstream.h:29:28: note: template is declared here
   29 | class _LIBCPP_TEMPLATE_VIS basic_stringstream;
      |                            ^
fcitx5-mcbopomofo/src/KeyHandler.cpp:991:23: error: implicit instantiation of undefined template 'std::basic_stringstream<char>'
  991 |     std::stringstream intStream;
      |                       ^
/usr/include/c++/v1/__fwd/sstream.h:29:28: note: template is declared here
   29 | class _LIBCPP_TEMPLATE_VIS basic_stringstream;
      |                            ^
fcitx5-mcbopomofo/src/KeyHandler.cpp:992:23: error: implicit instantiation of undefined template 'std::basic_stringstream<char>'
  992 |     std::stringstream decStream;
      |                       ^
/usr/include/c++/v1/__fwd/sstream.h:29:28: note: template is declared here
   29 | class _LIBCPP_TEMPLATE_VIS basic_stringstream;
      |                            ^
3 errors generated.
*** Error code 1
```