### PR TITLE
Fixes the issue that the Chinese number module does not correctly handle zero.

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -3,6 +3,37 @@ name: CI
 on: [push, pull_request]
 
 jobs:
+  build_ubuntu_24:
+    runs-on: ubuntu-latest
+    container: ubuntu:24.04
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install dependencies
+        run: |
+          export DEBIAN_FRONTEND=noninteractive
+          apt-get update
+          apt install -y pkg-config
+          apt install -y clang
+          apt install -y cmake extra-cmake-modules gettext libfmt-dev
+          apt install -y fcitx5 libfcitx5core-dev libfcitx5config-dev libfcitx5utils-dev fcitx5-modules-dev
+          apt install -y libjson-c-dev
+      - name: Build
+        run: |
+          mkdir -p build
+          cd build
+          cmake ../ -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_BUILD_TYPE=Debug
+          make -j
+          cd ../
+          mkdir -p src/Engine/build
+          cd src/Engine/build
+          cmake ../
+          make -j
+      - name: Test
+        run: |
+          cd build
+          ctest --output-on-failure
+
   build_ubuntu_22:
     runs-on: ubuntu-latest
     container: ubuntu:22.04

--- a/src/ChineseNumbers/ChineseNumbers.cpp
+++ b/src/ChineseNumbers/ChineseNumbers.cpp
@@ -84,7 +84,11 @@ std::string ChineseNumbers::Generate(const std::string& intPart,
 
   std::stringstream output;
   if (intTrimmed.empty()) {
-    output << "0";
+      if (digitCase == ChineseNumbers::ChineseNumberCase::LOWERCASE) {
+        output << kLowerDigits[0];
+      } else if (digitCase == ChineseNumbers::ChineseNumberCase::UPPERCASE) {
+        output << kUpperDigits[0];
+      }
   } else {
     size_t intSectionCount = static_cast<size_t>(
         ceil(static_cast<double>(intTrimmed.length()) / 4.0));

--- a/src/ChineseNumbers/ChineseNumbersTest.cpp
+++ b/src/ChineseNumbers/ChineseNumbersTest.cpp
@@ -24,6 +24,18 @@
 #include "ChineseNumbers.h"
 #include "gtest/gtest.h"
 
+TEST(ChineseNumberTest, Test0_lower) {
+  std::string output = ChineseNumbers::Generate(
+      "0000", "0", ChineseNumbers::ChineseNumberCase::LOWERCASE);
+  EXPECT_EQ(output, "〇");
+}
+
+TEST(ChineseNumberTest, Test0_uipper) {
+  std::string output = ChineseNumbers::Generate(
+      "0000", "0", ChineseNumbers::ChineseNumberCase::UPPERCASE);
+  EXPECT_EQ(output, "零");
+}
+
 TEST(ChineseNumberTest, Test1) {
   std::string output = ChineseNumbers::Generate(
       "0001", "0", ChineseNumbers::ChineseNumberCase::LOWERCASE);


### PR DESCRIPTION
Once a user inserts zero using the Chinese Number module, the output should be 零 or 〇. However, it was not well implemented. The PR fixes the issue.

Also updates the CI job for Ubuntu 24.