### PR TITLE
Add Ubuntu 25.10 "Questing Quokka" to the CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,6 +9,7 @@ jobs:
       matrix:
         os:
           [
+            "ubuntu:25.10",
             "ubuntu:25.04",
             "ubuntu:24.04",
             "ubuntu:22.04",
@@ -31,7 +32,7 @@ jobs:
           apt install -y fcitx5 libfcitx5core-dev libfcitx5config-dev libfcitx5utils-dev fcitx5-modules-dev
           apt install -y libicu-dev libjson-c-dev
       - name: Install Build Essential
-        if: matrix.os == 'ubuntu:24.10'
+        if: matrix.os == 'ubuntu:25.10'
         run: |
           apt install -y build-essential
       - name: Build


### PR DESCRIPTION
Ubuntu 25.10 just got released [1]. Let's add it to the CI.

Despite this being a regular Ubuntu release (non-LTS version), we do receive a few benifits:

1) newer kernel (`linux-generic/questing 6.17.0-5.5 amd64`)
2) rust-coreutils (`(uutils coreutils) 0.2.2`)
3) newer gcc (`gcc (Ubuntu 15.2.0-4ubuntu4) 15.2.0`)
4) newer fcitx5 library (`libfcitx5utils-dev:amd64 (5.1.14-1)`)

I believe by adding this to CI, we can catch issues with these newer versions of tools/environments. For instance, https://github.com/openvanilla/fcitx5-mcbopomofo/pull/195 is now applicable to the newer fcitx5 version on Ubuntu 25.10.

[1] https://discourse.ubuntu.com/t/questing-quokka-release-notes/59220