### PR TITLE
Fix the Shift+[1-9] handling in NumberInput state

### DIFF
--- a/src/McBopomofo.cpp
+++ b/src/McBopomofo.cpp
@@ -808,8 +808,8 @@ bool McBopomofoEngine::handleCandidateKeyEvent(
 
   bool shouldUseShiftKey =
       associatedPhrasesPlain != nullptr ||
-      (associatedPhrases != nullptr && associatedPhrases->useShiftKey &&
-       config_.shiftEnterEnabled.value());
+      (associatedPhrases != nullptr && associatedPhrases->useShiftKey) ||
+      numberInput != nullptr;
 
   // Plain Bopomofo and Associated Phrases.
   if (shouldUseShiftKey || numberInput != nullptr) {


### PR DESCRIPTION
The candidate panel were not handling the Shift+[1-9] keys.

This commit also fixes a bug that such Shift keys were not handled when Shift+Enter was disabled for associated phrases. With the v2 associated phrases always prompting when such phrases are available, the shift keys always need to be handled.