### PR TITLE
Handle force-commit without the reading string

### DIFF
--- a/src/KeyHandler.cpp
+++ b/src/KeyHandler.cpp
@@ -645,6 +645,11 @@ bool KeyHandler::handleCandidateKeyForTraditionalBopomofoIfRequired(
   return false;
 }
 
+std::string KeyHandler::getForceCommitComposingBufferWithoutReading() {
+  auto composedString = getComposedString(grid_.cursor());
+  return composedString.head + composedString.tail;
+}
+
 void KeyHandler::boostPhrase(const std::string& reading,
                              const std::string& value) {
   userPhraseAdder_->addUserPhrase(reading, value);

--- a/src/KeyHandler.h
+++ b/src/KeyHandler.h
@@ -95,6 +95,11 @@ class KeyHandler {
       Key key, SelectCurrentCandidateCallback SelectCurrentCandidateCallback,
       StateCallback stateCallback, ErrorCallback errorCallback);
 
+  // Get the remnant of the composing buffer if a force-commit is needed. This
+  // provides the input method engine a way to quickly reset itself by
+  // disregarding its current internal state.
+  std::string getForceCommitComposingBufferWithoutReading();
+
   void boostPhrase(const std::string& reading, const std::string& value);
 
   void excludePhrase(const std::string& reading, const std::string& value);

--- a/src/KeyHandlerTest.cpp
+++ b/src/KeyHandlerTest.cpp
@@ -389,4 +389,17 @@ TEST_F(
   ASSERT_TRUE(emptyState != nullptr);
 }
 
+TEST_F(KeyHandlerTest, ForceCommitStringContainsNoReading) {
+  auto keys = asciiKeys("5j/ jp6");
+  keys.emplace_back(Key::namedKey(Key::KeyName::LEFT));
+  keys.emplace_back(Key::asciiKey('g'));  // ㄕ
+  keys.emplace_back(Key::asciiKey('j'));  // ㄨ
+  auto endState = handleKeySequence(keys);
+  auto inputtingState = dynamic_cast<InputStates::Inputting*>(endState.get());
+  ASSERT_TRUE(inputtingState != nullptr);
+  ASSERT_EQ(inputtingState->composingBuffer, "中ㄕㄨ文");
+  ASSERT_EQ(inputtingState->cursorIndex, strlen("中ㄕㄨ"));
+  ASSERT_EQ(keyHandler_->getForceCommitComposingBufferWithoutReading(), "中文");
+}
+
 }  // namespace McBopomofo


### PR DESCRIPTION
This fixes #218

This makes fcitx5-mcbopomofo in sync with its macOS version's behavior, see https://github.com/openvanilla/McBopomofo/pull/340. Notice though that we are not letting the key handler to do any more state transitions, for the reason noted in the comments.
