### PR TITLE
Recommend using ninja-build for developers

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@
 
 ## 安裝方式
 
-以下說明如何在 Ubuntu 22.04 LTS 上面編譯安裝。
+以下說明如何在 Ubuntu 24.04 LTS（或是 22.04 LTS）上編譯安裝。
 
 請先安裝 fcitx5, CMake, 以及以下開發用模組：
 
@@ -37,9 +37,8 @@ sudo apt install \
 然後在本專案的 git 目錄下執行以下指令：
 
 ```bash
-mkdir -p build
+cmake -B build -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_BUILD_TYPE=Release
 cd build
-cmake ../ -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_BUILD_TYPE=Release
 make
 sudo make install
 
@@ -79,7 +78,18 @@ cpplint --filter=-build/c++11,-build/include_alpha,-build/include_order,-build/i
 編譯時開啟 `-DENABLE_CLANG_TIDY=On` cmake flag 以啟用 `clang-tidy` 檢查 (需要 clang 14+)。
 
 ```bash
-cmake ../ -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_BUILD_TYPE=Release -DENABLE_CLANG_TIDY=On
+cmake -B build -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_BUILD_TYPE=Release -DENABLE_CLANG_TIDY=On
+```
+
+## 使用 Ninja 加快建置速度
+
+如果系統已經安裝 [Ninja](https://ninja-build.org/)，可使用以下指令，讓 CMake 將 `make` 換成 `ninja`，加快建置速度。尤其在啟用 clang-tidy 檢查程式時，可[加速不少](https://github.com/openvanilla/fcitx5-mcbopomofo/issues/96)：
+
+```
+rm -rf build  # 如果先前已經使用 make，要先移除 build 目錄
+cmake -B build -G Ninja -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_BUILD_TYPE=Release -DENABLE_CLANG_TIDY=On
+cd build
+ninja
 ```
 
 ## 社群公約


### PR DESCRIPTION
Fixes #96

@xatier PTAL. I decided not to place a `CMakeUserPresets.json`, because, for example, on a fresh Ubuntu 24.04 LTS, `ninja-build` is not by default installed.

Also, for those who just need fcitx5-mcbopomofo up and running, it didn't seem to me that the speed-up from ninja was that obvious—a plain `make` could often outrun `ninja` when built without enabling clang-tidy (which is the default) on a 2021 mid-range laptop of mine. This being said, when clang-tidy is enabled (as you have observed in https://github.com/openvanilla/fcitx5-mcbopomofo/issues/96), the speed-up on my machine was in line with what you saw. I therefore decided to add a section that recommends ninja for those interested in developing fcitx5-mcbopomofo.

I also updated the `cmake` usage and switched to the `-B build` convention. Let me know if this looks good to you. Thanks!
