### PR TITLE
Update actions/checkout to version 6

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     container: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - name: Install dependencies
         run: |
           export DEBIAN_FRONTEND=noninteractive
@@ -49,7 +49,7 @@ jobs:
     container: archlinux:base-devel
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - name: Update pacman mirror list
         run: |
           pacman -Syy
@@ -79,7 +79,7 @@ jobs:
     runs-on: ubuntu-latest
     container: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - name: Install dependencies
         run: |
           dnf -y install gcc g++
@@ -101,7 +101,7 @@ jobs:
     runs-on: ubuntu-latest
     container: manjarolinux/base:latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - name: Install dependencies
         run: |
           pacman -Sy --noconfirm archlinux-keyring


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow configuration to use the latest major version of the `actions/checkout` action across all CI jobs. This change ensures that the workflow benefits from the latest features, security patches, and bug fixes provided by `actions/checkout@v6`.

Workflow configuration updates:

* Updated the `actions/checkout` action from version `v5` to `v6` in all CI job steps within `.github/workflows/ci.yaml`. [[1]](diffhunk://#diff-944291df2c9c06359d37cc8833d182d705c9e8c3108e7cfe132d61a06e9133ddL24-R24) [[2]](diffhunk://#diff-944291df2c9c06359d37cc8833d182d705c9e8c3108e7cfe132d61a06e9133ddL52-R52) [[3]](diffhunk://#diff-944291df2c9c06359d37cc8833d182d705c9e8c3108e7cfe132d61a06e9133ddL82-R82) [[4]](diffhunk://#diff-944291df2c9c06359d37cc8833d182d705c9e8c3108e7cfe132d61a06e9133ddL104-R104)