### PR TITLE
Always handles Shift+[1-9] for Associated Phrases.

### DIFF
--- a/src/McBopomofo.cpp
+++ b/src/McBopomofo.cpp
@@ -808,10 +808,9 @@ bool McBopomofoEngine::handleCandidateKeyEvent(
 
   bool shouldUseShiftKey =
       associatedPhrasesPlain != nullptr ||
-      (associatedPhrases != nullptr && associatedPhrases->useShiftKey &&
-       config_.shiftEnterEnabled.value());
+      (associatedPhrases != nullptr && associatedPhrases->useShiftKey);
 
-  // Plain Bopomofo and Associated Phrases.
+  // Plain Bopomofo, Associated Phrases, and Number Input.
   if (shouldUseShiftKey || numberInput != nullptr) {
     int code = origKey.code();
     // Shift-[1-9] keys can only be checked via raw key codes. The Key objects


### PR DESCRIPTION
Shift+[1-9] keys were not handled when Shift+Enter was disabled for associated phrases. With the v2 associated phrases always prompting when such phrases are available, those keys need to be handled.