### PR TITLE
fix a logic bug and other linter warnings

### DIFF
--- a/src/ChineseNumbers/ChineseNumbers.cpp
+++ b/src/ChineseNumbers/ChineseNumbers.cpp
@@ -26,6 +26,7 @@
 #include <cmath>
 #include <iostream>
 #include <sstream>
+#include <string>
 
 #include "StringUtils.h"
 

--- a/src/ChineseNumbers/ChineseNumbers.cpp
+++ b/src/ChineseNumbers/ChineseNumbers.cpp
@@ -84,11 +84,11 @@ std::string ChineseNumbers::Generate(const std::string& intPart,
 
   std::stringstream output;
   if (intTrimmed.empty()) {
-      if (digitCase == ChineseNumbers::ChineseNumberCase::LOWERCASE) {
-        output << kLowerDigits[0];
-      } else if (digitCase == ChineseNumbers::ChineseNumberCase::UPPERCASE) {
-        output << kUpperDigits[0];
-      }
+    if (digitCase == ChineseNumbers::ChineseNumberCase::LOWERCASE) {
+      output << kLowerDigits[0];
+    } else if (digitCase == ChineseNumbers::ChineseNumberCase::UPPERCASE) {
+      output << kUpperDigits[0];
+    }
   } else {
     size_t intSectionCount = static_cast<size_t>(
         ceil(static_cast<double>(intTrimmed.length()) / 4.0));

--- a/src/ChineseNumbers/ChineseNumbersTest.cpp
+++ b/src/ChineseNumbers/ChineseNumbersTest.cpp
@@ -21,6 +21,8 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 // OTHER DEALINGS IN THE SOFTWARE.
 
+#include <string>
+
 #include "ChineseNumbers.h"
 #include "gtest/gtest.h"
 

--- a/src/ChineseNumbers/StringUtils.cpp
+++ b/src/ChineseNumbers/StringUtils.cpp
@@ -25,6 +25,7 @@
 
 #include <algorithm>
 #include <sstream>
+#include <string>
 
 std::string StringUtils::TrimZerosAtStart(const std::string& input) {
   std::stringstream output;

--- a/src/ChineseNumbers/SuzhouNumbers.cpp
+++ b/src/ChineseNumbers/SuzhouNumbers.cpp
@@ -25,6 +25,7 @@
 
 #include <iostream>
 #include <sstream>
+#include <string>
 
 #include "StringUtils.h"
 

--- a/src/ChineseNumbers/SuzhouNumbersTest.cpp
+++ b/src/ChineseNumbers/SuzhouNumbersTest.cpp
@@ -21,6 +21,8 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 // OTHER DEALINGS IN THE SOFTWARE.
 
+#include <string>
+
 #include "SuzhouNumbers.h"
 #include "gtest/gtest.h"
 

--- a/src/DictionaryService.cpp
+++ b/src/DictionaryService.cpp
@@ -29,10 +29,14 @@
 #include <fmt/format.h>
 #include <json-c/json.h>
 
+#include <cstdio>
 #include <iomanip>
+#include <memory>
 #include <ostream>
 #include <sstream>
+#include <string>
 #include <utility>
+#include <vector>
 
 #include "Format.h"
 #include "Log.h"

--- a/src/Engine/AssociatedPhrasesV2.cpp
+++ b/src/Engine/AssociatedPhrasesV2.cpp
@@ -26,9 +26,12 @@
 #include <algorithm>
 #include <cstdlib>
 #include <limits>
+#include <memory>
 #include <sstream>
+#include <string>
 #include <unordered_set>
 #include <utility>
+#include <vector>
 
 #include "UTF8Helper.h"
 

--- a/src/Engine/AssociatedPhrasesV2Test.cpp
+++ b/src/Engine/AssociatedPhrasesV2Test.cpp
@@ -21,7 +21,10 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 // OTHER DEALINGS IN THE SOFTWARE.
 
+#include <memory>
 #include <string>
+#include <utility>
+#include <vector>
 
 #include "AssociatedPhrasesV2.h"
 #include "gtest/gtest.h"

--- a/src/Engine/Mandarin/Mandarin.cpp
+++ b/src/Engine/Mandarin/Mandarin.cpp
@@ -25,6 +25,9 @@
 
 #include <algorithm>
 #include <cctype>
+#include <map>
+#include <string>
+#include <vector>
 
 namespace Formosa {
 namespace Mandarin {

--- a/src/Engine/Mandarin/Mandarin.cpp
+++ b/src/Engine/Mandarin/Mandarin.cpp
@@ -59,7 +59,7 @@ class BopomofoCharacterMap {
 };
 
 const BPMF BPMF::FromHanyuPinyin(const std::string& str) {
-  if (str.length() == 0) {
+  if (str.empty()) {
     return BPMF();
   }
 
@@ -104,7 +104,7 @@ const BPMF BPMF::FromHanyuPinyin(const std::string& str) {
   }
 
   // try the first character
-  char c = pinyin.length() != 0 ? pinyin[0] : '\0';
+  char c = !pinyin.empty() ? pinyin[0] : '\0';
   switch (c) {
     case 'b':
       firstComponent = BPMF::B;

--- a/src/Engine/Mandarin/MandarinTest.cpp
+++ b/src/Engine/Mandarin/MandarinTest.cpp
@@ -21,6 +21,8 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 // OTHER DEALINGS IN THE SOFTWARE.
 
+#include <string>
+
 #include "Mandarin.h"
 #include "gtest/gtest.h"
 

--- a/src/Engine/McBopomofoLM.cpp
+++ b/src/Engine/McBopomofoLM.cpp
@@ -25,7 +25,9 @@
 
 #include <algorithm>
 #include <limits>
+#include <memory>
 #include <string>
+#include <unordered_set>
 #include <utility>
 #include <vector>
 

--- a/src/Engine/McBopomofoLM.cpp
+++ b/src/Engine/McBopomofoLM.cpp
@@ -142,9 +142,7 @@ McBopomofoLM::getUnigrams(const std::string& key) {
     // Find the highest score from the existing allUnigrams.
     double topScore = std::numeric_limits<double>::lowest();
     for (const auto& unigram : allUnigrams) {
-      if (unigram.score() > topScore) {
-        topScore = unigram.score();
-      }
+      topScore = std::max(topScore, unigram.score());
     }
 
     // Boost by a very small number. This is the score for user phrases.

--- a/src/Engine/McBopomofoLMTest.cpp
+++ b/src/Engine/McBopomofoLMTest.cpp
@@ -22,7 +22,9 @@
 // OTHER DEALINGS IN THE SOFTWARE.
 
 #include <cmath>
+#include <memory>
 #include <string>
+#include <utility>
 
 #include "McBopomofoLM.h"
 #include "gtest/gtest.h"

--- a/src/Engine/MemoryMappedFileTest.cpp
+++ b/src/Engine/MemoryMappedFileTest.cpp
@@ -21,10 +21,12 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 // OTHER DEALINGS IN THE SOFTWARE.
 
+#include <cstdio>
 #include <filesystem>
 #include <fstream>
 #include <random>
 #include <string>
+#include <utility>
 
 #include "MemoryMappedFile.h"
 #include "gtest/gtest.h"

--- a/src/Engine/ParselessLM.cpp
+++ b/src/Engine/ParselessLM.cpp
@@ -29,8 +29,10 @@
 #include <unistd.h>
 
 #include <memory>
+#include <string>
 #include <string_view>
 #include <utility>
+#include <vector>
 
 namespace McBopomofo {
 

--- a/src/Engine/ParselessLMTest.cpp
+++ b/src/Engine/ParselessLMTest.cpp
@@ -23,6 +23,9 @@
 
 #include <filesystem>
 #include <iostream>
+#include <memory>
+#include <utility>
+#include <vector>
 
 #include "ParselessLM.h"
 #include "gtest/gtest.h"

--- a/src/Engine/ParselessPhraseDB.cpp
+++ b/src/Engine/ParselessPhraseDB.cpp
@@ -25,6 +25,8 @@
 
 #include <cassert>
 #include <cstring>
+#include <string>
+#include <vector>
 
 namespace McBopomofo {
 

--- a/src/Engine/ParselessPhraseDB.cpp
+++ b/src/Engine/ParselessPhraseDB.cpp
@@ -97,7 +97,7 @@ const char* ParselessPhraseDB::findFirstMatchingLine(
   const char* bottom = end_;
 
   while (top < bottom) {
-    const char* mid = top + (bottom - top) / 2;
+    const char* mid = top + ((bottom - top) / 2);
     const char* ptr = mid;
 
     if (ptr != begin_) {

--- a/src/Engine/ParselessPhraseDBTest.cpp
+++ b/src/Engine/ParselessPhraseDBTest.cpp
@@ -24,7 +24,9 @@
 #include <cstdio>
 #include <filesystem>
 #include <map>
+#include <memory>
 #include <sstream>
+#include <string>
 #include <vector>
 
 #include "ParselessPhraseDB.h"

--- a/src/Engine/PhraseReplacementMap.cpp
+++ b/src/Engine/PhraseReplacementMap.cpp
@@ -29,6 +29,7 @@
 #include <unistd.h>
 
 #include <fstream>
+#include <string>
 
 #include "KeyValueBlobReader.h"
 

--- a/src/Engine/UTF8Helper.cpp
+++ b/src/Engine/UTF8Helper.cpp
@@ -23,6 +23,9 @@
 
 #include "UTF8Helper.h"
 
+#include <string>
+#include <vector>
+
 namespace McBopomofo {
 // NOLINTBEGIN(readability-magic-numbers)
 

--- a/src/Engine/UTF8HelperTest.cpp
+++ b/src/Engine/UTF8HelperTest.cpp
@@ -22,6 +22,7 @@
 // OTHER DEALINGS IN THE SOFTWARE.
 
 #include <string>
+#include <vector>
 
 #include "UTF8Helper.h"
 #include "gtest/gtest.h"

--- a/src/Engine/UserOverrideModel.cpp
+++ b/src/Engine/UserOverrideModel.cpp
@@ -26,6 +26,8 @@
 
 #include <cassert>
 #include <cmath>
+#include <list>
+#include <string>
 #include <utility>
 #include <vector>
 

--- a/src/Engine/UserOverrideModelTest.cpp
+++ b/src/Engine/UserOverrideModelTest.cpp
@@ -21,6 +21,8 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 // OTHER DEALINGS IN THE SOFTWARE.
 
+#include <string>
+
 #include "UserOverrideModel.h"
 #include "gtest/gtest.h"
 

--- a/src/Engine/UserPhrasesLM.cpp
+++ b/src/Engine/UserPhrasesLM.cpp
@@ -29,6 +29,7 @@
 #include <unistd.h>
 
 #include <fstream>
+#include <string>
 #include <vector>
 
 #include "KeyValueBlobReader.h"

--- a/src/Engine/UserPhrasesLMTest.cpp
+++ b/src/Engine/UserPhrasesLMTest.cpp
@@ -24,6 +24,7 @@
 #include <cstdio>
 #include <filesystem>
 #include <string>
+#include <vector>
 
 #include "UserPhrasesLM.h"
 #include "gtest/gtest.h"

--- a/src/Engine/gramambular2/reading_grid.cpp
+++ b/src/Engine/gramambular2/reading_grid.cpp
@@ -26,6 +26,7 @@
 #include <algorithm>
 #include <chrono>
 #include <limits>
+#include <memory>
 #include <stack>
 #include <string>
 #include <utility>

--- a/src/Engine/gramambular2/reading_grid.cpp
+++ b/src/Engine/gramambular2/reading_grid.cpp
@@ -419,9 +419,7 @@ void ReadingGrid::update() {
   size_t begin =
       (cursor_ <= kMaximumSpanLength) ? 0 : cursor_ - kMaximumSpanLength;
   size_t end = cursor_ + kMaximumSpanLength;
-  if (end > readings_.size()) {
-    end = readings_.size();
-  }
+  end = std::min(end, readings_.size());
 
   for (size_t pos = begin; pos < end; pos++) {
     for (size_t len = 1; len <= kMaximumSpanLength && pos + len <= end; len++) {
@@ -633,9 +631,7 @@ void ReadingGrid::Span::add(const ReadingGrid::NodePtr& node) {
   assert(node->spanningLength() > 0 &&
          node->spanningLength() <= kMaximumSpanLength);
   nodes_[node->spanningLength() - 1] = node;
-  if (node->spanningLength() >= maxLength_) {
-    maxLength_ = node->spanningLength();
-  }
+  maxLength_ = std::max(maxLength_, node->spanningLength());
 }
 
 void ReadingGrid::Span::removeNodesOfOrLongerThan(size_t length) {

--- a/src/Engine/gramambular2/reading_grid_test.cpp
+++ b/src/Engine/gramambular2/reading_grid_test.cpp
@@ -26,6 +26,7 @@
 #include <algorithm>
 #include <iostream>
 #include <map>
+#include <memory>
 #include <string>
 #include <vector>
 

--- a/src/Format.h
+++ b/src/Format.h
@@ -25,6 +25,7 @@
 #define SRC_FORMAT_H_
 
 #include <fmt/format.h>
+
 #include <utility>
 
 namespace McBopomofo {
@@ -35,6 +36,6 @@ namespace McBopomofo {
 #define FmtRuntime(X) (X)
 #endif
 
-}
+}  // namespace McBopomofo
 
-#endif
+#endif  // SRC_FORMAT_H_

--- a/src/InputMacro.cpp
+++ b/src/InputMacro.cpp
@@ -664,7 +664,7 @@ int GetCurrentYear() {
 int getYearBase(int year) {
   if (year < 4) {
     year = year * -1;
-    return 60 - (year + 2) % 60;
+    return 60 - ((year + 2) % 60);
   }
   return (year - 3) % 60;
 }

--- a/src/InputMacro.cpp
+++ b/src/InputMacro.cpp
@@ -29,6 +29,7 @@
 #include <functional>
 #include <iostream>
 #include <memory>
+#include <string>
 #include <utility>
 #include <vector>
 

--- a/src/InputState.cpp
+++ b/src/InputState.cpp
@@ -23,6 +23,8 @@
 
 #include "InputState.h"
 
+#include <string>
+
 namespace McBopomofo {
 
 InputStates::SelectingDateMacro::SelectingDateMacro(

--- a/src/InputState.h
+++ b/src/InputState.h
@@ -251,7 +251,8 @@ struct AssociatedPhrasesPlain : InputState {
 };
 
 struct EnclosingNumber : InputState {
-  EnclosingNumber(std::string number = "") : number(std::move(number)) {}
+  explicit EnclosingNumber(std::string number = "")
+      : number(std::move(number)) {}
   EnclosingNumber(EnclosingNumber const& number) : number(number.number) {}
   std::string composingBuffer() const { return "[標題數字] " + number; }
   std::string number;

--- a/src/KeyHandler.cpp
+++ b/src/KeyHandler.cpp
@@ -708,7 +708,7 @@ bool KeyHandler::handleAssociatedPhrases(InputStates::Inputting* state,
     errorCallback();
     return true;
   }
-  auto* inputting = dynamic_cast<InputStates::Inputting*>(state);
+  auto* inputting = state;
   if (inputting != nullptr) {
     // Find the selected node *before* the cursor.
     size_t prefixCursorIndex = cursor - 1;
@@ -1572,9 +1572,7 @@ size_t KeyHandler::candidateCursorIndex() {
 }
 
 void KeyHandler::setCandidateCursorIndex(size_t newCursor) {
-  if (newCursor > grid_.length()) {
-    newCursor = grid_.length();
-  }
+  newCursor = std::min(newCursor, grid_.length());
   grid_.setCursor(newCursor);
 }
 

--- a/src/KeyHandler.cpp
+++ b/src/KeyHandler.cpp
@@ -25,8 +25,11 @@
 
 #include <algorithm>
 #include <chrono>
+#include <memory>
 #include <sstream>
+#include <string>
 #include <utility>
+#include <vector>
 
 #include "ChineseNumbers/ChineseNumbers.h"
 #include "ChineseNumbers/SuzhouNumbers.h"

--- a/src/KeyHandlerTest.cpp
+++ b/src/KeyHandlerTest.cpp
@@ -21,7 +21,10 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 // OTHER DEALINGS IN THE SOFTWARE.
 
+#include <memory>
 #include <string>
+#include <utility>
+#include <vector>
 
 #include "KeyHandler.h"
 #include "gmock/gmock.h"

--- a/src/LanguageModelLoader.cpp
+++ b/src/LanguageModelLoader.cpp
@@ -28,6 +28,7 @@
 #include <filesystem>
 #include <fstream>
 #include <memory>
+#include <string>
 #include <utility>
 
 #include "Log.h"

--- a/src/LanguageModelLoader.cpp
+++ b/src/LanguageModelLoader.cpp
@@ -88,7 +88,7 @@ LanguageModelLoader::LanguageModelLoader(
   }
 
   userDataPath += "/mcbopomofo";
-  if (!std::filesystem::exists(userDataPath), err) {
+  if (!std::filesystem::exists(userDataPath, err)) {
     bool result = std::filesystem::create_directory(userDataPath, err);
     if (result) {
       FCITX_MCBOPOMOFO_INFO()

--- a/src/McBopomofo.cpp
+++ b/src/McBopomofo.cpp
@@ -33,6 +33,7 @@
 
 #include <memory>
 #include <sstream>
+#include <string>
 #include <unordered_map>
 #include <utility>
 #include <vector>

--- a/src/McBopomofo.cpp
+++ b/src/McBopomofo.cpp
@@ -75,7 +75,8 @@ static Key MapFcitxKey(const fcitx::Key& key, const fcitx::Key& origKey) {
       return Key::asciiKey(sym + 'a' - 'A',
                            key.states() & fcitx::KeyState::Shift,
                            key.states() & fcitx::KeyState::Ctrl);
-    } else if (sym >= 'a' && sym <= 'z') {
+    }
+    if (sym >= 'a' && sym <= 'z') {
       return Key::asciiKey(sym + 'A' - 'a',
                            key.states() & fcitx::KeyState::Shift,
                            key.states() & fcitx::KeyState::Ctrl);
@@ -833,7 +834,9 @@ bool McBopomofoEngine::handleCandidateKeyEvent(
     size_t cursor = keyHandler_->candidateCursorIndex();
 
     if (isCursorMovingLeft) {
-      if (cursor > 0) cursor--;
+      if (cursor > 0) {
+        cursor--;
+      }
     } else if (isCursorMovingRight) {
       cursor++;
     }
@@ -869,7 +872,7 @@ bool McBopomofoEngine::handleCandidateKeyEvent(
         int page = candidateList->currentPage();
         int pageSize = candidateList->size();
         int selectedCandidateIndex =
-            page * pageSize + candidateList->cursorIndex();
+            (page * pageSize) + candidateList->cursorIndex();
         std::string reading =
             choosingCandidate->candidates[selectedCandidateIndex].reading;
 
@@ -908,7 +911,7 @@ bool McBopomofoEngine::handleCandidateKeyEvent(
       int page = candidateList->currentPage();
       int pageSize = candidateList->size();
       int index = candidateList->cursorIndex();
-      int selectedCandidateIndex = page * pageSize + index;
+      int selectedCandidateIndex = (page * pageSize) + index;
       auto candidate = choosingCandidate->candidates[selectedCandidateIndex];
       std::string reading = candidate.reading;
       // If the reading has an invalid prefix, skip dictionary lookup

--- a/src/TimestampedPath.cpp
+++ b/src/TimestampedPath.cpp
@@ -23,6 +23,8 @@
 
 #include "TimestampedPath.h"
 
+#include <string>
+
 namespace McBopomofo {
 
 std::filesystem::path TimestampedPath::path() const { return path_; }

--- a/src/TimestampedPathTest.cpp
+++ b/src/TimestampedPathTest.cpp
@@ -24,6 +24,7 @@
 #include <filesystem>
 #include <fstream>
 #include <random>
+#include <string>
 
 #include "TimestampedPath.h"
 #include "gmock/gmock.h"


### PR DESCRIPTION
This commit fixes the following logic bug from the compiler warning:

```c++
fcitx5-mcbopomofo-git/src/fcitx5-mcbopomofo/src/LanguageModelLoader.cpp: In constructor ‘McBopomofo::LanguageModelLoader::LanguageModelLoader(std
::unique_ptr<LocalizedStrings>)’:
fcitx5-mcbopomofo-git/src/fcitx5-mcbopomofo/src/LanguageModelLoader.cpp:91:7: warning: value computed is not used [-Wunused-value]
   91 |   if (!std::filesystem::exists(userDataPath), err) {
      |       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

compiler: g++ (GCC) 15.1.1 20250425

`std::filesystem::exists` [1] may take one or two parameters; the result of the existence check will be discarded, and it takes `err` to the check due to the misplaced parameter.

I also fixed the following checks from `clang-tidy` (LLVM 20.1.6)

- readability-math-missing-parentheses
- readability-container-size-empty
- readability-else-after-return
- readability-use-std-min-max
- readability-redundant-casting

as well as the following from `cpplint` (2.0.0)

- build/header_guard
- runtime/explicit

[1] https://en.cppreference.com/w/cpp/filesystem/exists.html