### PR TITLE
Introduce a TimestampedPath class to simplify user data loading

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -21,12 +21,20 @@ add_subdirectory(Engine)
 add_subdirectory(ChineseNumbers)
 
 set(MCBOPOMOFO_LIB_SOURCES
- KeyHandler.cpp
- LanguageModelLoader.cpp
- InputState.cpp
- InputMacro.cpp
- Log.cpp
- DictionaryService.cpp
+    DictionaryService.cpp
+    DictionaryService.h
+    InputMacro.cpp
+    InputMacro.h
+    InputState.cpp
+    InputState.h
+    KeyHandler.cpp
+    KeyHandler.h
+    LanguageModelLoader.cpp
+    LanguageModelLoader.h
+    Log.cpp
+    Log.h
+    TimestampedPath.h
+    TimestampedPath.cpp
 )
 
 # https://stackoverflow.com/questions/26549137/shared-library-on-linux-and-fpic-error
@@ -105,7 +113,7 @@ if (ENABLE_TEST)
         endif()
 
         # Test target declarations.
-        add_executable(McBopomofoTest KeyHandlerTest.cpp)
+        add_executable(McBopomofoTest KeyHandlerTest.cpp TimestampedPathTest.cpp)
         target_compile_options(McBopomofoTest PRIVATE -Wno-unknown-pragmas)
         target_link_libraries(McBopomofoTest PRIVATE Fcitx5::Core GTest::gtest_main GTest::gmock_main McBopomofoLib fmt::fmt ${JSONC_LIBRARIES})
         target_include_directories(McBopomofoTest PRIVATE Fcitx5::Core fmt::fmt)

--- a/src/LanguageModelLoader.h
+++ b/src/LanguageModelLoader.h
@@ -24,7 +24,6 @@
 #ifndef SRC_LANGUAGEMODELLOADER_H_
 #define SRC_LANGUAGEMODELLOADER_H_
 
-#include <filesystem>
 #include <memory>
 #include <string>
 #include <string_view>
@@ -32,6 +31,7 @@
 #include "Engine/McBopomofoLM.h"
 #include "InputMacro.h"
 #include "InputMode.h"
