### PR TITLE
Update action container list

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,7 +9,7 @@ jobs:
       matrix:
         os:
           [
-            "ubuntu:24.10",
+            "ubuntu:25.04",
             "ubuntu:24.04",
             "ubuntu:22.04",
             "debian:12",
@@ -28,7 +28,7 @@ jobs:
           apt install -y clang
           apt install -y cmake extra-cmake-modules gettext libfmt-dev
           apt install -y fcitx5 libfcitx5core-dev libfcitx5config-dev libfcitx5utils-dev fcitx5-modules-dev
-          apt install -y libjson-c-dev
+          apt install -y libicu-dev libjson-c-dev
       - name: Install Build Essential
         if: matrix.os == 'ubuntu:24.10'
         run: |


### PR DESCRIPTION
Replacing ubuntu24.10 with ubuntu25.04, since the former is EOLed. Also added a dep that now needs to be explicitly specified on ubuntu25.04.
