### PR TITLE
Bump version to 2.9.5

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.10)
-project(fcitx5-mcbopomofo VERSION 2.9.4)
+project(fcitx5-mcbopomofo VERSION 2.9.5)
 
 find_package(ECM REQUIRED 1.0.0)
 set(CMAKE_MODULE_PATH ${ECM_MODULE_PATH} "${CMAKE_CURRENT_SOURCE_DIR}/cmake" ${CMAKE_MODULE_PATH})

--- a/org.fcitx.Fcitx5.Addon.McBopomofo.metainfo.xml.in
+++ b/org.fcitx.Fcitx5.Addon.McBopomofo.metainfo.xml.in
@@ -14,6 +14,7 @@
   <url type="vcs-browser">https://github.com/openvanilla/fcitx5-mcbopomofo</url>
   <project_group>Fcitx</project_group>
   <releases>
+    <release version="2.9.5" date="2025-12-19"/>
     <release version="2.9.4" date="2025-11-19"/>
     <release version="2.9.2" date="2025-07-07"/>
     <release version="2.9.1" date="2025-02-27"/>

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.10)
-project(mcbopomofo VERSION 2.9.4)
+project(mcbopomofo VERSION 2.9.5)
 
 find_package(PkgConfig REQUIRED)
 find_package(Fcitx5Core REQUIRED)


### PR DESCRIPTION
- Streamlined, consolidated number input mode
- Fixes the mismapped '9' key on numpad
- Fixes non-functional Shift+[1-9] keys if Shift+Enter was disabled for associated phrases
