### PR TITLE
Implements the feature to select next punctuation by repeating the current punctuation key

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
-rm -rf build
-mkdir -p build
+# rm -rf build
+# mkdir -p build
 cd build
 cmake .. -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_BUILD_TYPE=Debug # use Debug for easy debugging with gdb
 make                                                          # or ninja, depending on your system

--- a/po/en.po
+++ b/po/en.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: fcitx5-mcbopomofo v0.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-02-19 23:06+0800\n"
+"POT-Creation-Date: 2025-03-15 19:45+0800\n"
 "PO-Revision-Date: 2022-03-22 20:28-0700\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -19,55 +19,59 @@ msgstr ""
 
 #: src/McBopomofo.cpp:327
 msgid "Cursor is between syllables {0} and {1}"
-msgstr ""
+msgstr "Cursor is between syllables {0} and {1}"
 
 #: src/McBopomofo.cpp:332
 msgid "{0} syllables required"
-msgstr ""
+msgstr "{0} syllables required"
 
 #: src/McBopomofo.cpp:336
 msgid "{0} syllables maximum"
-msgstr ""
+msgstr "{0} syllables maximum"
 
 #: src/McBopomofo.cpp:340
 msgid "phrase already exists"
-msgstr ""
+msgstr "phrase already exists"
 
 #: src/McBopomofo.cpp:344
 msgid "press Enter to add the phrase"
-msgstr ""
+msgstr "press Enter to add the phrase"
 
 #: src/McBopomofo.cpp:350
 msgid "Marked: {0}, syllables: {1}, {2}"
-msgstr ""
+msgstr "Marked: {0}, syllables: {1}, {2}"
 
 #: src/McBopomofo.cpp:362
 msgid "# Custom Phrases or Characters."
-msgstr ""
+msgstr "# Custom Phrases or Characters."
 
 #: src/McBopomofo.cpp:364
 msgid ""
 "# See https://github.com/openvanilla/McBopomofo/wiki/使用手冊#手動加詞 for "
 "usage."
 msgstr ""
+"# See https://github.com/openvanilla/McBopomofo/wiki/使用手冊#手動加詞 for "
+"usage."
 
 #: src/McBopomofo.cpp:366
 msgid ""
 "# Add your phrases and their respective Bopomofo reading below. Use hyphen "
 "(\"-\")"
 msgstr ""
+"# Add your phrases and their respective Bopomofo reading below. Use hyphen "
+"(\"-\")"
 
 #: src/McBopomofo.cpp:367
 msgid "# to connect the Bopomofo syllables."
-msgstr ""
+msgstr "# to connect the Bopomofo syllables."
 
 #: src/McBopomofo.cpp:371 src/McBopomofo.cpp:390
 msgid "# Any line that starts with \"#\" is treated as comment."
-msgstr ""
+msgstr "# Any line that starts with \"#\" is treated as comment."
 
 #: src/McBopomofo.cpp:380
 msgid "# Custom Excluded Phrases or Characters."
-msgstr ""
+msgstr "# Custom Excluded Phrases or Characters."
 
 #: src/McBopomofo.cpp:382
 msgid ""
@@ -80,11 +84,14 @@ msgid ""
 "# For example, the line below will prevent the phrase \"家祠\" from showing "
 "up anywhere:"
 msgstr ""
+"# For example, the line below will prevent the phrase \"家祠\" from showing "
+"up anywhere:"
 
 #: src/McBopomofo.cpp:388
 msgid ""
 "# Note that you need to use a hyphen (\"-\") between Bopomofo syllables."
 msgstr ""
+"# Note that you need to use a hyphen (\"-\") between Bopomofo syllables."
 
 #: src/McBopomofo.cpp:438 src/McBopomofo.cpp:446
 #, fuzzy
@@ -98,15 +105,15 @@ msgstr "Full Width Punctuation"
 
 #: src/McBopomofo.cpp:444
 msgid "Punctuation"
-msgstr ""
+msgstr "Punctuation"
 
 #: src/McBopomofo.cpp:448
 msgid "Now using half width punctuation"
-msgstr ""
+msgstr "Now using half width punctuation"
 
 #: src/McBopomofo.cpp:449
 msgid "Now using full width punctuation"
-msgstr ""
+msgstr "Now using full width punctuation"
 
 #: src/McBopomofo.cpp:466 src/McBopomofo.cpp:553
 #, fuzzy
