### PR TITLE
Fix the Qodo code review agent CI configuration that stopped working

### DIFF
--- a/.github/workflows/qodo-pr-agent.yaml
+++ b/.github/workflows/qodo-pr-agent.yaml
@@ -17,8 +17,11 @@ jobs:
     steps:
       - name: PR Agent action step
         id: pragent
-        uses: docker://codiumai/pr-agent:latest
+        uses: docker://codiumai/pr-agent:github_action
         env:
           OPENAI_KEY: ${{ secrets.OPENAI_KEY }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
- 
+          github_action_config.auto_review: "true" # enable\disable auto review
+          github_action_config.auto_describe: "true" # enable\disable auto describe
+          github_action_config.auto_improve: "true" # enable\disable auto improve
+          github_action_config.pr_actions: '["opened", "reopened", "ready_for_review", "review_requested"]'


### PR DESCRIPTION
This PR:

* Attempts to make Qodo's code review agent work again before we make a decision for its continued use
* Rename the confusing file name—it should have been "*codium*-ai-pr-agent" not "*codeium*-pr-agent", but now that they have rebranded themselves as Qodo, let's use that.

