### PR TITLE
Prompt when reading and composed lengths differ

### DIFF
--- a/src/KeyHandler.cpp
+++ b/src/KeyHandler.cpp
@@ -1455,9 +1455,13 @@ KeyHandler::ComposedString KeyHandler::getComposedString(size_t builderCursor) {
     runningCursor += distance;
 
     // Create a tooltip to warn the user that their cursor is between two
-    // readings (syllables) even if the cursor is not in the middle of a
-    // composed string due to its being shorter than the number of readings.
-    if (valueCodePointCount < readingLength) {
+    // readings (syllables) either because the composed string's code point
+    // count is shorter than the number of readings (in such cases the cursor
+    // may move within the same code point more than once) or because the
+    // composed string's code point count is longer than the number of
+    // readings (in such cases a cursor movement may skip over more than one
+    // code point in the composed string).
+    if (valueCodePointCount != readingLength) {
       // builderCursor is guaranteed to be > 0. If it was 0, we wouldn't even
       // reach here due to runningCursor having already "caught up" with
       // builderCursor. It is also guaranteed to be less than the size of the


### PR DESCRIPTION
Before this commit, fcitx5-mcbopomofo only prompts for cursor position when the composed string's code point count is less than the reading count. This commit makes sure that it also prompts when the code point count is bigger than the reading count. This syncs the behavior with that in the macOS version.

Screenshot for the existing behavior:

<img width="412" height="107" alt="screenshot1" src="https://github.com/user-attachments/assets/0efa15e7-1d15-4622-b6fa-2e56fd8dc558" />

Screenshot for the updated behavior:

<img width="412" height="107" alt="screenshot2" src="https://github.com/user-attachments/assets/fea3eb81-cf16-4670-b67a-4e8b2576ee6e" />

Now that we allow spaces in user-defined phrases, this adjustment should come in handy.
