### PR TITLE
Patch standardpaths for Fcitx5Utils > 5.1.13

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -28,7 +28,7 @@ jobs:
           apt-get update
           apt install -y pkg-config
           apt install -y clang
-          apt install -y cmake extra-cmake-modules gettext libfmt-dev
+          apt install -y cmake extra-cmake-modules git gettext libfmt-dev
           apt install -y fcitx5 libfcitx5core-dev libfcitx5config-dev libfcitx5utils-dev fcitx5-modules-dev
           apt install -y libicu-dev libjson-c-dev
       - name: Install Build Essential
@@ -120,7 +120,7 @@ jobs:
         run: |
           dnf -y install gcc g++
           dnf -y install fcitx5 fcitx5-configtool fcitx5-devel \
-                 cmake extra-cmake-modules gettext fmt-devel \
+                 cmake extra-cmake-modules git gettext fmt-devel \
                  libicu-devel json-c-devel
       - name: Build
         run: |
@@ -141,7 +141,7 @@ jobs:
       - name: Install dependencies
         run: |
           pacman -Sy
-          pacman -Sy --noconfirm gcc cmake make pkg-config extra-cmake-modules fmt fcitx5 fcitx5-chinese-addons fcitx5-gtk fcitx5-qt
+          pacman -Sy --noconfirm gcc cmake make pkg-config extra-cmake-modules git fmt fcitx5 fcitx5-chinese-addons fcitx5-gtk fcitx5-qt
       - name: Build
         run: |
           mkdir -p build

