### PR TITLE
Commit the space or letter along with the buffer

### DIFF
--- a/src/KeyHandler.cpp
+++ b/src/KeyHandler.cpp
@@ -246,20 +246,17 @@ bool KeyHandler::handle(Key key, McBopomofo::InputState* state,
   // Space also emits a space if not configured as a candidate choosing key.
   if (maybeNotEmptyState != nullptr && key.ascii == Key::SPACE &&
       (key.shiftPressed || !chooseCandidateUsingSpace_)) {
+    grid_.insertReading(" ");
+    walk();
+    auto inputtingState = buildInputtingState();
     if (grid_.cursor() >= grid_.length()) {
-      auto inputtingState = buildInputtingState();
       // Steal the composingBuffer built by the inputting state.
       auto committingState = std::make_unique<InputStates::Committing>(
           inputtingState->composingBuffer);
       stateCallback(std::move(committingState));
-
-      auto commitSpaceState = std::make_unique<InputStates::Committing>(" ");
-      stateCallback(std::move(commitSpaceState));
       reset();
     } else {
-      grid_.insertReading(" ");
-      walk();
-      stateCallback(buildInputtingState());
+      stateCallback(std::move(inputtingState));
     }
     return true;
   }
@@ -479,9 +476,8 @@ bool KeyHandler::handle(Key key, McBopomofo::InputState* state,
 
     // Upper case letters.
     if (simpleAscii >= 'A' && simpleAscii <= 'Z') {
+      unigram = std::string(kLetterPrefix) + chrStr;
       if (putLowercaseLettersToComposingBuffer_) {
-        unigram = std::string(kLetterPrefix) + chrStr;
-
         // Ignore return value, since we always return true below.
         handlePunctuation(unigram, state, stateCallback, errorCallback);
       } else {
@@ -491,15 +487,20 @@ bool KeyHandler::handle(Key key, McBopomofo::InputState* state,
           return false;
         }
 
-        // First, commit what's already in the composing buffer.
+        grid_.insertReading(unigram);
+        size_t loc = grid_.cursor();
+        if (loc > 0) {  // Cursor must have moved after the insertion above.
+          --loc;
+
+          // Choose the uppercase letter.
+          grid_.overrideCandidate(loc, chrStr);
+        }
+        walk();
         auto inputtingState = buildInputtingState();
         // Steal the composingBuffer built by the inputting state.
         auto committingState = std::make_unique<InputStates::Committing>(
             inputtingState->composingBuffer);
         stateCallback(std::move(committingState));
-
-        // Then we commit that single character.
-        stateCallback(std::make_unique<InputStates::Committing>(chrStr));
         reset();
       }
       return true;

--- a/src/KeyHandlerTest.cpp
+++ b/src/KeyHandlerTest.cpp
@@ -252,8 +252,7 @@ TEST_F(KeyHandlerTest, UppercaseLetterCommitComposingBufferByDefault) {
   auto endState = handleKeySequence(asciiKeys("jp6A"));
   auto committingState = dynamic_cast<InputStates::Committing*>(endState.get());
   ASSERT_TRUE(committingState != nullptr);
-  // "文" was already committed, so only A is committed.
-  ASSERT_EQ(committingState->text, "A");
+  ASSERT_EQ(committingState->text, "文A");
 }
 
 TEST_F(KeyHandlerTest, UppercaseLetterNotHandledIfComposingBufferIsEmpty) {


### PR DESCRIPTION
### **User description**
Fixes #187. Double-commit doesn't work with apps like Chrome, which upon receiving two commit events only causes the composing buffer to be cleared, which in turn leads to the loss of user input.


___

### **PR Type**
Bug fix


___

### **Description**
- Commit space/letter with composing buffer

- Avoid double-commit that loses text

- Update handling for Shift+Space and Shift+letters

- Maintain composing flow via grid insertion


___

### Diagram Walkthrough


```mermaid
flowchart LR
  K["KeyHandler::handle"] --> S["Detect NotEmpty + Space/Shift+Space"]
  S -- "insert ' ' into grid + walk" --> B["buildInputtingState"]
  B -- "commit composed buffer once" --> C["Committing state"]
  K --> L["Detect Shift+Uppercase Letter"]
  L -- "insert letter unigram into grid" --> O["overrideCandidate to uppercase"]
  O -- "walk + buildInputtingState" --> C
  C --> R["reset"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>KeyHandler.cpp</strong><dd><code>Single-commit flow for Shift+Space and Shift+letters</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/KeyHandler.cpp

<ul><li>Insert space into grid and walk before commit.<br> <li> Commit composed buffer once; remove second space commit.<br> <li> For Shift+uppercase, insert unigram, override candidate, walk, then <br>commit once.<br> <li> Remove prior double-commit of buffer then character.</ul>


</details>


  </td>
  <td><a href="https://github.com/openvanilla/fcitx5-mcbopomofo/pull/188/files#diff-e5f1eb352fc719fc9e84cf7b08d562b0c304a5540f991eae67a49497a0e2829a">+14/-13</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

