### PR TITLE
Bump CMake minimal version to 3.10

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.6)
+cmake_minimum_required(VERSION 3.10)
 project(fcitx5-mcbopomofo VERSION 2.9.0)
 
 find_package(ECM REQUIRED 1.0.0)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.6)
+cmake_minimum_required(VERSION 3.10)
 project(mcbopomofo VERSION 2.9.0)
 
 find_package(PkgConfig REQUIRED)

--- a/src/ChineseNumbers/CMakeLists.txt
+++ b/src/ChineseNumbers/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.6)
+cmake_minimum_required(VERSION 3.10)
 project(ChineseNumbersLib)
 
 set(CMAKE_CXX_STANDARD 17)

--- a/src/Engine/CMakeLists.txt
+++ b/src/Engine/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.6)
+cmake_minimum_required(VERSION 3.10)
 project(McBopomofoLMLib)
 
 set(CMAKE_CXX_STANDARD 17)

--- a/src/Engine/Mandarin/CMakeLists.txt
+++ b/src/Engine/Mandarin/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.6)
+cmake_minimum_required(VERSION 3.10)
 project(Mandarin)
 
 set(CMAKE_CXX_STANDARD 17)

--- a/src/Engine/gramambular2/CMakeLists.txt
+++ b/src/Engine/gramambular2/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.6)
+cmake_minimum_required(VERSION 3.10)
 project(gramambular2)
 
 set(CMAKE_CXX_STANDARD 17)


### PR DESCRIPTION
Modern CMake (3.31) has deprecated versions older than 3.10.

https://cmake.org/cmake/help/latest/release/3.31.html#id14