--- a/patches/standardpaths-fix.patch
+++ b/patches/standardpaths-fix.patch
@@ -1,0 +1,106 @@
+diff --git a/src/DictionaryService.cpp b/src/DictionaryService.cpp
+index a7fcdfa..750e689 100644
+--- a/src/DictionaryService.cpp
++++ b/src/DictionaryService.cpp
+@@ -25,7 +25,7 @@
+ 
+ #include <fcitx-utils/i18n.h>
+ #include <fcitx-utils/misc.h>
+-#include <fcitx-utils/standardpath.h>
++#include <fcitx-utils/standardpaths.h>
+ #include <fmt/format.h>
+ #include <json-c/json.h>
+ 
+@@ -144,8 +144,8 @@ void McBopomofo::DictionaryServices::load() {
+   services_.emplace_back(std::make_unique<CharacterInfoService>());
+ 
+   // Load json and add to services_
+-  std::string dictionaryServicesPath = fcitx::StandardPath::global().locate(
+-      fcitx::StandardPath::Type::PkgData, kDataPath);
++  std::string dictionaryServicesPath = fcitx::StandardPaths::global().locate(
++      fcitx::StandardPathsType::PkgData, kDataPath);
+   FILE* file = fopen(dictionaryServicesPath.c_str(), "r");
+   if (!file) {
+     FCITX_MCBOPOMOFO_INFO()
+diff --git a/src/LanguageModelLoader.cpp b/src/LanguageModelLoader.cpp
+index 2585be2..efffc44 100644
+--- a/src/LanguageModelLoader.cpp
++++ b/src/LanguageModelLoader.cpp
+@@ -23,7 +23,7 @@
+ 
+ #include "LanguageModelLoader.h"
+ 
+-#include <fcitx-utils/standardpath.h>
++#include <fcitx-utils/standardpaths.h>
+ 
+ #include <filesystem>
+ #include <fstream>
+@@ -47,8 +47,8 @@ LanguageModelLoader::LanguageModelLoader(
+     std::unique_ptr<LocalizedStrings> localizedStrings)
+     : localizedStrings_(std::move(localizedStrings)),
+       lm_(std::make_shared<McBopomofoLM>()) {
+-  std::string buildInLMPath = fcitx::StandardPath::global().locate(
+-      fcitx::StandardPath::Type::PkgData, kDataPath);
++  std::string buildInLMPath = fcitx::StandardPaths::global().locate(
++      fcitx::StandardPathsType::PkgData, kDataPath);
+   FCITX_MCBOPOMOFO_INFO() << "Built-in LM: " << buildInLMPath;
+   lm_->loadLanguageModel(buildInLMPath.c_str());
+   if (!lm_->isDataModelLoaded()) {
+@@ -56,8 +56,8 @@ LanguageModelLoader::LanguageModelLoader(
+   }
+ 
+   // Load associated phrases v2.
+-  std::string associatedPhrasesV2Path = fcitx::StandardPath::global().locate(
+-      fcitx::StandardPath::Type::PkgData, kAssociatedPhrasesV2Path);
++  std::string associatedPhrasesV2Path = fcitx::StandardPaths::global().locate(
++      fcitx::StandardPathsType::PkgData, kAssociatedPhrasesV2Path);
+   FCITX_MCBOPOMOFO_INFO() << "Associated phrases: " << associatedPhrasesV2Path;
+   lm_->loadAssociatedPhrasesV2(associatedPhrasesV2Path.c_str());
+ 
+@@ -67,8 +67,8 @@ LanguageModelLoader::LanguageModelLoader(
+   };
+   lm_->setMacroConverter(converter);
+ 
+-  std::string userDataPath = fcitx::StandardPath::global().userDirectory(
+-      fcitx::StandardPath::Type::PkgData);
++  std::string userDataPath = fcitx::StandardPaths::global().userDirectory(
++      fcitx::StandardPathsType::PkgData);
+ 
+   // fcitx5 is configured not to provide userDataPath, bail.
+   if (userDataPath.empty()) {
+@@ -118,8 +118,8 @@ void LanguageModelLoader::loadModelForMode(McBopomofo::InputMode mode) {
+                          ? kDataPathPlainBPMF
+                          : kDataPath;
+ 
+-  std::string buildInLMPath = fcitx::StandardPath::global().locate(
+-      fcitx::StandardPath::Type::PkgData, path);
++  std::string buildInLMPath = fcitx::StandardPaths::global().locate(
++      fcitx::StandardPathsType::PkgData, path);
+ 
+   FCITX_MCBOPOMOFO_INFO() << "Built-in LM: " << buildInLMPath;
+   lm_->loadLanguageModel(buildInLMPath.c_str());
+diff --git a/src/McBopomofo.h b/src/McBopomofo.h
+index fe97cb8..ea8b8a4 100644
+--- a/src/McBopomofo.h
++++ b/src/McBopomofo.h
+@@ -28,7 +28,7 @@
+ #include <fcitx-config/enum.h>
+ #include <fcitx-config/iniparser.h>
+ #include <fcitx-utils/i18n.h>
+-#include <fcitx-utils/standardpath.h>
++#include <fcitx-utils/standardpaths.h>
+ #include <fcitx/action.h>
+ #include <fcitx/addonfactory.h>
+ #include <fcitx/addonmanager.h>
+@@ -216,8 +216,9 @@ FCITX_CONFIGURATION(
+             "xdg-open \"",
+             fcitx::stringutils::replaceAll(
+                 fcitx::stringutils::joinPath(
+-                    fcitx::StandardPath::global().userDirectory(
+-                        fcitx::StandardPath::Type::PkgData),
++                    fcitx::StandardPaths::global()
++                        .userDirectory(fcitx::StandardPathsType::PkgData)
++                        .string(),
+                     "mcbopomofo"),
+                 "\"", "\"\"\""),
+             "\"")};);

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -17,6 +17,17 @@ if (CMAKE_VERSION VERSION_GREATER_EQUAL "3.23.0")
     find_package(GTest)
 endif()
 
+# Check Fcitx5Utils version and apply the standardpaths patch
+MESSAGE(STATUS "Found Fcitx5Utils (found version \"${Fcitx5Utils_VERSION}\")")
+if (Fcitx5Utils_VERSION VERSION_GREATER_EQUAL "5.1.13")
+    MESSAGE(STATUS "Patching for Fcitx5 standardpaths")
+    find_package(Git REQUIRED)
+    execute_process(
+        COMMAND ${GIT_EXECUTABLE} apply --whitespace=nowarn ${CMAKE_SOURCE_DIR}/patches/standardpaths-fix.patch
+        WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+    )
+endif()
+
 add_subdirectory(Engine)
 add_subdirectory(ChineseNumbers)
 


### PR DESCRIPTION
This PR applies the patch in https://github.com/openvanilla/fcitx5-mcbopomofo/pull/195 if we find a recent version of fcitx5 in the CMake script.

This provides a more flexible way to handle between old and fcitx5 versions across various distributions. Once we are all passed 5.1.13, we can apply the patch permanently and remove the if block in the CMake script.