### PR TITLE
Adds  an option to allow typing Chinese even if Caps Lock is on

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -128,17 +128,14 @@ jobs:
           ctest --output-on-failure
 
   build_manjaro:
-    # strategy:
-    #   fail-fast: false
-    #   matrix:
-    #     os: ["fedora:42", "fedora:41", "fedora:40", "fedora:39"]
     runs-on: ubuntu-latest
     container: manjarolinux/base:latest
     steps:
       - uses: actions/checkout@v4
       - name: Install dependencies
         run: |
-          pacman -S --noconfirm gcc cmake make pkg-config extra-cmake-modules fmt fcitx5 fcitx5-chinese-addons fcitx5-gtk fcitx5-qt
+          pacman -Sy
+          pacman -Sy --noconfirm gcc cmake make pkg-config extra-cmake-modules fmt fcitx5 fcitx5-chinese-addons fcitx5-gtk fcitx5-qt
       - name: Build
         run: |
           mkdir -p build

--- a/po/en.po
+++ b/po/en.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: fcitx5-mcbopomofo v0.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-09-24 13:07+0800\n"
+"POT-Creation-Date: 2024-12-07 02:17+0800\n"
 "PO-Revision-Date: 2022-03-22 20:28-0700\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -17,294 +17,304 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: src/McBopomofo.cpp:309
+#: src/McBopomofo.cpp:327
+#, c++-format
 msgid "Cursor is between syllables {0} and {1}"
 msgstr ""
 
-#: src/McBopomofo.cpp:314
+#: src/McBopomofo.cpp:332
+#, c++-format
 msgid "{0} syllables required"
 msgstr ""
 
-#: src/McBopomofo.cpp:318
+#: src/McBopomofo.cpp:336
+#, c++-format
 msgid "{0} syllables maximum"
 msgstr ""
 
-#: src/McBopomofo.cpp:322
+#: src/McBopomofo.cpp:340
 msgid "phrase already exists"
 msgstr ""
 
-#: src/McBopomofo.cpp:326
+#: src/McBopomofo.cpp:344
 msgid "press Enter to add the phrase"
 msgstr ""
 
-#: src/McBopomofo.cpp:332
+#: src/McBopomofo.cpp:350
+#, c++-format
 msgid "Marked: {0}, syllables: {1}, {2}"
 msgstr ""
 
-#: src/McBopomofo.cpp:344
+#: src/McBopomofo.cpp:362
 msgid "# Custom Phrases or Characters."
 msgstr ""
 
-#: src/McBopomofo.cpp:346
+#: src/McBopomofo.cpp:364
 msgid ""
 "# See https://github.com/openvanilla/McBopomofo/wiki/使用手冊#手動加詞 for "
 "usage."
 msgstr ""
 
-#: src/McBopomofo.cpp:348
+#: src/McBopomofo.cpp:366
 msgid ""
 "# Add your phrases and their respective Bopomofo reading below. Use hyphen "
 "(\"-\")"
 msgstr ""
 
-#: src/McBopomofo.cpp:349
+#: src/McBopomofo.cpp:367
 msgid "# to connect the Bopomofo syllables."
 msgstr ""
 
-#: src/McBopomofo.cpp:353 src/McBopomofo.cpp:372
+#: src/McBopomofo.cpp:371 src/McBopomofo.cpp:390
 msgid "# Any line that starts with \"#\" is treated as comment."
 msgstr ""
 
-#: src/McBopomofo.cpp:362
+#: src/McBopomofo.cpp:380
 msgid "# Custom Excluded Phrases or Characters."
 msgstr ""
 
-#: src/McBopomofo.cpp:364
+#: src/McBopomofo.cpp:382
 msgid ""
 "# See https://github.com/openvanilla/McBopomofo/wiki/使用手冊#手動刪詞 for "
 "usage."
 msgstr ""
 
-#: src/McBopomofo.cpp:366
+#: src/McBopomofo.cpp:384
 msgid ""
 "# For example, the line below will prevent the phrase \"家祠\" from showing "
 "up anywhere:"
 msgstr ""
 
-#: src/McBopomofo.cpp:370
+#: src/McBopomofo.cpp:388
 msgid ""
 "# Note that you need to use a hyphen (\"-\") between Bopomofo syllables."
 msgstr ""
 
-#: src/McBopomofo.cpp:420 src/McBopomofo.cpp:428
+#: src/McBopomofo.cpp:438 src/McBopomofo.cpp:446
 #, fuzzy
 msgid "Half Width Punctuation"
 msgstr "Half Width Punctuation"
 
-#: src/McBopomofo.cpp:421 src/McBopomofo.cpp:429 src/McBopomofo.cpp:529
+#: src/McBopomofo.cpp:439 src/McBopomofo.cpp:447 src/McBopomofo.cpp:547
 #, fuzzy
 msgid "Full Width Punctuation"
 msgstr "Full Width Punctuation"
 
-#: src/McBopomofo.cpp:426
+#: src/McBopomofo.cpp:444
 msgid "Punctuation"
 msgstr ""
 
-#: src/McBopomofo.cpp:430
+#: src/McBopomofo.cpp:448
 msgid "Now using half width punctuation"
 msgstr ""
 
-#: src/McBopomofo.cpp:431
+#: src/McBopomofo.cpp:449
 msgid "Now using full width punctuation"
 msgstr ""
 
-#: src/McBopomofo.cpp:448 src/McBopomofo.cpp:535
+#: src/McBopomofo.cpp:466 src/McBopomofo.cpp:553
 #, fuzzy
 msgid "Associated Phrases - On"
 msgstr "Associated Phrases - On"
 
