### PR TITLE
Handle candidate keys correctly in the NumberInput

### DIFF
--- a/src/KeyHandler.cpp
+++ b/src/KeyHandler.cpp
@@ -1125,12 +1125,18 @@ bool KeyHandler::handleNumberInput(Key key,
         std::make_unique<InputStates::NumberInput>(newNumber, candidates);
     stateCallback(std::move(newState));
     return true;
+  } else if (!state->candidates.empty()) {
+    // If the candidate panel is visible, let it handle the key.
+    return false;
   } else if (std::isprint(key.ascii)) {
+    // Reject all other printable, non-numeric keys.
     errorCallback();
     return true;
   }
 
-  return false;
+  // If the buffer is empty, all other keys (e.g. cursor keys) exit the state.
+  stateCallback(std::make_unique<InputStates::EmptyIgnoringPrevious>());
+  return true;
 }
 
 bool KeyHandler::handleBig5(Key key, McBopomofo::InputStates::Big5* state,

--- a/src/McBopomofo.cpp
+++ b/src/McBopomofo.cpp
@@ -716,13 +716,6 @@ void McBopomofoEngine::keyEvent(const fcitx::InputMethodEntry& /*unused*/,
       keyEvent.filterAndAccept();
       return;
     }
-    InputStates::NumberInput* currentNumberInput =
-        dynamic_cast<InputStates::NumberInput*>(state_.get());
-    if (currentNumberInput != nullptr) {
-      if (currentNumberInput->candidates.empty()) {
-        return;
-      }
-    }
   }
 
   if (dynamic_cast<InputStates::ChoosingCandidate*>(state_.get()) != nullptr ||


### PR DESCRIPTION
This fixes a regression introduced in https://github.com/openvanilla/fcitx5-mcbopomofo/pull/225 that consumes the Shift+[1-9] keys when there are candidates. `Key::ascii` alone is not enough to determine that it's produced from a Shift+[1-9] key, and such keys must be not be consumed in KeyHandler when the candidate panel is visible. The regression also caused Space to be consumed unconditionally, casuing Space to fail to work as the page flip key in the candidate panel.

This also exits the NumberInput state when a non-alphanumeric key is pressed when the number composition buffer is empty. This fixes the problem that the number prompt ("[數字]") got force-committed by the client app when fcitx5 was told that the key was not handled.