### PR TITLE
Introduce compatibility layer to support Fcitx5 < 5.1.13

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -17,6 +17,13 @@ if (CMAKE_VERSION VERSION_GREATER_EQUAL "3.23.0")
     find_package(GTest)
 endif()
 
+# Check Fcitx5Utils version and enable the legacy path
+MESSAGE(STATUS "Found Fcitx5Utils (found version \"${Fcitx5Utils_VERSION}\")")
+if (Fcitx5Utils_VERSION VERSION_LESS "5.1.13")
+    MESSAGE(STATUS "Use legacy FCITX5 API <standardpath.h>")
+    add_compile_definitions(USE_LEGACY_FCITX5_API_STANDARDPATH=1)
+endif()
+
 add_subdirectory(Engine)
 add_subdirectory(ChineseNumbers)
 
@@ -62,7 +69,7 @@ add_library(mcbopomofo MODULE McBopomofo.cpp)
 # Use this to build McBopomofo on, for example, Ubuntu 20.04 LTS
 if (USE_LEGACY_FCITX5_API)
     MESSAGE(STATUS "Using legacy (pre-2021) Fcitx5 API")
-    add_compile_definitions(mcbopomofo USE_LEGACY_FCITX5_API=1)
+    add_compile_definitions(USE_LEGACY_FCITX5_API=1)
 endif()
 target_compile_options(mcbopomofo PRIVATE -Wno-unknown-pragmas)
 target_link_libraries(mcbopomofo PRIVATE Fcitx5::Core Fcitx5::Module::Notifications McBopomofoLib fmt::fmt ${JSONC_LIBRARIES})