-#: src/McBopomofo.cpp:449 src/McBopomofo.cpp:536
+#: src/McBopomofo.cpp:467 src/McBopomofo.cpp:554
 #, fuzzy
 msgid "Associated Phrases - Off"
 msgstr "Associated Phrases - Off"
 
-#: src/McBopomofo.cpp:455
+#: src/McBopomofo.cpp:473
 #, fuzzy
 msgid "Associated Phrases"
 msgstr "Associated Phrases"
 
-#: src/McBopomofo.cpp:457
+#: src/McBopomofo.cpp:475
 #, fuzzy
 msgid "Associated Phrases On"
 msgstr "Associated Phrases On"
 
-#: src/McBopomofo.cpp:458
+#: src/McBopomofo.cpp:476
 #, fuzzy
 msgid "Associated Phrases Off"
 msgstr "Associated Phrases Off"
 
-#: src/McBopomofo.cpp:460
+#: src/McBopomofo.cpp:478
 msgid "Now you can use Shift + Enter to insert associated phrases"
 msgstr ""
 
-#: src/McBopomofo.cpp:462
+#: src/McBopomofo.cpp:480
 #, fuzzy
 msgid "Associated Phrases is now enabled."
 msgstr "Associated Phrases is now enabled."
 
-#: src/McBopomofo.cpp:463
+#: src/McBopomofo.cpp:481
 #, fuzzy
 msgid "Associated Phrases is now disabled."
 msgstr "Associated Phrases is now disabled."
 
-#: src/McBopomofo.cpp:471
+#: src/McBopomofo.cpp:489
 msgid "Edit User Phrases"
 msgstr ""
 
-#: src/McBopomofo.cpp:481
+#: src/McBopomofo.cpp:499
 msgid "Edit Excluded Phrases"
 msgstr ""
 
-#: src/McBopomofo.cpp:528
+#: src/McBopomofo.cpp:546
 msgid "Half width Punctuation"
 msgstr ""
 
-#: src/McBopomofo.cpp:1290
+#: src/McBopomofo.cpp:1376
+#, c++-format
 msgid "UTF8 String Length: {0}"
 msgstr ""
 
-#: src/McBopomofo.cpp:1293
+#: src/McBopomofo.cpp:1379
+#, c++-format
 msgid "Code Point Count: {0}"
 msgstr ""
 
-#: src/McBopomofo.h:59
+#: src/McBopomofo.h:60
 msgid "standard"
 msgstr "Standard"
 
-#: src/McBopomofo.h:60
+#: src/McBopomofo.h:61
 msgid "eten"
 msgstr "ETen"
 
-#: src/McBopomofo.h:60
+#: src/McBopomofo.h:61
 msgid "hsu"
 msgstr "Hsu"
 
-#: src/McBopomofo.h:60
+#: src/McBopomofo.h:61
 msgid "et26"
 msgstr "ETen26"
 
-#: src/McBopomofo.h:61
+#: src/McBopomofo.h:62
 msgid "hanyupinyin"
 msgstr "Pinyin"
 
-#: src/McBopomofo.h:61
+#: src/McBopomofo.h:62
 msgid "ibm"
 msgstr "IBM"
 
-#: src/McBopomofo.h:68
+#: src/McBopomofo.h:69
 msgid "123456789"
 msgstr ""
 
-#: src/McBopomofo.h:69
+#: src/McBopomofo.h:70
 msgid "asdfghjkl"
 msgstr ""
 
-#: src/McBopomofo.h:69
+#: src/McBopomofo.h:70
 msgid "asdfzxcvb"
 msgstr ""
 
-#: src/McBopomofo.h:72
+#: src/McBopomofo.h:73
 msgid "Not Set"
 msgstr ""
 
-#: src/McBopomofo.h:73
+#: src/McBopomofo.h:74
 msgid "Vertical"
 msgstr ""
 
-#: src/McBopomofo.h:73
+#: src/McBopomofo.h:74
 msgid "Horizontal"
 msgstr ""
 
-#: src/McBopomofo.h:76
+#: src/McBopomofo.h:77
 msgid "before_cursor"
 msgstr "Before the Cursor (Like Hanin)"
 
-#: src/McBopomofo.h:77
+#: src/McBopomofo.h:78
 msgid "after_cursor"
 msgstr "After the Cursor (Like MS IME)"
 
-#: src/McBopomofo.h:81
+#: src/McBopomofo.h:82
 msgid "directly_output_uppercase"
 msgstr "Directly Output Uppercase Letters"
 
-#: src/McBopomofo.h:82
+#: src/McBopomofo.h:83
 msgid "put_lowercase_to_buffer"
 msgstr "Put Lowercase Letters to Composing Buffer"
 
-#: src/McBopomofo.h:88
+#: src/McBopomofo.h:89
 msgid "disabled"
 msgstr "Disabled"
 
-#: src/McBopomofo.h:89
+#: src/McBopomofo.h:90
 msgid "output_bpmf_reading"
 msgstr "Input Bofomofo Readings"
 
-#: src/McBopomofo.h:90
+#: src/McBopomofo.h:91
 msgid "output_html_ruby_text"
 msgstr "Input HTML Ruby Text"
 
-#: src/McBopomofo.h:98
+#: src/McBopomofo.h:99
 msgid "Bopomofo Keyboard Layout"
 msgstr "Bopomofo Keyboard Layout"
 
-#: src/McBopomofo.h:104
+#: src/McBopomofo.h:105
 msgid "Candidate List Layout"
 msgstr "Candidate List Layout"
 