@@ -135,7 +142,7 @@ msgstr "Associated Phrases Off"
 
 #: src/McBopomofo.cpp:478
 msgid "Now you can use Shift + Enter to insert associated phrases"
-msgstr ""
+msgstr "Now you can use Shift + Enter to insert associated phrases"
 
 #: src/McBopomofo.cpp:480
 #, fuzzy
@@ -149,23 +156,23 @@ msgstr "Associated Phrases is now disabled."
 
 #: src/McBopomofo.cpp:489
 msgid "Edit User Phrases"
-msgstr ""
+msgstr "Edit User Phrases"
 
 #: src/McBopomofo.cpp:499
 msgid "Edit Excluded Phrases"
-msgstr ""
+msgstr "Edit Excluded Phrases"
 
 #: src/McBopomofo.cpp:546
 msgid "Half width Punctuation"
-msgstr ""
-
-#: src/McBopomofo.cpp:1378
-msgid "UTF8 String Length: {0}"
-msgstr ""
+msgstr "Half width Punctuation"
 
 #: src/McBopomofo.cpp:1381
+msgid "UTF8 String Length: {0}"
+msgstr "UTF8 String Length: {0}"
+
+#: src/McBopomofo.cpp:1384
 msgid "Code Point Count: {0}"
-msgstr ""
+msgstr "Code Point Count: {0}"
 
 #: src/McBopomofo.h:60
 msgid "standard"
@@ -205,15 +212,15 @@ msgstr ""
 
 #: src/McBopomofo.h:73
 msgid "Not Set"
-msgstr ""
+msgstr "Not Set"
 
 #: src/McBopomofo.h:74
 msgid "Vertical"
-msgstr ""
+msgstr "Vertical"
 
 #: src/McBopomofo.h:74
 msgid "Horizontal"
-msgstr ""
+msgstr "Horizontal"
 
 #: src/McBopomofo.h:77
 msgid "before_cursor"
@@ -275,7 +282,7 @@ msgstr "Move cursor after selection"
 
 #: src/McBopomofo.h:131
 msgid "Allow using J and K key to move the cursor when choosing candidates"
-msgstr ""
+msgstr "Allow using J and K key to move the cursor when choosing candidates"
 
 #: src/McBopomofo.h:138
 msgid "ESC key clears entire composing buffer"
@@ -283,7 +290,7 @@ msgstr "ESC key clears entire composing buffer"
 
 #: src/McBopomofo.h:143
 msgid "Allow typing in Chinese while Caps Lock is on (like MS IME)"
-msgstr ""
+msgstr "Allow typing in Chinese while Caps Lock is on (like MS IME)"
 
 #: src/McBopomofo.h:148
 msgid "Shift + Letter Keys"
@@ -291,35 +298,39 @@ msgstr "Shift + Letter Keys"
 
 #: src/McBopomofo.h:154
 msgid "Shift + Enter Key triggers associated phrases"
-msgstr ""
+msgstr "Shift + Enter Key triggers associated phrases"
 
 #: src/McBopomofo.h:159
+msgid "Repeated punctuation to select next candidate"
+msgstr "Repeated punctuation to select next candidate"
+
+#: src/McBopomofo.h:164
 msgid "Control + Enter Key"
 msgstr "Control + Enter Key"
 
-#: src/McBopomofo.h:164
+#: src/McBopomofo.h:169
 msgid "Open User Phrase Files With"
 msgstr "Open User Phrase Files With"
 
-#: src/McBopomofo.h:169
+#: src/McBopomofo.h:174
 msgid "Add Phrase Hook Path"
 msgstr "Add Phrase Hook Path"
 
-#: src/McBopomofo.h:175
+#: src/McBopomofo.h:180
 msgid "Run the hook script after adding a phrase"
 msgstr "Run the hook script after adding a phrase"
 
-#: src/McBopomofo.h:179
+#: src/McBopomofo.h:184
 msgid "Enable Half Width Punctuation"
 msgstr "Enable Half Width Punctuation"
 
-#: src/McBopomofo.h:184
+#: src/McBopomofo.h:189
 msgid "Enable Associated Phrases"
 msgstr "Enable Associated Phrases"
 
-#: src/McBopomofo.h:194
+#: src/McBopomofo.h:199
 msgid "User Data"
