### PR TITLE
Remove legacy (pre-2021) fcitx5 API support

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -51,35 +51,6 @@ jobs:
           cd build
           ctest --output-on-failure
 
-  build_debian_based_legacy:
-    strategy:
-      fail-fast: false
-      matrix:
-        os: ["ubuntu:20.04", "linuxmintd/mint20-amd64"]
-    runs-on: ubuntu-latest
-    container: ${{ matrix.os }}
-    steps:
-      - uses: actions/checkout@v5
-      - name: Install dependencies
-        run: |
-          export DEBIAN_FRONTEND=noninteractive
-          apt-get update
-          apt install -y pkg-config
-          apt install -y clang
-          apt install -y cmake extra-cmake-modules gettext libfmt-dev
-          apt install -y fcitx5 libfcitx5core-dev libfcitx5config-dev libfcitx5utils-dev fcitx5-modules-dev
-          apt install -y libicu-dev libjson-c-dev
-      - name: Build
-        run: |
-          mkdir -p build
-          cd build
-          cmake ../ -DCMAKE_INSTALL_PREFIX=/usr -DUSE_LEGACY_FCITX5_API=1 -DCMAKE_BUILD_TYPE=Debug
-          make -j
-      - name: Test
-        run: |
-          cd build
-          ctest --output-on-failure
-
   build_archlinux:
     runs-on: ubuntu-latest
     container: archlinux:base-devel

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -66,11 +66,6 @@ include_directories(Engine/Mandarin)
 include_directories(ChineseNumbers)
 
 add_library(mcbopomofo MODULE McBopomofo.cpp)
-# Use this to build McBopomofo on, for example, Ubuntu 20.04 LTS
-if (USE_LEGACY_FCITX5_API)
-    MESSAGE(STATUS "Using legacy (pre-2021) Fcitx5 API")
-    add_compile_definitions(USE_LEGACY_FCITX5_API=1)
-endif()
 target_compile_options(mcbopomofo PRIVATE -Wno-unknown-pragmas)
 target_link_libraries(mcbopomofo PRIVATE Fcitx5::Core Fcitx5::Module::Notifications McBopomofoLib fmt::fmt ${JSONC_LIBRARIES})
 target_include_directories(mcbopomofo PRIVATE Fcitx5::Core Fcitx5::Module::Notifications fmt::fmt)