-#: src/McBopomofo.h:109
+#: src/McBopomofo.h:110
 msgid "Selection Keys"
 msgstr "Selection Keys"
 
-#: src/McBopomofo.h:114
+#: src/McBopomofo.h:115
 #, fuzzy
 msgid "Selection Keys Count"
 msgstr "Selection Keys Count"
 
-#: src/McBopomofo.h:119
+#: src/McBopomofo.h:120
 msgid "Show Candidate Phrase"
 msgstr "Show Candidates"
 
-#: src/McBopomofo.h:124
+#: src/McBopomofo.h:125
 msgid "Move cursor after selection"
 msgstr "Move cursor after selection"
 
-#: src/McBopomofo.h:129
+#: src/McBopomofo.h:130
 msgid "Allow using J and K key to move the cursor when choosing candidates"
 msgstr ""
 
-#: src/McBopomofo.h:136
+#: src/McBopomofo.h:137
 msgid "ESC key clears entire composing buffer"
 msgstr "ESC key clears entire composing buffer"
 
-#: src/McBopomofo.h:140
+#: src/McBopomofo.h:142
+msgid "Allow typing in Chinese while Caps Lock is on (like MS IME)"
+msgstr ""
+
+#: src/McBopomofo.h:147
 msgid "Shift + Letter Keys"
 msgstr "Shift + Letter Keys"
 
-#: src/McBopomofo.h:146
+#: src/McBopomofo.h:153
 msgid "Control + Enter Key"
 msgstr "Control + Enter Key"
 
-#: src/McBopomofo.h:151
+#: src/McBopomofo.h:158
 msgid "Open User Phrase Files With"
 msgstr "Open User Phrase Files With"
 
-#: src/McBopomofo.h:156
+#: src/McBopomofo.h:163
 msgid "Add Phrase Hook Path"
 msgstr "Add Phrase Hook Path"
 
-#: src/McBopomofo.h:161
+#: src/McBopomofo.h:169
 msgid "Run the hook script after adding a phrase"
 msgstr "Run the hook script after adding a phrase"
 
-#: src/McBopomofo.h:164
+#: src/McBopomofo.h:173
 msgid "Enable Half Width Punctuation"
 msgstr "Enable Half Width Punctuation"
 
-#: src/McBopomofo.h:168
+#: src/McBopomofo.h:178
 msgid "Enable Associated Phrases"
 msgstr "Enable Associated Phrases"
 
-#: src/McBopomofo.h:172
+#: src/McBopomofo.h:188
 msgid "User Data"
 msgstr ""
 
@@ -313,6 +323,7 @@ msgid "Character Information"
 msgstr "Character Information"
 
 #: src/DictionaryService.cpp:105
+#, c++-format
 msgid "Look up \"{0}\" in {1}"
 msgstr "Look up \"{0}\" in {1}"
 
@@ -338,10 +349,9 @@ msgstr "McBopomofo for Fcitx 5"
 msgid "A Bopomofo input method that picks phrases intelligently"
 msgstr "A Bopomofo input method that picks phrases intelligently"
 
-#: org.fcitx.Fcitx5.Addon.McBopomofo.metainfo.xml.in:10
 #, fuzzy
-msgid "The McBopomofo Authors"
-msgstr "Plain Bopomofo"
+#~ msgid "The McBopomofo Authors"
+#~ msgstr "Plain Bopomofo"
 
 #~ msgid "Open URL With"
 #~ msgstr "Open URL With"

--- a/po/fcitx5-mcbopomofo.pot
+++ b/po/fcitx5-mcbopomofo.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: fcitx5-mcbopomofo\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-09-24 13:07+0800\n"
+"POT-Creation-Date: 2024-12-07 02:17+0800\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,284 +17,294 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src/McBopomofo.cpp:309
+#: src/McBopomofo.cpp:327
+#, c++-format
 msgid "Cursor is between syllables {0} and {1}"
 msgstr ""
 
-#: src/McBopomofo.cpp:314
+#: src/McBopomofo.cpp:332
+#, c++-format
 msgid "{0} syllables required"
 msgstr ""
 
-#: src/McBopomofo.cpp:318
+#: src/McBopomofo.cpp:336
+#, c++-format
 msgid "{0} syllables maximum"
 msgstr ""
 
-#: src/McBopomofo.cpp:322
+#: src/McBopomofo.cpp:340
 msgid "phrase already exists"
 msgstr ""
 
-#: src/McBopomofo.cpp:326
+#: src/McBopomofo.cpp:344
 msgid "press Enter to add the phrase"
 msgstr ""
 
-#: src/McBopomofo.cpp:332
+#: src/McBopomofo.cpp:350
+#, c++-format
 msgid "Marked: {0}, syllables: {1}, {2}"
 msgstr ""
 
-#: src/McBopomofo.cpp:344
+#: src/McBopomofo.cpp:362
 msgid "# Custom Phrases or Characters."
 msgstr ""
 
-#: src/McBopomofo.cpp:346
+#: src/McBopomofo.cpp:364
 msgid ""
 "# See https://github.com/openvanilla/McBopomofo/wiki/使用手冊#手動加詞 for "
 "usage."
 msgstr ""
 
-#: src/McBopomofo.cpp:348
+#: src/McBopomofo.cpp:366
 msgid ""
 "# Add your phrases and their respective Bopomofo reading below. Use hyphen "
 "(\"-\")"
 msgstr ""
 
-#: src/McBopomofo.cpp:349
+#: src/McBopomofo.cpp:367
 msgid "# to connect the Bopomofo syllables."
 msgstr ""
 