--- a/src/DictionaryService.cpp
+++ b/src/DictionaryService.cpp
@@ -144,8 +144,8 @@ void McBopomofo::DictionaryServices::load() {
   services_.emplace_back(std::make_unique<CharacterInfoService>());
 
   // Load json and add to services_
-  std::string dictionaryServicesPath = fcitx::StandardPath::global().locate(
-      fcitx::StandardPath::Type::PkgData, kDataPath);
+  std::string dictionaryServicesPath =
+      McBopomofo::fcitx5_compat::locate(kDataPath);
   FILE* file = fopen(dictionaryServicesPath.c_str(), "r");
   if (!file) {
     FCITX_MCBOPOMOFO_INFO()

--- a/src/DictionaryService.h
+++ b/src/DictionaryService.h
@@ -1,4 +1,3 @@
-
 // Copyright (c) 2024 and onwards The McBopomofo Authors.
 //
 // Permission is hereby granted, free of charge, to any person
@@ -31,6 +30,7 @@
 #include <vector>
 
 #include "InputState.h"
+#include "PathCompat.h"
 
 namespace McBopomofo {
 

--- a/src/LanguageModelLoader.cpp
+++ b/src/LanguageModelLoader.cpp
@@ -47,8 +47,7 @@ LanguageModelLoader::LanguageModelLoader(
     std::unique_ptr<LocalizedStrings> localizedStrings)
     : localizedStrings_(std::move(localizedStrings)),
       lm_(std::make_shared<McBopomofoLM>()) {
-  std::string buildInLMPath = fcitx::StandardPath::global().locate(
-      fcitx::StandardPath::Type::PkgData, kDataPath);
+  std::string buildInLMPath = McBopomofo::fcitx5_compat::locate(kDataPath);
   FCITX_MCBOPOMOFO_INFO() << "Built-in LM: " << buildInLMPath;
   lm_->loadLanguageModel(buildInLMPath.c_str());
   if (!lm_->isDataModelLoaded()) {
@@ -56,8 +55,8 @@ LanguageModelLoader::LanguageModelLoader(
   }
 
   // Load associated phrases v2.
-  std::string associatedPhrasesV2Path = fcitx::StandardPath::global().locate(
-      fcitx::StandardPath::Type::PkgData, kAssociatedPhrasesV2Path);
+  std::string associatedPhrasesV2Path =
+      McBopomofo::fcitx5_compat::locate(kAssociatedPhrasesV2Path);
   FCITX_MCBOPOMOFO_INFO() << "Associated phrases: " << associatedPhrasesV2Path;
   lm_->loadAssociatedPhrasesV2(associatedPhrasesV2Path.c_str());
 
@@ -67,8 +66,7 @@ LanguageModelLoader::LanguageModelLoader(
   };
   lm_->setMacroConverter(converter);
 
-  std::string userDataPath = fcitx::StandardPath::global().userDirectory(
-      fcitx::StandardPath::Type::PkgData);
+  std::string userDataPath = McBopomofo::fcitx5_compat::userDirectory();
 
   // fcitx5 is configured not to provide userDataPath, bail.
   if (userDataPath.empty()) {
@@ -118,8 +116,7 @@ void LanguageModelLoader::loadModelForMode(McBopomofo::InputMode mode) {
                          ? kDataPathPlainBPMF
                          : kDataPath;
 
-  std::string buildInLMPath = fcitx::StandardPath::global().locate(
-      fcitx::StandardPath::Type::PkgData, path);
+  std::string buildInLMPath = McBopomofo::fcitx5_compat::locate(path);
 
   FCITX_MCBOPOMOFO_INFO() << "Built-in LM: " << buildInLMPath;
   lm_->loadLanguageModel(buildInLMPath.c_str());

--- a/src/LanguageModelLoader.h
+++ b/src/LanguageModelLoader.h
@@ -31,6 +31,7 @@
 #include "Engine/McBopomofoLM.h"
 #include "InputMacro.h"
 #include "InputMode.h"
+#include "PathCompat.h"
 #include "TimestampedPath.h"
 
 namespace McBopomofo {

--- a/src/McBopomofo.h
+++ b/src/McBopomofo.h
@@ -46,6 +46,7 @@
 #include "InputState.h"
 #include "KeyHandler.h"
 #include "LanguageModelLoader.h"
+#include "PathCompat.h"
 
 namespace McBopomofo {
 
@@ -216,9 +217,7 @@ FCITX_CONFIGURATION(
             "xdg-open \"",
             fcitx::stringutils::replaceAll(
                 fcitx::stringutils::joinPath(
-                    fcitx::StandardPath::global().userDirectory(
-                        fcitx::StandardPath::Type::PkgData),
-                    "mcbopomofo"),
+                    McBopomofo::fcitx5_compat::userDirectory(), "mcbopomofo"),
                 "\"", "\"\"\""),
             "\"")};);
 

--- a/src/PathCompat.h
+++ b/src/PathCompat.h
@@ -1,0 +1,61 @@
+// Copyright (c) 2025 and onwards The McBopomofo Authors.
+//
+// Permission is hereby granted, free of charge, to any person
+// obtaining a copy of this software and associated documentation
+// files (the "Software"), to deal in the Software without
+// restriction, including without limitation the rights to use,
+// copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following
+// conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+// OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+// HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+// OTHER DEALINGS IN THE SOFTWARE.
+
+#ifndef SRC_PATH_COMPAT_H_
+#define SRC_PATH_COMPAT_H_
+
+#include <string>
+
+#ifdef USE_LEGACY_FCITX5_API_STANDARDPATH
+#include <fcitx-utils/standardpath.h>
+#else
+#include <fcitx-utils/standardpaths.h>
+#endif
+
+namespace McBopomofo {
+namespace fcitx5_compat {
+
+inline std::string locate(const std::string& path) {
+#ifdef USE_LEGACY_FCITX5_API_STANDARDPATH
+  return fcitx::StandardPath::global().locate(
+      fcitx::StandardPath::Type::PkgData, path);
+#else
+  return fcitx::StandardPaths::global().locate(
+      fcitx::StandardPathsType::PkgData, path);
+#endif
+}
+
+inline std::string userDirectory() {
+#ifdef USE_LEGACY_FCITX5_API_STANDARDPATH
+  return fcitx::StandardPath::global().userDirectory(
+      fcitx::StandardPath::Type::PkgData);
+#else
+  return fcitx::StandardPaths::global().userDirectory(
+      fcitx::StandardPathsType::PkgData);
+#endif
+}
+
+}  // namespace fcitx5_compat
+}  // namespace McBopomofo
+
+#endif  // SRC_PATH_COMPAT_H_


### PR DESCRIPTION
This PR introduces an abstraction layer to wrap the old and new fcitx5 APIs for the following:

```
McBopomofo::fcitx5_compat::locate(const std::string& path)
McBopomofo::fcitx5_compat::userDirectory()
```

The CMake script will detect the older version of the library and enable the legacy path.