-msgstr ""
+msgstr "User Data"
 
 #: src/DictionaryService.cpp:60 src/DictionaryService.cpp:80
 msgid "Character Information"

--- a/po/fcitx5-mcbopomofo.pot
+++ b/po/fcitx5-mcbopomofo.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: fcitx5-mcbopomofo\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-02-19 23:13+0800\n"
+"POT-Creation-Date: 2025-03-15 19:45+0800\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -150,11 +150,11 @@ msgstr ""
 msgid "Half width Punctuation"
 msgstr ""
 
-#: src/McBopomofo.cpp:1378
+#: src/McBopomofo.cpp:1381
 msgid "UTF8 String Length: {0}"
 msgstr ""
 
-#: src/McBopomofo.cpp:1381
+#: src/McBopomofo.cpp:1384
 msgid "Code Point Count: {0}"
 msgstr ""
 
@@ -228,15 +228,15 @@ msgstr ""
 
 #: src/McBopomofo.h:90
 msgid "output_bpmf_reading"
-msgstr "Input Bofomofo Readings"
+msgstr ""
 
 #: src/McBopomofo.h:91
 msgid "output_html_ruby_text"
-msgstr "Input HTML Ruby Text"
+msgstr ""
 
 #: src/McBopomofo.h:92
 msgid "output_hanyu_pinyin"
-msgstr "Input Hanyu Pinyin"
+msgstr "Hanyu Pinyin"
 
 #: src/McBopomofo.h:100
 msgid "Bopomofo Keyboard Layout"
@@ -283,30 +283,34 @@ msgid "Shift + Enter Key triggers associated phrases"
 msgstr ""
 
 #: src/McBopomofo.h:159
-msgid "Control + Enter Key"
+msgid "Repeated punctuation to select next candidate"
 msgstr ""
 
 #: src/McBopomofo.h:164
-msgid "Open User Phrase Files With"
+msgid "Control + Enter Key"
 msgstr ""
 
 #: src/McBopomofo.h:169
+msgid "Open User Phrase Files With"
+msgstr ""
+
+#: src/McBopomofo.h:174
 msgid "Add Phrase Hook Path"
 msgstr ""
 
-#: src/McBopomofo.h:175
+#: src/McBopomofo.h:180
 msgid "Run the hook script after adding a phrase"
 msgstr ""
 
-#: src/McBopomofo.h:179
+#: src/McBopomofo.h:184
 msgid "Enable Half Width Punctuation"
 msgstr ""
 
-#: src/McBopomofo.h:184
+#: src/McBopomofo.h:189
 msgid "Enable Associated Phrases"
 msgstr ""
 
-#: src/McBopomofo.h:194
+#: src/McBopomofo.h:199
 msgid "User Data"
 msgstr ""
 

--- a/po/zh_TW.po
+++ b/po/zh_TW.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: fcitx5-mcbopomofo v0.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-02-19 23:06+0800\n"
+"POT-Creation-Date: 2025-03-15 19:45+0800\n"
 "PO-Revision-Date: 2022-12-28 21:39+0800\n"
 "Last-Translator: Chaoting Liu <brli@chakralinux.org>\n"
 "Language-Team: none\n"
@@ -167,11 +167,11 @@ msgstr "編輯排除的詞彙"
 msgid "Half width Punctuation"
 msgstr "半形標點"
 
-#: src/McBopomofo.cpp:1378
+#: src/McBopomofo.cpp:1381
 msgid "UTF8 String Length: {0}"
 msgstr "UTF8 字串長度 {0}"
 
-#: src/McBopomofo.cpp:1381
+#: src/McBopomofo.cpp:1384
 msgid "Code Point Count: {0}"
 msgstr "總字數 {0}"
 
@@ -303,30 +303,34 @@ msgid "Shift + Enter Key triggers associated phrases"
 msgstr "使用 Shift + Enter 按鍵輸入聯想詞"
 
 #: src/McBopomofo.h:159
+msgid "Repeated punctuation to select next candidate"
+msgstr "重複輸入標點時，輸入下一個候選標點符號"
+
+#: src/McBopomofo.h:164
 msgid "Control + Enter Key"
 msgstr "Control + Enter 按鍵"
 
-#: src/McBopomofo.h:164
+#: src/McBopomofo.h:169
 msgid "Open User Phrase Files With"
 msgstr "開啟自訂詞庫檔案要用"
 
