### PR TITLE
Add Debian 13 "Trixie" to the CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,6 +13,7 @@ jobs:
             "ubuntu:24.04",
             "ubuntu:22.04",
             "debian:12",
+            "debian:13",
             "linuxmintd/mint22-amd64",
             "linuxmintd/mint21-amd64",
           ]


### PR DESCRIPTION
Debian 13 was released [1] earlier last month; let's add it to the CI.

[1] https://www.debian.org/releases/stable/release-notes/index.en.html