### PR TITLE
Fix preedit visibility in terminal applications

### DIFF
--- a/src/McBopomofo.cpp
+++ b/src/McBopomofo.cpp
@@ -1653,11 +1653,7 @@ void McBopomofoEngine::handleStateWithCustomInput(fcitx::InputContext* context,
   preedit.append(composingBuffer, normalFormat);
   preedit.setCursor(static_cast<int>(composingBuffer.length()));
 
-  if (useClientPreedit) {
-    context->inputPanel().setClientPreedit(preedit);
-  } else {
-    context->inputPanel().setPreedit(preedit);
-  }
+  setPreeditText(context, preedit);
   context->updatePreedit();
 }
 
@@ -1702,6 +1698,15 @@ fcitx::CandidateLayoutHint McBopomofoEngine::getCandidateLayoutHint() const {
   return layoutHint;
 }
 
+void McBopomofoEngine::setPreeditText(fcitx::InputContext* context,
+                                      const fcitx::Text& preedit) {
+  // Set both client and server preedit to ensure visibility across all
+  // applications, including those that don't properly support the Preedit
+  // capability (e.g., terminal applications).
+  context->inputPanel().setClientPreedit(preedit);
+  context->inputPanel().setPreedit(preedit);
+}
+
 void McBopomofoEngine::updatePreedit(fcitx::InputContext* context,
                                      InputStates::NotEmpty* state) {
   bool useClientPreedit =
@@ -1722,11 +1727,7 @@ void McBopomofoEngine::updatePreedit(fcitx::InputContext* context,
   }
   preedit.setCursor(static_cast<int>(state->cursorIndex));
 
-  if (useClientPreedit) {
-    context->inputPanel().setClientPreedit(preedit);
-  } else {
-    context->inputPanel().setPreedit(preedit);
-  }
+  setPreeditText(context, preedit);
 
   context->inputPanel().setAuxDown(fcitx::Text(state->tooltip));
   context->updatePreedit();

--- a/src/McBopomofo.h
+++ b/src/McBopomofo.h
@@ -271,6 +271,10 @@ class McBopomofoEngine : public fcitx::InputMethodEngine {
 
   // Helpers.
 
+  // Sets both client and server preedit to ensure visibility across all
+  // applications.
+  void setPreeditText(fcitx::InputContext* context, const fcitx::Text& preedit);
+
   // Updates the preedit with a not-empty state's composing buffer and
   // cursor index.
   void updatePreedit(fcitx::InputContext* context,


### PR DESCRIPTION
## Problem
Chinese character preview (preedit) is not visible in terminal-based applications like GitHub Copilot CLI.

## Root Cause
The current implementation uses an if-else condition to set either `setClientPreedit()` or `setPreedit()` based on the `Preedit` capability flag. Terminal applications typically don't advertise this capability, so only server-side preedit is set. However, for proper visibility across all applications, both should be set.

## Solution
Set both client and server preedit unconditionally. This ensures the composing buffer is visible in:
- Terminal applications (like Copilot CLI)
- GUI applications with proper preedit support
- Applications with partial or non-standard preedit implementations

## Changes
- Modified `handleStateWithCustomInput()` to always set both preeeedits
- Modified `updatePreedit()` to always set both preeeedits
- Removed conditional logic that only set one or the other

## Testing
Tested with GitHub Copilot CLI in terminal - Chinese preview now visible during input.

Fixes the terminal preedit visibility issue without affecting existing GUI application behavior.