-#: src/McBopomofo.h:169
+#: src/McBopomofo.h:174
 msgid "Add Phrase Hook Path"
 msgstr "加詞腳本路徑"
 
-#: src/McBopomofo.h:175
+#: src/McBopomofo.h:180
 msgid "Run the hook script after adding a phrase"
 msgstr "在加入新詞之後執行加詞腳本"
 
-#: src/McBopomofo.h:179
+#: src/McBopomofo.h:184
 msgid "Enable Half Width Punctuation"
 msgstr "啟用半形標點符號"
 
-#: src/McBopomofo.h:184
+#: src/McBopomofo.h:189
 msgid "Enable Associated Phrases"
 msgstr "啟用聯想詞功能"
 
-#: src/McBopomofo.h:194
+#: src/McBopomofo.h:199
 msgid "User Data"
 msgstr "打開使用者資料目錄"
 

--- a/src/KeyHandler.h
+++ b/src/KeyHandler.h
@@ -150,6 +150,10 @@ class KeyHandler {
   void setOnAddNewPhrase(
       std::function<void(const std::string&)> onAddNewPhrase);
 
+  //  Sets whether repeated punctuation characters should be used to select
+  //  candidates.
+  void setRepeatedPunctuationToSelectCandidateEnabled(bool enabled);
+
   // Compute the actual candidate cursor index based on the current index.
   size_t actualCandidateCursorIndex();
   // Compute the actual candidate cursor index.
@@ -207,7 +211,7 @@ class KeyHandler {
                              StateCallback stateCallback,
                              ErrorCallback errorCallback);
 
-  bool handleTabKey(Key key, McBopomofo::InputState* state,
+  bool handleTabKey(bool isShiftPressed, McBopomofo::InputState* state,
                     const StateCallback& stateCallback,
                     const ErrorCallback& errorCallback);
   bool handleCursorKeys(Key key, McBopomofo::InputState* state,
@@ -217,6 +221,7 @@ class KeyHandler {
                         const StateCallback& stateCallback,
                         const ErrorCallback& errorCallback);
   bool handlePunctuation(const std::string& punctuationUnigramKey,
+                         McBopomofo::InputState* state,
                          const StateCallback& stateCallback,
                          const ErrorCallback& errorCallback);
 
@@ -284,6 +289,7 @@ class KeyHandler {
   bool shiftEnterEnabled_ = true;
   bool associatedPhrasesEnabled_ = false;
   bool halfWidthPunctuationEnabled_ = false;
+  bool repeatedPunctuationToSelectCandidateEnabled_ = false;
   KeyHandlerCtrlEnter ctrlEnterKey_ = KeyHandlerCtrlEnter::Disabled;
   std::function<void(const std::string&)> onAddNewPhrase_;
 

--- a/src/McBopomofo.cpp
+++ b/src/McBopomofo.cpp
@@ -604,6 +604,9 @@ void McBopomofoEngine::activate(const fcitx::InputMethodEntry& entry,
       config_.associatedPhrasesEnabled.value());
   keyHandler_->setHalfWidthPunctuationEnabled(
       config_.halfWidthPunctuationEnable.value());
+  keyHandler_->setRepeatedPunctuationToSelectCandidateEnabled(
+      config_.repeatedPunctuationToSelectCandidateEnabled.value());
+
   languageModelLoader_->reloadUserModelsIfNeeded();
 }
 

--- a/src/McBopomofo.h
+++ b/src/McBopomofo.h
@@ -153,6 +153,11 @@ FCITX_CONFIGURATION(
         this, "ShitEnterEnabled",
         _("Shift + Enter Key triggers associated phrases"), true};
 
+    // Repeated punctuation to select next candidate.
+    fcitx::Option<bool> repeatedPunctuationToSelectCandidateEnabled{
+        this, "RepeatedPunctuationToSelectCandidateEnabled",
+        _("Repeated punctuation to select next candidate"), false};
+
     // Ctrl + enter keys.
     fcitx::OptionWithAnnotation<KeyHandlerCtrlEnter,
                                 KeyHandlerCtrlEnterI18NAnnotation>


### PR DESCRIPTION
Updates translations and improves punctuation handling by adding a feature to use repeated punctuation to select the next candidate. Also refactors tab key handling and fixes a bug related to custom phrase addition.