--- a/src/McBopomofo.cpp
+++ b/src/McBopomofo.cpp
@@ -710,13 +710,8 @@ void McBopomofoEngine::keyEvent(const fcitx::InputMethodEntry& /*unused*/,
     // Absorb all keys when the candidate panel is on.
     keyEvent.filterAndAccept();
 
-#ifdef USE_LEGACY_FCITX5_API
-    auto maybeCandidateList = dynamic_cast<fcitx::CommonCandidateList*>(
-        context->inputPanel().candidateList());
-#else
     auto* maybeCandidateList = dynamic_cast<fcitx::CommonCandidateList*>(
         context->inputPanel().candidateList().get());
-#endif
     if (maybeCandidateList == nullptr) {
       // TODO(unassigned): Just assert this.
       FCITX_MCBOPOMOFO_WARN() << "inconsistent state";
@@ -793,11 +788,7 @@ bool McBopomofoEngine::handleCandidateKeyEvent(
         code >= kFcitxRawKeycode_1 && code <= kFcitxRawKeycode_9) {
       int idx = code - kFcitxRawKeycode_1;
       if (idx < candidateList->size()) {
-#ifdef USE_LEGACY_FCITX5_API
-        candidateList->candidate(idx)->select(context);
-#else
         candidateList->candidate(idx).select(context);
-#endif
       }
       return true;
     }
@@ -810,11 +801,7 @@ bool McBopomofoEngine::handleCandidateKeyEvent(
     }
 
     if (idx != -1 && idx < candidateList->size()) {
-#ifdef USE_LEGACY_FCITX5_API
-      candidateList->candidate(idx)->select(context);
-#else
       candidateList->candidate(idx).select(context);
-#endif
       return true;
     }
   }
@@ -993,12 +980,7 @@ bool McBopomofoEngine::handleCandidateKeyEvent(
       auto* choosingCandidate =
           dynamic_cast<InputStates::ChoosingCandidate*>(state_.get());
       if (choosingCandidate != nullptr) {
-#ifdef USE_LEGACY_FCITX5_API
-        size_t globalIndex =
-            idx + candidateList->size() * candidateList->currentPage();
-#else
         size_t globalIndex = candidateList->globalCursorIndex();
-#endif
         auto prevState = std::make_unique<InputStates::ChoosingCandidate>(
             *choosingCandidate);
         std::string prefixReading =
@@ -1032,11 +1014,7 @@ bool McBopomofoEngine::handleCandidateKeyEvent(
   if (returnPressed) {
     int idx = candidateList->cursorIndex();
     if (idx < candidateList->size()) {
-#ifdef USE_LEGACY_FCITX5_API
-      candidateList->candidate(idx)->select(context);
-#else
       candidateList->candidate(idx).select(context);
-#endif
     }
     return true;
   }
@@ -1073,19 +1051,12 @@ bool McBopomofoEngine::handleCandidateKeyEvent(
         auto copy = std::make_unique<InputStates::ChoosingCandidate>(*choosing);
         stateCallback(std::move(copy));
 
-#ifdef USE_LEGACY_FCITX5_API
-        auto maybeCandidateList = dynamic_cast<fcitx::CommonCandidateList*>(
-            context->inputPanel().candidateList());
-#else
         auto* maybeCandidateList = dynamic_cast<fcitx::CommonCandidateList*>(
             context->inputPanel().candidateList().get());
-#endif
         size_t index = selecting->selectedCandidateIndex;
         // Make sure fcitx5 shows the candidate page; needed when page > 0.
-#ifndef USE_LEGACY_FCITX5_API
         maybeCandidateList->setPage(static_cast<int>(index) /
                                     maybeCandidateList->pageSize());
-#endif
         maybeCandidateList->setGlobalCursorIndex(static_cast<int>(index));
         return true;
       }
@@ -1108,19 +1079,13 @@ bool McBopomofoEngine::handleCandidateKeyEvent(
         auto copy = std::make_unique<InputStates::ChoosingCandidate>(*choosing);
         stateCallback(std::move(copy));
 
-#ifdef USE_LEGACY_FCITX5_API
-        auto maybeCandidateList = dynamic_cast<fcitx::CommonCandidateList*>(
-            context->inputPanel().candidateList());
-#else
         auto* maybeCandidateList = dynamic_cast<fcitx::CommonCandidateList*>(
             context->inputPanel().candidateList().get());
-#endif
         size_t index = associatedPhrases->selectedCandidateIndex;
-#ifndef USE_LEGACY_FCITX5_API
+
         // Make sure fcitx5 shows the candidate page; needed when page > 0.
         maybeCandidateList->setPage(static_cast<int>(index) /
                                     maybeCandidateList->pageSize());
-#endif
         maybeCandidateList->setGlobalCursorIndex(static_cast<int>(index));
       } else if (inputting != nullptr) {
         auto copy = std::make_unique<InputStates::Inputting>(*inputting);
@@ -1319,11 +1284,7 @@ bool McBopomofoEngine::handleCandidateKeyEvent(
             [candidateList, context] {
               auto idx = candidateList->cursorIndex();
               if (idx < candidateList->size()) {
-#ifdef USE_LEGACY_FCITX5_API
-                candidateList->candidate(idx)->select(context);
-#else
                 candidateList->candidate(idx).select(context);
-#endif
               }
             },
             stateCallback, errorCallback);
@@ -1462,13 +1423,10 @@ void McBopomofoEngine::handleCandidatesState(fcitx::InputContext* context,
     selectionKeys_ = fcitx::Key::keyListFromString(
         "Shift+1 Shift+2 Shift+3 Shift+4 Shift+5 Shift+6 Shift+7 Shift+8 "
         "Shift+9");
-#ifdef USE_LEGACY_FCITX5_API
-#else
     std::vector<std::string> labels = {
         "⇧1. ", "⇧2. ", "⇧3. ", "⇧4. ", "⇧5. ", "⇧6. ", "⇧7. ", "⇧8. ", "⇧9. ",
     };
     candidateList->setLabels(labels);
-#endif
     candidateList->setPageSize(static_cast<int>(selectionKeys_.size()));
   } else {
     if (keysConfig == SelectionKeys::Key_asdfghjkl) {
@@ -1535,37 +1493,22 @@ void McBopomofoEngine::handleCandidatesState(fcitx::InputContext* context,
         displayText += ")";
       }
 
-#ifdef USE_LEGACY_FCITX5_API
-      fcitx::CandidateWord* candidate = new McBopomofoCandidateWord(
-          fcitx::Text(displayText), c, choosing->originalCursor, keyHandler_,
-          callback);
-      // ownership of candidate is transferred to candidateList.
-      candidateList->append(candidate);
-#else
       std::unique_ptr<fcitx::CandidateWord> candidate =
           std::make_unique<McBopomofoCandidateWord>(fcitx::Text(displayText), c,
                                                     choosing->originalCursor,
                                                     keyHandler_, callback);
       candidateList->append(std::move(candidate));
-#endif
     }
   } else if (selectingDictionary != nullptr) {
     size_t index = 0;
     for (const auto& menuItem : selectingDictionary->menu) {
       std::string displayText = menuItem;
 
-#ifdef USE_LEGACY_FCITX5_API
-      fcitx::CandidateWord* candidate = new McBopomofoDictionaryServiceWord(
-          fcitx::Text(displayText), index, selectingDictionary, keyHandler_,
-          callback);
-      candidateList->append(candidate);
-#else
       std::unique_ptr<fcitx::CandidateWord> candidate =
           std::make_unique<McBopomofoDictionaryServiceWord>(
               fcitx::Text(displayText), index, selectingDictionary, keyHandler_,
               callback);
       candidateList->append(std::move(candidate));
-#endif
       index++;
     }
   } else if (showingCharInfo != nullptr) {
@@ -1579,101 +1522,59 @@ void McBopomofoEngine::handleCandidatesState(fcitx::InputContext* context,
     for (const auto& menuItem : menu) {
       std::string displayText = menuItem;
 
-#ifdef USE_LEGACY_FCITX5_API
-      fcitx::CandidateWord* candidate =
-          new McBopomofoTextOnlyCandidateWord(fcitx::Text(displayText));
-      candidateList->append(candidate);
-#else
       std::unique_ptr<fcitx::CandidateWord> candidate =
           std::make_unique<McBopomofoTextOnlyCandidateWord>(
               fcitx::Text(displayText));
       candidateList->append(std::move(candidate));
-#endif
     }
   } else if (associatedPhrases != nullptr) {
     std::vector<InputStates::ChoosingCandidate::Candidate> candidates =
         associatedPhrases->candidates;
 
     for (const auto& c : candidates) {
-#ifdef USE_LEGACY_FCITX5_API
-      fcitx::CandidateWord* candidate =
-          new McBopomofoAssociatedPhraseCandidateWord(
-              fcitx::Text(c.value), c, associatedPhrases->prefixReading,
-              associatedPhrases->prefixValue,
-              associatedPhrases->prefixCursorIndex, keyHandler_, callback);
-      // ownership of candidate is transferred to candidateList.
-      candidateList->append(candidate);
-#else
       std::unique_ptr<fcitx::CandidateWord> candidate =
           std::make_unique<McBopomofoAssociatedPhraseCandidateWord>(
               fcitx::Text(c.value), c, associatedPhrases->prefixReading,
               associatedPhrases->prefixValue,
               associatedPhrases->prefixCursorIndex, keyHandler_, callback);
       candidateList->append(std::move(candidate));
-#endif
     }
   } else if (associatedPhrasesPlain != nullptr) {
     std::vector<InputStates::ChoosingCandidate::Candidate> candidates =
         associatedPhrasesPlain->candidates;
     for (const auto& c : candidates) {
-#ifdef USE_LEGACY_FCITX5_API
-      fcitx::CandidateWord* candidate = new McBopomofoCandidateWord(
-          fcitx::Text(c.value), c, 0, keyHandler_, callback);
-      // ownership of candidate is transferred to candidateList.
-      candidateList->append(candidate);
-#else
       std::unique_ptr<fcitx::CandidateWord> candidate =
           std::make_unique<McBopomofoCandidateWord>(fcitx::Text(c.value), c, 0,
                                                     keyHandler_, callback);
       candidateList->append(std::move(candidate));
-#endif
     }
   } else if (selectingFeature != nullptr) {
     size_t index = 0;
     for (const auto& menuItem : selectingFeature->features) {
       std::string displayText = menuItem.name;
 
-#ifdef USE_LEGACY_FCITX5_API
-      fcitx::CandidateWord* candidate =
-          new McBopomofoFeatureWord(fcitx::Text(displayText), index,
-                                    selectingFeature, keyHandler_, callback);
-      candidateList->append(candidate);
-#else
       std::unique_ptr<fcitx::CandidateWord> candidate =
           std::make_unique<McBopomofoFeatureWord>(fcitx::Text(displayText),
                                                   index, selectingFeature,
                                                   keyHandler_, callback);
       candidateList->append(std::move(candidate));
-#endif
       index++;
     }
   } else if (selectingDateMacro != nullptr) {
     for (const auto& displayText : selectingDateMacro->menu) {
-#ifdef USE_LEGACY_FCITX5_API
-      fcitx::CandidateWord* candidate = new McBopomofoDirectInsertWord(
-          fcitx::Text(displayText), displayText, callback);
-      candidateList->append(candidate);
-#else
       std::unique_ptr<fcitx::CandidateWord> candidate =
           std::make_unique<McBopomofoDirectInsertWord>(fcitx::Text(displayText),
                                                        displayText, callback);
       candidateList->append(std::move(candidate));
-#endif
     }
   } else if (customMenu != nullptr) {
     size_t index = 0;
     for (const auto& entry : customMenu->entries) {
       std::string displayText = entry.name;
-#ifdef USE_LEGACY_FCITX5_API
-      fcitx::CandidateWord* candidate = new McBopomofoCustomMenuWord(
-          fcitx::Text(displayText), index, customMenu);
-      candidateList->append(candidate);
-#else
       std::unique_ptr<fcitx::CandidateWord> candidate =
           std::make_unique<McBopomofoCustomMenuWord>(fcitx::Text(displayText),
                                                      index, customMenu);
       candidateList->append(std::move(candidate));
-#endif
       index++;
     }
   }
@@ -1705,15 +1606,9 @@ void McBopomofoEngine::handleChineseNumberState(
 
   bool useClientPreedit =
       context->capabilityFlags().test(fcitx::CapabilityFlag::Preedit);
-#ifdef USE_LEGACY_FCITX5_API
-  fcitx::TextFormatFlags normalFormat{useClientPreedit
-                                          ? fcitx::TextFormatFlag::Underline
-                                          : fcitx::TextFormatFlag::None};
-#else
   fcitx::TextFormatFlags normalFormat{useClientPreedit
                                           ? fcitx::TextFormatFlag::Underline
                                           : fcitx::TextFormatFlag::NoFlag};
-#endif
   fcitx::Text preedit;
   preedit.append(current->composingBuffer(), normalFormat);
   preedit.setCursor(static_cast<int>(current->composingBuffer().length()));
@@ -1734,15 +1629,9 @@ void McBopomofoEngine::handleEnclosingNumberState(
 
   bool useClientPreedit =
       context->capabilityFlags().test(fcitx::CapabilityFlag::Preedit);
-#ifdef USE_LEGACY_FCITX5_API
-  fcitx::TextFormatFlags normalFormat{useClientPreedit
-                                          ? fcitx::TextFormatFlag::Underline
-                                          : fcitx::TextFormatFlag::None};
-#else
   fcitx::TextFormatFlags normalFormat{useClientPreedit
                                           ? fcitx::TextFormatFlag::Underline
                                           : fcitx::TextFormatFlag::NoFlag};
-#endif
   fcitx::Text preedit;
   preedit.append(current->composingBuffer(), normalFormat);
   preedit.setCursor(static_cast<int>(current->composingBuffer().length()));
@@ -1799,15 +1688,9 @@ void McBopomofoEngine::updatePreedit(fcitx::InputContext* context,
                                      InputStates::NotEmpty* state) {
   bool useClientPreedit =
       context->capabilityFlags().test(fcitx::CapabilityFlag::Preedit);
-#ifdef USE_LEGACY_FCITX5_API
-  fcitx::TextFormatFlags normalFormat{useClientPreedit
-                                          ? fcitx::TextFormatFlag::Underline
-                                          : fcitx::TextFormatFlag::None};
-#else
   fcitx::TextFormatFlags normalFormat{useClientPreedit
                                           ? fcitx::TextFormatFlag::Underline
                                           : fcitx::TextFormatFlag::NoFlag};
-#endif
   fcitx::Text preedit;
   if (auto* marking = dynamic_cast<InputStates::Marking*>(state)) {
     preedit.append(marking->head, normalFormat);


### PR DESCRIPTION
Also removes CI builds on Ubuntu 20.04 and Mint 20

Fixes #205

I also updated the wiki at https://github.com/openvanilla/fcitx5-mcbopomofo/wiki/如何在-Ubuntu-20.04-LTS-上編譯 to reflect the fact that 2.9.2 is the last version that can be built with the legacy fcitx5 API.
