### PR TITLE
Update Archlinux PKGBUILD

### DIFF
--- a/distro/archlinux/PKGBUILD
+++ b/distro/archlinux/PKGBUILD
@@ -2,7 +2,7 @@
 # Contributor: xatier
 _pkgname=fcitx5-mcbopomofo
 pkgname=fcitx5-mcbopomofo-git
-pkgver=2.7.r0.g6e3ab94
+pkgver=2.8.1.r0.175894b
 pkgrel=1
 pkgdesc="McBopomofo for fcitx5"
 arch=('x86_64')


### PR DESCRIPTION
This is similar to #137 but bumps to 2.8.1. @xatier could you please take a look?

Also I'd like to revisit [this comment of yours](https://github.com/openvanilla/fcitx5-mcbopomofo/pull/137#issuecomment-2019356086):

> as a side note, when users build the package with the `makepkg` tool, the `pkgver` function will be invoked and the variable `pkgver` will be automatically updated. We don't necessarily need to update this every single commit, but it's nice to have it to be updated once in a while.

What does it mean to me? Is there any action on my part?

Thanks!
