### PR TITLE
Allow direct numpad input while composing

### DIFF
--- a/src/KeyHandler.cpp
+++ b/src/KeyHandler.cpp
@@ -33,7 +33,6 @@
 
 #include "ChineseNumbers/ChineseNumbers.h"
 #include "ChineseNumbers/SuzhouNumbers.h"
-#include "Log.h"
 #include "UTF8Helper.h"
 
 namespace McBopomofo {
@@ -45,6 +44,7 @@ constexpr char kPunctuationKeyPrefix[] = "_punctuation_";
 constexpr char kCtrlPunctuationKeyPrefix[] = "_ctrl_punctuation_";
 constexpr char kHalfWidthPunctuationKeyPrefix[] = "_half_punctuation_";
 constexpr char kLetterPrefix[] = "_letter_";
+constexpr char kNumPadPrefix[] = "_numpad_";
 constexpr size_t kMinValidMarkingReadingCount = 2;
 constexpr size_t kMaxValidMarkingReadingCount = 8;
 constexpr size_t kMaxChineseNumberConversionDigits = 20;
@@ -439,7 +439,7 @@ bool KeyHandler::handle(Key key, McBopomofo::InputState* state,
     return true;
   }
 
-  if (key.ascii != 0) {
+  if (key.ascii != 0 && !key.isFromNumberPad) {
     std::string chrStr(1, key.ascii);
     std::string unigram;
 
@@ -505,6 +505,14 @@ bool KeyHandler::handle(Key key, McBopomofo::InputState* state,
       }
       return true;
     }
+  }
+
+  if (key.ascii != 0 && key.isFromNumberPad && maybeNotEmptyState != nullptr) {
+    std::string unigram = kNumPadPrefix + std::string(1, key.ascii);
+    grid_.insertReading(unigram);
+    walk();
+    stateCallback(buildInputtingState());
+    return true;
   }
 
   // No key is handled. Refresh and consume the key.

--- a/src/KeyHandler.h
+++ b/src/KeyHandler.h
@@ -24,15 +24,12 @@
 #ifndef SRC_KEYHANDLER_H_
 #define SRC_KEYHANDLER_H_
 
-#include <cstdint>
 #include <functional>
 #include <memory>
 #include <string>
-#include <vector>
 
 #include "DictionaryService.h"
 #include "Engine/Mandarin/Mandarin.h"
-#include "Engine/McBopomofoLM.h"
 #include "Engine/UserOverrideModel.h"
 #include "Engine/gramambular2/language_model.h"
 #include "Engine/gramambular2/reading_grid.h"


### PR DESCRIPTION
### **User description**
Fixes #199. This enables numpad to be used as a text input source, such that numbers 0-9 and the symbols (`+-*/.`) can be directly placed into the composing buffer when it's not empty.

Note: this PR is currently in draft, because it needs an upstream change to add numpad symbols to the data.


___

### **PR Type**
Enhancement


___

### **Description**
- Enable numpad input during composition

- Add `_numpad_` unigram prefix handling

- Prevent ascii path for numpad keys

- Minor includes cleanup in headers


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["KeyHandler::handle"] -- "ascii && !numpad" --> B["existing ASCII flow"]
  A -- "ascii && numpad && composing" --> C["insert `_numpad_` + char"]
  C -- "grid_.insertReading + walk" --> D["buildInputtingState()"]
  D -- "update UI" --> E["stateCallback"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>KeyHandler.cpp</strong><dd><code>Add composing support for numpad input</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/KeyHandler.cpp

<ul><li>Add <code>_numpad_</code> prefix constant.<br> <li> Bypass ASCII path for numpad keys.<br> <li> Insert numpad input into grid when composing.<br> <li> Trigger walk and update composing state.</ul>


</details>


  </td>
  <td><a href="https://github.com/openvanilla/fcitx5-mcbopomofo/pull/201/files#diff-e5f1eb352fc719fc9e84cf7b08d562b0c304a5540f991eae67a49497a0e2829a">+10/-2</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Formatting</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>KeyHandler.h</strong><dd><code>Cleanup unused header includes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/KeyHandler.h

- Remove unused includes.
- Minor header cleanup.


</details>


  </td>
  <td><a href="https://github.com/openvanilla/fcitx5-mcbopomofo/pull/201/files#diff-8bf6674fa0fe0feb53820efb7bee31fe087cf2c2ec05d11885b53b75416e759a">+0/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