-#: src/McBopomofo.cpp:353 src/McBopomofo.cpp:372
+#: src/McBopomofo.cpp:371 src/McBopomofo.cpp:390
 msgid "# Any line that starts with \"#\" is treated as comment."
 msgstr ""
 
-#: src/McBopomofo.cpp:362
+#: src/McBopomofo.cpp:380
 msgid "# Custom Excluded Phrases or Characters."
 msgstr ""
 
-#: src/McBopomofo.cpp:364
+#: src/McBopomofo.cpp:382
 msgid ""
 "# See https://github.com/openvanilla/McBopomofo/wiki/使用手冊#手動刪詞 for "
 "usage."
 msgstr ""
 
-#: src/McBopomofo.cpp:366
+#: src/McBopomofo.cpp:384
 msgid ""
 "# For example, the line below will prevent the phrase \"家祠\" from showing "
 "up anywhere:"
 msgstr ""
 
-#: src/McBopomofo.cpp:370
+#: src/McBopomofo.cpp:388
 msgid ""
 "# Note that you need to use a hyphen (\"-\") between Bopomofo syllables."
 msgstr ""
 
-#: src/McBopomofo.cpp:420 src/McBopomofo.cpp:428
+#: src/McBopomofo.cpp:438 src/McBopomofo.cpp:446
 msgid "Half Width Punctuation"
 msgstr ""
 
-#: src/McBopomofo.cpp:421 src/McBopomofo.cpp:429 src/McBopomofo.cpp:529
+#: src/McBopomofo.cpp:439 src/McBopomofo.cpp:447 src/McBopomofo.cpp:547
 msgid "Full Width Punctuation"
 msgstr ""
 
-#: src/McBopomofo.cpp:426
+#: src/McBopomofo.cpp:444
 msgid "Punctuation"
 msgstr ""
 
-#: src/McBopomofo.cpp:430
+#: src/McBopomofo.cpp:448
 msgid "Now using half width punctuation"
 msgstr ""
 
-#: src/McBopomofo.cpp:431
+#: src/McBopomofo.cpp:449
 msgid "Now using full width punctuation"
 msgstr ""
 
-#: src/McBopomofo.cpp:448 src/McBopomofo.cpp:535
+#: src/McBopomofo.cpp:466 src/McBopomofo.cpp:553
 msgid "Associated Phrases - On"
 msgstr ""
 
-#: src/McBopomofo.cpp:449 src/McBopomofo.cpp:536
+#: src/McBopomofo.cpp:467 src/McBopomofo.cpp:554
 msgid "Associated Phrases - Off"
 msgstr ""
 
-#: src/McBopomofo.cpp:455
+#: src/McBopomofo.cpp:473
 msgid "Associated Phrases"
 msgstr ""
 
-#: src/McBopomofo.cpp:457
+#: src/McBopomofo.cpp:475
 msgid "Associated Phrases On"
 msgstr ""
 
-#: src/McBopomofo.cpp:458
+#: src/McBopomofo.cpp:476
 msgid "Associated Phrases Off"
 msgstr ""
 
-#: src/McBopomofo.cpp:460
+#: src/McBopomofo.cpp:478
 msgid "Now you can use Shift + Enter to insert associated phrases"
 msgstr ""
 
-#: src/McBopomofo.cpp:462
+#: src/McBopomofo.cpp:480
 msgid "Associated Phrases is now enabled."
 msgstr ""
 
-#: src/McBopomofo.cpp:463
+#: src/McBopomofo.cpp:481
 msgid "Associated Phrases is now disabled."
 msgstr ""
 
-#: src/McBopomofo.cpp:471
+#: src/McBopomofo.cpp:489
 msgid "Edit User Phrases"
 msgstr ""
 
-#: src/McBopomofo.cpp:481
+#: src/McBopomofo.cpp:499
 msgid "Edit Excluded Phrases"
 msgstr ""
 
-#: src/McBopomofo.cpp:528
+#: src/McBopomofo.cpp:546
 msgid "Half width Punctuation"
 msgstr ""
 
-#: src/McBopomofo.cpp:1290
+#: src/McBopomofo.cpp:1376
+#, c++-format
 msgid "UTF8 String Length: {0}"
 msgstr ""
 
-#: src/McBopomofo.cpp:1293
+#: src/McBopomofo.cpp:1379
+#, c++-format
 msgid "Code Point Count: {0}"
 msgstr ""
 
-#: src/McBopomofo.h:59
+#: src/McBopomofo.h:60
 msgid "standard"
 msgstr ""
 
-#: src/McBopomofo.h:60
+#: src/McBopomofo.h:61
 msgid "eten"
 msgstr ""
 
-#: src/McBopomofo.h:60
+#: src/McBopomofo.h:61
 msgid "hsu"
 msgstr ""
 
-#: src/McBopomofo.h:60
+#: src/McBopomofo.h:61
 msgid "et26"
 msgstr ""
 
-#: src/McBopomofo.h:61
+#: src/McBopomofo.h:62
 msgid "hanyupinyin"
 msgstr ""
 
-#: src/McBopomofo.h:61
+#: src/McBopomofo.h:62
 msgid "ibm"
 msgstr ""
 
-#: src/McBopomofo.h:68
+#: src/McBopomofo.h:69
 msgid "123456789"
 msgstr ""
 
-#: src/McBopomofo.h:69
+#: src/McBopomofo.h:70
 msgid "asdfghjkl"
 msgstr ""
 
-#: src/McBopomofo.h:69
+#: src/McBopomofo.h:70
 msgid "asdfzxcvb"
 msgstr ""
 
