### PR TITLE
Update fcitx::StandardPath APIs to fcitx::StandardPaths

### DIFF
--- a/src/DictionaryService.cpp
+++ b/src/DictionaryService.cpp
@@ -25,7 +25,7 @@
 
 #include <fcitx-utils/i18n.h>
 #include <fcitx-utils/misc.h>
-#include <fcitx-utils/standardpath.h>
+#include <fcitx-utils/standardpaths.h>
 #include <fmt/format.h>
 #include <json-c/json.h>
 
@@ -144,8 +144,8 @@ void McBopomofo::DictionaryServices::load() {
   services_.emplace_back(std::make_unique<CharacterInfoService>());
 
   // Load json and add to services_
-  std::string dictionaryServicesPath = fcitx::StandardPath::global().locate(
-      fcitx::StandardPath::Type::PkgData, kDataPath);
+  std::string dictionaryServicesPath = fcitx::StandardPaths::global().locate(
+      fcitx::StandardPathsType::PkgData, kDataPath);
   FILE* file = fopen(dictionaryServicesPath.c_str(), "r");
   if (!file) {
     FCITX_MCBOPOMOFO_INFO()

--- a/src/LanguageModelLoader.cpp
+++ b/src/LanguageModelLoader.cpp
@@ -23,7 +23,7 @@
 
 #include "LanguageModelLoader.h"
 
-#include <fcitx-utils/standardpath.h>
+#include <fcitx-utils/standardpaths.h>
 
 #include <filesystem>
 #include <fstream>
@@ -47,8 +47,8 @@ LanguageModelLoader::LanguageModelLoader(
     std::unique_ptr<LocalizedStrings> localizedStrings)
     : localizedStrings_(std::move(localizedStrings)),
       lm_(std::make_shared<McBopomofoLM>()) {
-  std::string buildInLMPath = fcitx::StandardPath::global().locate(
-      fcitx::StandardPath::Type::PkgData, kDataPath);
+  std::string buildInLMPath = fcitx::StandardPaths::global().locate(
+      fcitx::StandardPathsType::PkgData, kDataPath);
   FCITX_MCBOPOMOFO_INFO() << "Built-in LM: " << buildInLMPath;
   lm_->loadLanguageModel(buildInLMPath.c_str());
   if (!lm_->isDataModelLoaded()) {
@@ -56,8 +56,8 @@ LanguageModelLoader::LanguageModelLoader(
   }
 
   // Load associated phrases v2.
-  std::string associatedPhrasesV2Path = fcitx::StandardPath::global().locate(
-      fcitx::StandardPath::Type::PkgData, kAssociatedPhrasesV2Path);
+  std::string associatedPhrasesV2Path = fcitx::StandardPaths::global().locate(
+      fcitx::StandardPathsType::PkgData, kAssociatedPhrasesV2Path);
   FCITX_MCBOPOMOFO_INFO() << "Associated phrases: " << associatedPhrasesV2Path;
   lm_->loadAssociatedPhrasesV2(associatedPhrasesV2Path.c_str());
 
@@ -67,8 +67,8 @@ LanguageModelLoader::LanguageModelLoader(
   };
   lm_->setMacroConverter(converter);
 
-  std::string userDataPath = fcitx::StandardPath::global().userDirectory(
-      fcitx::StandardPath::Type::PkgData);
+  std::string userDataPath = fcitx::StandardPaths::global().userDirectory(
+      fcitx::StandardPathsType::PkgData);
 
   // fcitx5 is configured not to provide userDataPath, bail.
   if (userDataPath.empty()) {
@@ -118,8 +118,8 @@ void LanguageModelLoader::loadModelForMode(McBopomofo::InputMode mode) {
                          ? kDataPathPlainBPMF
                          : kDataPath;
 
-  std::string buildInLMPath = fcitx::StandardPath::global().locate(
-      fcitx::StandardPath::Type::PkgData, path);
+  std::string buildInLMPath = fcitx::StandardPaths::global().locate(
+      fcitx::StandardPathsType::PkgData, path);
 
   FCITX_MCBOPOMOFO_INFO() << "Built-in LM: " << buildInLMPath;
   lm_->loadLanguageModel(buildInLMPath.c_str());

--- a/src/McBopomofo.h
+++ b/src/McBopomofo.h
@@ -28,7 +28,7 @@
 #include <fcitx-config/enum.h>
 #include <fcitx-config/iniparser.h>
 #include <fcitx-utils/i18n.h>
-#include <fcitx-utils/standardpath.h>
+#include <fcitx-utils/standardpaths.h>
 #include <fcitx/action.h>
 #include <fcitx/addonfactory.h>
 #include <fcitx/addonmanager.h>
@@ -216,8 +216,9 @@ FCITX_CONFIGURATION(
             "xdg-open \"",
             fcitx::stringutils::replaceAll(
                 fcitx::stringutils::joinPath(
-                    fcitx::StandardPath::global().userDirectory(
-                        fcitx::StandardPath::Type::PkgData),
+                    fcitx::StandardPaths::global()
+                        .userDirectory(fcitx::StandardPathsType::PkgData)
+                        .string(),
                     "mcbopomofo"),
                 "\"", "\"\"\""),
             "\"")};);


### PR DESCRIPTION
StandardPath has been marked as deprecated in favor of the new std::filesystem APIs [1].

- <fcitx-utils/standardpath.h>   ->  <fcitx-utils/standardpaths.h>
- fcitx::StandardPath::global()  ->  fcitx::StandardPaths::global()
- fcitx::StandardPath::Type      ->  fcitx::StandardPathsType

Note that StandardPaths methods return `std::filesystem::path`, and can be converted to `std::string` implicitly during assignments.

[1] https://github.com/fcitx/fcitx5/commit/de532a807e1fa0243b36fd6e6f7fd1fb172051e1