### PR TITLE
Fix Manjaro build failures

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -111,7 +111,7 @@ jobs:
       - uses: actions/checkout@v5
       - name: Install dependencies
         run: |
-          pacman -Sy
+          pacman -Sy --noconfirm archlinux-keyring
           pacman -Sy --noconfirm gcc cmake make pkg-config extra-cmake-modules fmt fcitx5 fcitx5-chinese-addons fcitx5-gtk fcitx5-qt
       - name: Build
         run: |


### PR DESCRIPTION
### **User description**
This fixes the Manjaro build failures we have been seeing lately. Seems a pretty common issue.


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Stabilize Manjaro CI dependency installation

- Pre-install archlinux-keyring non-interactively


___

### Diagram Walkthrough


```mermaid
flowchart LR
  CI["GitHub Actions CI"] -- runs --> ManjaroJob["Manjaro build job"]
  ManjaroJob -- before --> PacmanSync["pacman -Sy"]
  ManjaroJob -- after --> KeyringSync["pacman -Sy --noconfirm archlinux-keyring"]
  KeyringSync -- enables --> DepsInstall["Install build/runtime deps"]
  DepsInstall -- enables --> BuildStep["CMake build"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ci.yaml</strong><dd><code>Pre-install pacman keyring to fix Manjaro CI</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/ci.yaml

<ul><li>Add <code>--noconfirm archlinux-keyring</code> to initial pacman sync<br> <li> Keep non-interactive install for required build dependencies</ul>


</details>


  </td>
  <td><a href="https://github.com/openvanilla/fcitx5-mcbopomofo/pull/213/files#diff-944291df2c9c06359d37cc8833d182d705c9e8c3108e7cfe132d61a06e9133dd">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