-#: src/McBopomofo.h:72
+#: src/McBopomofo.h:73
 msgid "Not Set"
 msgstr ""
 
-#: src/McBopomofo.h:73
+#: src/McBopomofo.h:74
 msgid "Vertical"
 msgstr ""
 
-#: src/McBopomofo.h:73
+#: src/McBopomofo.h:74
 msgid "Horizontal"
 msgstr ""
 
-#: src/McBopomofo.h:76
+#: src/McBopomofo.h:77
 msgid "before_cursor"
 msgstr ""
 
-#: src/McBopomofo.h:77
+#: src/McBopomofo.h:78
 msgid "after_cursor"
 msgstr ""
 
-#: src/McBopomofo.h:81
+#: src/McBopomofo.h:82
 msgid "directly_output_uppercase"
 msgstr ""
 
-#: src/McBopomofo.h:82
+#: src/McBopomofo.h:83
 msgid "put_lowercase_to_buffer"
 msgstr ""
 
-#: src/McBopomofo.h:88
+#: src/McBopomofo.h:89
 msgid "disabled"
 msgstr ""
 
-#: src/McBopomofo.h:89
+#: src/McBopomofo.h:90
 msgid "output_bpmf_reading"
 msgstr ""
 
-#: src/McBopomofo.h:90
+#: src/McBopomofo.h:91
 msgid "output_html_ruby_text"
 msgstr ""
 
-#: src/McBopomofo.h:98
+#: src/McBopomofo.h:99
 msgid "Bopomofo Keyboard Layout"
 msgstr ""
 
-#: src/McBopomofo.h:104
+#: src/McBopomofo.h:105
 msgid "Candidate List Layout"
 msgstr ""
 
-#: src/McBopomofo.h:109
+#: src/McBopomofo.h:110
 msgid "Selection Keys"
 msgstr ""
 
-#: src/McBopomofo.h:114
+#: src/McBopomofo.h:115
 msgid "Selection Keys Count"
 msgstr ""
 
-#: src/McBopomofo.h:119
+#: src/McBopomofo.h:120
 msgid "Show Candidate Phrase"
 msgstr ""
 
-#: src/McBopomofo.h:124
+#: src/McBopomofo.h:125
 msgid "Move cursor after selection"
 msgstr ""
 
-#: src/McBopomofo.h:129
+#: src/McBopomofo.h:130
 msgid "Allow using J and K key to move the cursor when choosing candidates"
 msgstr ""
 
-#: src/McBopomofo.h:136
+#: src/McBopomofo.h:137
 msgid "ESC key clears entire composing buffer"
 msgstr ""
 
-#: src/McBopomofo.h:140
+#: src/McBopomofo.h:142
+msgid "Allow typing in Chinese while Caps Lock is on (like MS IME)"
+msgstr ""
+
+#: src/McBopomofo.h:147
 msgid "Shift + Letter Keys"
 msgstr ""
 
-#: src/McBopomofo.h:146
+#: src/McBopomofo.h:153
 msgid "Control + Enter Key"
 msgstr ""
 
-#: src/McBopomofo.h:151
+#: src/McBopomofo.h:158
 msgid "Open User Phrase Files With"
 msgstr ""
 
-#: src/McBopomofo.h:156
+#: src/McBopomofo.h:163
 msgid "Add Phrase Hook Path"
 msgstr ""
 
-#: src/McBopomofo.h:161
+#: src/McBopomofo.h:169
 msgid "Run the hook script after adding a phrase"
 msgstr ""
 
-#: src/McBopomofo.h:164
+#: src/McBopomofo.h:173
 msgid "Enable Half Width Punctuation"
 msgstr ""
 
-#: src/McBopomofo.h:168
+#: src/McBopomofo.h:178
 msgid "Enable Associated Phrases"
 msgstr ""
 
-#: src/McBopomofo.h:172
+#: src/McBopomofo.h:188
 msgid "User Data"
 msgstr ""
 
@@ -303,6 +313,7 @@ msgid "Character Information"
 msgstr ""
 
 #: src/DictionaryService.cpp:105
+#, c++-format
 msgid "Look up \"{0}\" in {1}"
 msgstr ""
 
@@ -324,8 +335,4 @@ msgstr ""
 
 #: org.fcitx.Fcitx5.Addon.McBopomofo.metainfo.xml.in:8
 msgid "A Bopomofo input method that picks phrases intelligently"
-msgstr ""
-
-#: org.fcitx.Fcitx5.Addon.McBopomofo.metainfo.xml.in:10
-msgid "The McBopomofo Authors"
 msgstr ""

--- a/po/zh_TW.po
+++ b/po/zh_TW.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: fcitx5-mcbopomofo v0.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-09-24 13:07+0800\n"
+"POT-Creation-Date: 2024-12-07 02:17+0800\n"
 "PO-Revision-Date: 2022-12-28 21:39+0800\n"
 "Last-Translator: Chaoting Liu <brli@chakralinux.org>\n"
 "Language-Team: none\n"
@@ -18,35 +18,39 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 3.2.2\n"
 
-#: src/McBopomofo.cpp:309
+#: src/McBopomofo.cpp:327
+#, c++-format
 msgid "Cursor is between syllables {0} and {1}"
 msgstr "游標在「{0}」與「{1}」之間"
 
-#: src/McBopomofo.cpp:314
+#: src/McBopomofo.cpp:332
+#, c++-format
 msgid "{0} syllables required"
 msgstr "至少需要選取{0}個字"
 
-#: src/McBopomofo.cpp:318
+#: src/McBopomofo.cpp:336
+#, c++-format
 msgid "{0} syllables maximum"
 msgstr "最多只能選取{0}個字"
 