+#include "TimestampedPath.h"
 
 namespace McBopomofo {
 
@@ -58,11 +58,13 @@ class LanguageModelLoader : public UserPhraseAdder {
 
   void reloadUserModelsIfNeeded();
 
-  std::string userDataPath() { return userDataPath_; }
+  std::string userDataPath() const { return userDataPath_; }
 
-  std::string userPhrasesPath() { return userPhrasesPath_; }
+  std::string userPhrasesPath() const { return userPhrasesPath_.path(); }
 
-  std::string excludedPhrasesPath() { return excludedPhrasesPath_; }
+  std::string excludedPhrasesPath() const {
+    return excludedPhrasesPath_.path();
+  }
 
  private:
   void populateUserDataFilesIfNeeded();
@@ -72,13 +74,10 @@ class LanguageModelLoader : public UserPhraseAdder {
   std::shared_ptr<McBopomofoLM> lm_;
 
   std::string userDataPath_;
-  std::string userPhrasesPath_;
-  std::filesystem::file_time_type userPhrasesTimestamp_;
-  std::string excludedPhrasesPath_;
-  std::filesystem::file_time_type excludedPhrasesTimestamp_;
-  std::string phrasesReplacementPath_;
-  std::filesystem::file_time_type phrasesReplacementTimestamp_;
-  McBopomofo::InputMacroController inputMacroController_;
+  TimestampedPath userPhrasesPath_;
+  TimestampedPath excludedPhrasesPath_;
+  TimestampedPath phrasesReplacementPath_;
+  InputMacroController inputMacroController_;
 
  public:
   class LocalizedStrings {

--- a/src/TimestampedPath.cpp
+++ b/src/TimestampedPath.cpp
@@ -1,0 +1,71 @@
+// Copyright (c) 2024 and onwards The McBopomofo Authors.
+//
+// Permission is hereby granted, free of charge, to any person
+// obtaining a copy of this software and associated documentation
+// files (the "Software"), to deal in the Software without
+// restriction, including without limitation the rights to use,
+// copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following
+// conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+// OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+// HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+// OTHER DEALINGS IN THE SOFTWARE.
+
+#include "TimestampedPath.h"
+
+namespace McBopomofo {
+
+std::filesystem::path TimestampedPath::path() const { return path_; }
+
+bool TimestampedPath::pathExists() {
+  [[maybe_unused]] std::error_code err;
+  return !path_.empty() && std::filesystem::exists(path_, err);
+}
+
+bool TimestampedPath::pathIsFile() {
+  [[maybe_unused]] std::error_code err;
+  return pathExists() && !std::filesystem::is_directory(path_, err);
+}
+
+bool TimestampedPath::timestampDifferentFromLastCheck() {
+  if (!pathExists()) {
+    std::filesystem::file_time_type zero = {};
+    return timestamp_ != zero;
+  }
+
+  std::error_code err;
+  std::filesystem::file_time_type t =
+      std::filesystem::last_write_time(path_, err);
+  if (err) {
+    return true;
+  }
+
+  return t != timestamp_;
+}
+
+void TimestampedPath::checkTimestamp() {
+  if (pathExists()) {
+    std::error_code err;
+    std::filesystem::file_time_type t =
+        std::filesystem::last_write_time(path_, err);
+    if (err) {
+      timestamp_ = {};
+    } else {
+      timestamp_ = t;
+    }
+  } else {
+    timestamp_ = {};
+  }
+}
+
+}  // namespace McBopomofo

--- a/src/TimestampedPath.h
+++ b/src/TimestampedPath.h
@@ -1,0 +1,62 @@
+// Copyright (c) 2024 and onwards The McBopomofo Authors.
+//
+// Permission is hereby granted, free of charge, to any person
+// obtaining a copy of this software and associated documentation
+// files (the "Software"), to deal in the Software without
+// restriction, including without limitation the rights to use,
+// copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following
+// conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+// OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+// HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+// OTHER DEALINGS IN THE SOFTWARE.
+
+#ifndef SRC_TIMESTAMPEDPATH_H_
+#define SRC_TIMESTAMPEDPATH_H_
+
+#include <filesystem>
+#include <string>
+
+namespace McBopomofo {
+
+// Represents a path with a timestamp. The timestamp is not synced upon
+// construction (unless it's copied or moved) and a checkTimestamp() call is
+// required to sync it. This is so that first-time loading logic can be always
+// built on checking timestampDifferentFromLastCheck(), which returns false for
+// a newly constructed instance with an existing path. If the path does not
+// exist, its timestamp is assumed to be zero.
+class TimestampedPath {
+ public:
+  TimestampedPath() {}
+  explicit TimestampedPath(const std::string& path) : path_(path) {}
+
+  [[nodiscard]] std::filesystem::path path() const;
+
+  bool pathExists();
+
+  // For simplicity, this is defined as "not a directory" and does not
+  // distinguish between file types (such as links). If the file does not exist,
+  // this always returns false.
+  bool pathIsFile();
+
+  bool timestampDifferentFromLastCheck();
+  void checkTimestamp();
+
+ protected:
+  std::filesystem::path path_;
+  std::filesystem::file_time_type timestamp_ = {};
+};
+
+}  // namespace McBopomofo
+
+#endif  // SRC_TIMESTAMPEDPATH_H_

--- a/src/TimestampedPathTest.cpp
+++ b/src/TimestampedPathTest.cpp
@@ -1,0 +1,129 @@
+// Copyright (c) 2024 and onwards The McBopomofo Authors.
+//
+// Permission is hereby granted, free of charge, to any person
+// obtaining a copy of this software and associated documentation
+// files (the "Software"), to deal in the Software without
+// restriction, including without limitation the rights to use,
+// copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following
+// conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+// OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+// HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+// OTHER DEALINGS IN THE SOFTWARE.
+
+#include <filesystem>
+#include <fstream>
+#include <random>
+
+#include "TimestampedPath.h"
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+
+namespace McBopomofo {
+
+TEST(TimestampedPathTest, DefaultConstructor) {
+  TimestampedPath p;
+  ASSERT_FALSE(p.pathExists());
+  ASSERT_FALSE(p.pathIsFile());
+  ASSERT_FALSE(p.timestampDifferentFromLastCheck());
+  p.checkTimestamp();
+  ASSERT_FALSE(p.timestampDifferentFromLastCheck());
+}
+
+TEST(TimestampedPathTest, BasicFunctionalities) {
+  std::random_device rd;
+  std::default_random_engine re(rd());
+  std::uniform_int_distribution<unsigned int> suffix_gen(0);
+
+  std::string prefix("org.openvanilla.mcbopomofo.timestamppathtest-");
+  std::filesystem::path tmp_file_path;
+
+  constexpr int kMaxRetry = 10;
+  for (int i = 0; i < kMaxRetry; ++i) {
+    std::string filename = prefix + std::to_string(suffix_gen(re));
+    std::filesystem::path p = std::filesystem::temp_directory_path() / filename;
+    if (!std::filesystem::exists(p)) {
+      tmp_file_path = p;
+      break;
+    }
+  }
+  ASSERT_FALSE(tmp_file_path.empty()) << "Must form a temp filename";
+
+  TimestampedPath p(tmp_file_path);
+  ASSERT_FALSE(p.timestampDifferentFromLastCheck());
+  ASSERT_FALSE(p.pathExists());
+
+  std::ofstream ofs(tmp_file_path);
+  ofs << "hello, world\n";
+  ofs.close();
+
+  ASSERT_TRUE(p.pathExists());
+  ASSERT_TRUE(p.pathIsFile());
+  ASSERT_TRUE(p.timestampDifferentFromLastCheck());
+  p.checkTimestamp();
+  ASSERT_FALSE(p.timestampDifferentFromLastCheck());
+
+  TimestampedPath existingPath(tmp_file_path);
+  ASSERT_TRUE(existingPath.pathExists());
+  ASSERT_TRUE(existingPath.pathIsFile());
+  ASSERT_TRUE(existingPath.timestampDifferentFromLastCheck());
+  existingPath.checkTimestamp();
+  ASSERT_FALSE(existingPath.timestampDifferentFromLastCheck());
+
+  std::error_code err;
+  std::filesystem::file_time_type t1 =
+      std::filesystem::last_write_time(tmp_file_path, err);
+  ASSERT_FALSE(err);
+
+  ASSERT_FALSE(p.timestampDifferentFromLastCheck());
+
+  // Advance the last write time.
+  auto epoch = t1.time_since_epoch();
+  std::filesystem::file_time_type t2(++epoch);
+  std::filesystem::last_write_time(tmp_file_path, t2, err);
+  ASSERT_FALSE(err);
+
+  // Sanity check.
+  std::filesystem::file_time_type t3 =
+      std::filesystem::last_write_time(tmp_file_path, err);
+  ASSERT_FALSE(err);
+  ASSERT_EQ(t2, t3);
+  ASSERT_GT(t3, t1);
+
+  ASSERT_TRUE(p.timestampDifferentFromLastCheck());
+  p.checkTimestamp();
+  ASSERT_FALSE(p.timestampDifferentFromLastCheck());
+
+  TimestampedPath p2 = p;
+  ASSERT_TRUE(p2.pathExists());
+  ASSERT_TRUE(p2.pathIsFile());
+  ASSERT_FALSE(p2.timestampDifferentFromLastCheck());
+
+  std::filesystem::remove(tmp_file_path, err);
+  ASSERT_FALSE(err);
+  ASSERT_FALSE(p.pathExists());
+  ASSERT_FALSE(p.pathIsFile());
+  ASSERT_TRUE(p.timestampDifferentFromLastCheck());
+
+  ASSERT_FALSE(p2.pathExists());
+  ASSERT_FALSE(p2.pathIsFile());
+  ASSERT_TRUE(p2.timestampDifferentFromLastCheck());
+
+  p.checkTimestamp();
+  ASSERT_FALSE(p.timestampDifferentFromLastCheck());
+
+  p2.checkTimestamp();
+  ASSERT_FALSE(p2.timestampDifferentFromLastCheck());
+}
+
+}  // namespace McBopomofo


### PR DESCRIPTION
We used to have quite some duplicate code for checking the timestamps of the user data files. `TimestampedPath` is introduced to remove the duplication.

Also all `std::filesystem` uses are now the `noexcept` version that takes an extra error code as the out parameter. We don't need to be surprised by exceptions.
