### PR TITLE
Fix build with fcitx5 5.1.13

### DIFF
--- a/src/DictionaryService.cpp
+++ b/src/DictionaryService.cpp
@@ -34,6 +34,7 @@
 #include <sstream>
 #include <utility>
 
+#include "Format.h"
 #include "Log.h"
 
 constexpr char kDataPath[] = "data/mcbopomofo-dictionary-service.json";
@@ -57,7 +58,7 @@ std::string urlEncode(const std::string& str) {
 class CharacterInfoService : public McBopomofo::DictionaryService {
  public:
   std::string name() const override {
-    return fmt::format(_("Character Information"));
+    return fmt::format(FmtRuntime(_("Character Information")));
   }
 
   void lookup(std::string phrase, McBopomofo::InputState* state,
@@ -77,7 +78,7 @@ class CharacterInfoService : public McBopomofo::DictionaryService {
   }
 
   std::string textForMenu(std::string /*Unused*/) const override {
-    return fmt::format(_("Character Information"));
+    return fmt::format(FmtRuntime(_("Character Information")));
   }
 };
 
@@ -102,7 +103,8 @@ class HttpBasedDictionaryService : public McBopomofo::DictionaryService {
   }
 
   std::string textForMenu(std::string selectedString) const override {
-    return fmt::format(_("Look up \"{0}\" in {1}"), selectedString, name_);
+    return fmt::format(FmtRuntime(_("Look up \"{0}\" in {1}")),
+                       selectedString, name_);
   }
 
  private:

--- a/src/Format.h
+++ b/src/Format.h
@@ -1,0 +1,40 @@
+// Copyright (c) 2025 and onwards The McBopomofo Authors.
+//
+// Permission is hereby granted, free of charge, to any person
+// obtaining a copy of this software and associated documentation
+// files (the "Software"), to deal in the Software without
+// restriction, including without limitation the rights to use,
+// copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following
+// conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+// OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+// HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+// OTHER DEALINGS IN THE SOFTWARE.
+
+#ifndef SRC_FORMAT_H_
+#define SRC_FORMAT_H_
+
+#include <fmt/format.h>
+#include <utility>
+
+namespace McBopomofo {
+
+#if FMT_VERSION >= 80000
+#define FmtRuntime(X) fmt::runtime(X)
+#else
+#define FmtRuntime(X) (X)
+#endif
+
+}
+
+#endif

--- a/src/McBopomofo.cpp
+++ b/src/McBopomofo.cpp
@@ -37,6 +37,7 @@
 #include <utility>
 #include <vector>
 
+#include "Format.h"
 #include "Key.h"
 #include "Log.h"
 #include "UTF8Helper.h"
@@ -324,16 +325,19 @@ class KeyHandlerLocalizedString : public KeyHandler::LocalizedStrings {
  public:
   std::string cursorIsBetweenSyllables(
       const std::string& prevReading, const std::string& nextReading) override {
-    return fmt::format(_("Cursor is between syllables {0} and {1}"),
-                       prevReading, nextReading);
+    return fmt::format(
+        FmtRuntime(_("Cursor is between syllables {0} and {1}")), prevReading,
+        nextReading);
   }
 
   std::string syllablesRequired(size_t syllables) override {
-    return fmt::format(_("{0} syllables required"), std::to_string(syllables));
+    return fmt::format(FmtRuntime(_("{0} syllables required")),
+                       std::to_string(syllables));
   }
 
   std::string syllablesMaximum(size_t syllables) override {
-    return fmt::format(_("{0} syllables maximum"), std::to_string(syllables));
+    return fmt::format(FmtRuntime(_("{0} syllables maximum")),
+                       std::to_string(syllables));
   }
 
   std::string phraseAlreadyExists() override {
@@ -347,8 +351,8 @@ class KeyHandlerLocalizedString : public KeyHandler::LocalizedStrings {
   std::string markedWithSyllablesAndStatus(const std::string& marked,
                                            const std::string& readingUiText,
                                            const std::string& status) override {
-    return fmt::format(_("Marked: {0}, syllables: {1}, {2}"), marked,
-                       readingUiText, status);
+    return fmt::format(FmtRuntime(_("Marked: {0}, syllables: {1}, {2}")),
+                       marked, readingUiText, status);
   }
 };
 
@@ -1380,10 +1384,11 @@ void McBopomofoEngine::handleCandidatesState(fcitx::InputContext* context,
     }
   } else if (showingCharInfo != nullptr) {
     std::vector<std::string> menu;
-    menu.emplace_back(fmt::format(_("UTF8 String Length: {0}"),
+    menu.emplace_back(fmt::format(FmtRuntime(_("UTF8 String Length: {0}")),
                                   showingCharInfo->selectedPhrase.length()));
     size_t count = CodePointCount(showingCharInfo->selectedPhrase);
-    menu.emplace_back(fmt::format(_("Code Point Count: {0}"), count));
+    menu.emplace_back(
+        fmt::format(FmtRuntime(_("Code Point Count: {0}")), count));
 
     for (const auto& menuItem : menu) {
       std::string displayText = menuItem;


### PR DESCRIPTION
5.1.13 bump C++ standard to C++20 and changes the fmt behavior. Use
fmt::runtime to wrap the string to make it compatible with both C++17
and C++20.