-#: src/McBopomofo.cpp:322
+#: src/McBopomofo.cpp:340
 msgid "phrase already exists"
 msgstr "詞庫已經有這個詞"
 
-#: src/McBopomofo.cpp:326
+#: src/McBopomofo.cpp:344
 msgid "press Enter to add the phrase"
 msgstr "請按 Enter 加入自訂詞庫"
 
-#: src/McBopomofo.cpp:332
+#: src/McBopomofo.cpp:350
+#, c++-format
 msgid "Marked: {0}, syllables: {1}, {2}"
 msgstr "選取了「{0}」，注音「{1}」：{2}"
 
-#: src/McBopomofo.cpp:344
+#: src/McBopomofo.cpp:362
 msgid "# Custom Phrases or Characters."
 msgstr "# 手動加詞資料檔"
 
-#: src/McBopomofo.cpp:346
+#: src/McBopomofo.cpp:364
 msgid ""
 "# See https://github.com/openvanilla/McBopomofo/wiki/使用手冊#手動加詞 for "
 "usage."
@@ -54,26 +58,26 @@ msgstr ""
 "# 使用方式請參考 https://github.com/openvanilla/McBopomofo/wiki/使用手冊#手動"
 "加詞"
 
-#: src/McBopomofo.cpp:348
+#: src/McBopomofo.cpp:366
 msgid ""
 "# Add your phrases and their respective Bopomofo reading below. Use hyphen "
 "(\"-\")"
 msgstr ""
 "# 請在下方加入用戶自訂字詞。每個詞後面要有字詞的讀音。注音音節之間要用減"
 
-#: src/McBopomofo.cpp:349
+#: src/McBopomofo.cpp:367
 msgid "# to connect the Bopomofo syllables."
 msgstr "# 號 (\"-\") 分隔。例如，以下範例加入「小麥注音」一詞："
 
-#: src/McBopomofo.cpp:353 src/McBopomofo.cpp:372
+#: src/McBopomofo.cpp:371 src/McBopomofo.cpp:390
 msgid "# Any line that starts with \"#\" is treated as comment."
 msgstr "# 如果任何一行以 \"#\" 開頭，該行將被當作註解忽略。"
 
-#: src/McBopomofo.cpp:362
+#: src/McBopomofo.cpp:380
 msgid "# Custom Excluded Phrases or Characters."
 msgstr "# 手動刪詞資料檔"
 
-#: src/McBopomofo.cpp:364
+#: src/McBopomofo.cpp:382
 msgid ""
 "# See https://github.com/openvanilla/McBopomofo/wiki/使用手冊#手動刪詞 for "
 "usage."
@@ -81,7 +85,7 @@ msgstr ""
 "# 使用方式請參考 https://github.com/openvanilla/McBopomofo/wiki/使用手冊#手動"
 "刪詞"
 
-#: src/McBopomofo.cpp:366
+#: src/McBopomofo.cpp:384
 msgid ""
 "# For example, the line below will prevent the phrase \"家祠\" from showing "
 "up anywhere:"
@@ -89,229 +93,235 @@ msgstr ""
 "# 如果將下面這行範例加入資料檔中，輸入 \"ㄐㄧㄚ ㄘˊ\" 時不會再看到「家祠」一"
 "詞："
 
-#: src/McBopomofo.cpp:370
+#: src/McBopomofo.cpp:388
 msgid ""
 "# Note that you need to use a hyphen (\"-\") between Bopomofo syllables."
 msgstr "# 請注意，注音音節之間要用減號 (\"-\") 分隔。"
 
-#: src/McBopomofo.cpp:420 src/McBopomofo.cpp:428
+#: src/McBopomofo.cpp:438 src/McBopomofo.cpp:446
 #, fuzzy
 msgid "Half Width Punctuation"
 msgstr "半形標點"
 
-#: src/McBopomofo.cpp:421 src/McBopomofo.cpp:429 src/McBopomofo.cpp:529
+#: src/McBopomofo.cpp:439 src/McBopomofo.cpp:447 src/McBopomofo.cpp:547
 msgid "Full Width Punctuation"
 msgstr "全形標點"
 
-#: src/McBopomofo.cpp:426
+#: src/McBopomofo.cpp:444
 msgid "Punctuation"
 msgstr "標點符號"
 
-#: src/McBopomofo.cpp:430
+#: src/McBopomofo.cpp:448
 msgid "Now using half width punctuation"
 msgstr "開始使用半形標點符號"
 
-#: src/McBopomofo.cpp:431
+#: src/McBopomofo.cpp:449
 msgid "Now using full width punctuation"
 msgstr "開始使用全形標點"
 
-#: src/McBopomofo.cpp:448 src/McBopomofo.cpp:535
+#: src/McBopomofo.cpp:466 src/McBopomofo.cpp:553
 #, fuzzy
 msgid "Associated Phrases - On"
 msgstr "聯想詞 - 開啟"
 
-#: src/McBopomofo.cpp:449 src/McBopomofo.cpp:536
+#: src/McBopomofo.cpp:467 src/McBopomofo.cpp:554
 #, fuzzy
 msgid "Associated Phrases - Off"
 msgstr "聯想詞 - 關閉"
 
-#: src/McBopomofo.cpp:455
+#: src/McBopomofo.cpp:473
 #, fuzzy
 msgid "Associated Phrases"
 msgstr "聯想詞"
 
-#: src/McBopomofo.cpp:457
+#: src/McBopomofo.cpp:475
 #, fuzzy
 msgid "Associated Phrases On"
 msgstr "啟用聯想詞功能"
 
-#: src/McBopomofo.cpp:458
+#: src/McBopomofo.cpp:476
 #, fuzzy
 msgid "Associated Phrases Off"
 msgstr "停用聯想詞功能"
 
-#: src/McBopomofo.cpp:460
+#: src/McBopomofo.cpp:478
 msgid "Now you can use Shift + Enter to insert associated phrases"
 msgstr "您接下來可以使用 Shift + Enter 按鍵輸入聯想詞"
 
-#: src/McBopomofo.cpp:462
+#: src/McBopomofo.cpp:480
 #, fuzzy
 msgid "Associated Phrases is now enabled."
 msgstr "聯想詞功能已開啟"
 
-#: src/McBopomofo.cpp:463
+#: src/McBopomofo.cpp:481
 #, fuzzy
 msgid "Associated Phrases is now disabled."
 msgstr "聯想詞功能已關閉"
 
-#: src/McBopomofo.cpp:471
+#: src/McBopomofo.cpp:489
 msgid "Edit User Phrases"
 msgstr "編輯使用者詞彙"
 
-#: src/McBopomofo.cpp:481
+#: src/McBopomofo.cpp:499
 msgid "Edit Excluded Phrases"
 msgstr "編輯排除的詞彙"
 
-#: src/McBopomofo.cpp:528
+#: src/McBopomofo.cpp:546
 msgid "Half width Punctuation"
 msgstr "半形標點"
 
-#: src/McBopomofo.cpp:1290
+#: src/McBopomofo.cpp:1376
+#, c++-format
 msgid "UTF8 String Length: {0}"
 msgstr "UTF8 字串長度 {0}"
 
-#: src/McBopomofo.cpp:1293
+#: src/McBopomofo.cpp:1379
+#, c++-format
 msgid "Code Point Count: {0}"
 msgstr "總字數 {0}"
 
-#: src/McBopomofo.h:59
+#: src/McBopomofo.h:60
 msgid "standard"
 msgstr "標準"
 
-#: src/McBopomofo.h:60
+#: src/McBopomofo.h:61
 msgid "eten"
 msgstr "倚天"
 
-#: src/McBopomofo.h:60
+#: src/McBopomofo.h:61
 msgid "hsu"
 msgstr "許氏鍵盤"
 
-#: src/McBopomofo.h:60
+#: src/McBopomofo.h:61
 msgid "et26"
 msgstr "倚天26鍵"
 
-#: src/McBopomofo.h:61
+#: src/McBopomofo.h:62
 msgid "hanyupinyin"
 msgstr "漢語拼音"
 
-#: src/McBopomofo.h:61
+#: src/McBopomofo.h:62
 msgid "ibm"
 msgstr "IBM"
 
-#: src/McBopomofo.h:68
+#: src/McBopomofo.h:69
 msgid "123456789"
 msgstr ""
 
-#: src/McBopomofo.h:69
+#: src/McBopomofo.h:70
 msgid "asdfghjkl"
 msgstr ""
 
-#: src/McBopomofo.h:69
+#: src/McBopomofo.h:70
 msgid "asdfzxcvb"
 msgstr ""
 
-#: src/McBopomofo.h:72
+#: src/McBopomofo.h:73
 msgid "Not Set"
 msgstr "尚未設置"
 
-#: src/McBopomofo.h:73
+#: src/McBopomofo.h:74
 msgid "Vertical"
 msgstr "垂直選字窗"
 
-#: src/McBopomofo.h:73
+#: src/McBopomofo.h:74
 msgid "Horizontal"
 msgstr "水平選字窗"
 
-#: src/McBopomofo.h:76
+#: src/McBopomofo.h:77
 msgid "before_cursor"
 msgstr "游標前面（像漢音輸入法）"
 
-#: src/McBopomofo.h:77
+#: src/McBopomofo.h:78
 msgid "after_cursor"
 msgstr "游標後面（像微軟新注音）"
 
-#: src/McBopomofo.h:81
+#: src/McBopomofo.h:82
 msgid "directly_output_uppercase"
 msgstr "直接輸入大寫字母"
 
-#: src/McBopomofo.h:82
+#: src/McBopomofo.h:83
 msgid "put_lowercase_to_buffer"
 msgstr "在輸入緩衝區中輸入小寫字母"
 
-#: src/McBopomofo.h:88
+#: src/McBopomofo.h:89
 msgid "disabled"
 msgstr "無作用"
 
-#: src/McBopomofo.h:89
+#: src/McBopomofo.h:90
 msgid "output_bpmf_reading"
 msgstr "輸出整個句子的注音符號"
 
-#: src/McBopomofo.h:90
+#: src/McBopomofo.h:91
 msgid "output_html_ruby_text"
 msgstr "輸出加上注音標示的 HTML (Ruby Text)"
 
-#: src/McBopomofo.h:98
+#: src/McBopomofo.h:99
 msgid "Bopomofo Keyboard Layout"
 msgstr "注音鍵盤配置"
 
-#: src/McBopomofo.h:104
+#: src/McBopomofo.h:105
 msgid "Candidate List Layout"
 msgstr "選字窗樣式"
 
-#: src/McBopomofo.h:109
+#: src/McBopomofo.h:110
 msgid "Selection Keys"
 msgstr "選字鍵"
 
-#: src/McBopomofo.h:114
+#: src/McBopomofo.h:115
 #, fuzzy
 msgid "Selection Keys Count"
 msgstr "選字鍵"
 
-#: src/McBopomofo.h:119
+#: src/McBopomofo.h:120
 msgid "Show Candidate Phrase"
 msgstr "選字時，候選詞起算點"
 
-#: src/McBopomofo.h:124
+#: src/McBopomofo.h:125
 msgid "Move cursor after selection"
 msgstr "選字後自動移動游標"
 
-#: src/McBopomofo.h:129
+#: src/McBopomofo.h:130
 msgid "Allow using J and K key to move the cursor when choosing candidates"
-msgstr ""
+msgstr "允許使用 J 和 K 鍵在選字時移動游標"
 
-#: src/McBopomofo.h:136
+#: src/McBopomofo.h:137
 msgid "ESC key clears entire composing buffer"
 msgstr "ESC 按鍵清除輸入緩衝區的所有內容"
 
-#: src/McBopomofo.h:140
+#: src/McBopomofo.h:142
+msgid "Allow typing in Chinese while Caps Lock is on (like MS IME)"
+msgstr "在大寫鎖定時也能輸入中文（像微軟新注音）"
+
+#: src/McBopomofo.h:147
 msgid "Shift + Letter Keys"
 msgstr "Shift + 字母按鍵"
 
-#: src/McBopomofo.h:146
+#: src/McBopomofo.h:153
 msgid "Control + Enter Key"
 msgstr "Control + Enter 按鍵"
 
-#: src/McBopomofo.h:151
+#: src/McBopomofo.h:158
 msgid "Open User Phrase Files With"
 msgstr "開啟自訂詞庫檔案要用"
 
-#: src/McBopomofo.h:156
+#: src/McBopomofo.h:163
 msgid "Add Phrase Hook Path"
 msgstr "加詞腳本路徑"
 
-#: src/McBopomofo.h:161
+#: src/McBopomofo.h:169
 msgid "Run the hook script after adding a phrase"
 msgstr "在加入新詞之後執行加詞腳本"
 
-#: src/McBopomofo.h:164
+#: src/McBopomofo.h:173
 msgid "Enable Half Width Punctuation"
 msgstr "啟用半形標點符號"
 
-#: src/McBopomofo.h:168
+#: src/McBopomofo.h:178
 msgid "Enable Associated Phrases"
 msgstr "啟用聯想詞功能"
 
-#: src/McBopomofo.h:172
+#: src/McBopomofo.h:188
 msgid "User Data"
 msgstr "打開使用者資料目錄"
 
@@ -320,6 +330,7 @@ msgid "Character Information"
 msgstr "字元資訊"
 
 #: src/DictionaryService.cpp:105
+#, c++-format
 msgid "Look up \"{0}\" in {1}"
 msgstr "在{1}尋找「{0}」"
 
@@ -343,10 +354,9 @@ msgstr "Fctix 5 的小麥注音"
 msgid "A Bopomofo input method that picks phrases intelligently"
 msgstr "一套智慧選字的注音輸入法"
 
-#: org.fcitx.Fcitx5.Addon.McBopomofo.metainfo.xml.in:10
 #, fuzzy
-msgid "The McBopomofo Authors"
-msgstr "小麥注音"
+#~ msgid "The McBopomofo Authors"
+#~ msgstr "小麥注音"
 
 #~ msgid "Open URL With"
 #~ msgstr "開啟網址連結時要用"

--- a/src/McBopomofo.h
+++ b/src/McBopomofo.h
@@ -136,6 +136,12 @@ FCITX_CONFIGURATION(
         this, "EscKeyClearsEntireComposingBuffer",
         _("ESC key clears entire composing buffer"), false};
 
+    // Allow inputting Chinese when Caps Lock is on.
+    fcitx::Option<bool> capsLockAllowChineseInput{
+        this, "capsLockAllowChineseInput",
+        _("Allow typing in Chinese while Caps Lock is on (like MS IME)"),
+        false};
+
     // Shift + letter keys.
     fcitx::OptionWithAnnotation<ShiftLetterKeys, ShiftLetterKeysI18NAnnotation>
         shiftLetterKeys{this, "ShiftLetterKeys", _("Shift + Letter Keys"),
@@ -174,10 +180,10 @@ FCITX_CONFIGURATION(
 
     // Helps to open the user data directory.
     //
-    // We have menu items in FCITX's input method to let the users to edit the
-    // user phrases, however, the input menu is not visiable on some desktop
-    // environments, so we provide another button in the preferenace dialog to
-    // open the user data directory.
+    // We have menu items in FCITX's input method to let the users to edit
+    // the user phrases, however, the input menu is not visiable on some
+    // desktop environments, so we provide another button in the preferenace
+    // dialog to open the user data directory.
     fcitx::ExternalOption userDataDir{
         this, "UserDataDir", _("User Data"),
         fcitx::stringutils::concat(

--- a/src/McBopomofo.h
+++ b/src/McBopomofo.h
@@ -181,8 +181,8 @@ FCITX_CONFIGURATION(
     // Helps to open the user data directory.
     //
     // We have menu items in FCITX's input method to let the users to edit
-    // the user phrases, however, the input menu is not visiable on some
-    // desktop environments, so we provide another button in the preferenace
+    // the user phrases, however, the input menu is not visible on some
+    // desktop environments, so we provide another button in the preference
     // dialog to open the user data directory.
     fcitx::ExternalOption userDataDir{
         this, "UserDataDir", _("User Data"),


### PR DESCRIPTION
The PR introduces a new feature. When this option is enabled and a user types a letter, it will be converted into a lowercase Bopomofo syllable.

Prior to the PR, our handling of the Caps Lock state was inadequate. The state was present in the raw key data but absent from the 'key' method of the input event. This issue was also addressed by the PR.

The PR is for #163.