### PR TITLE
feat: persist UserOverrideModel across sessions

### DIFF
--- a/src/Engine/UserOverrideModel.cpp
+++ b/src/Engine/UserOverrideModel.cpp
@@ -26,7 +26,9 @@
 
 #include <cassert>
 #include <cmath>
+#include <fstream>
 #include <list>
+#include <sstream>
 #include <string>
 #include <utility>
 #include <vector>
@@ -295,6 +297,118 @@ static std::string FormObservationKey(
   }
 
   return anteriorStr + "-" + prevStr + "-" + headStr;
+}
+
+static constexpr char kFileHeader[] = "mcbopomofo-user-override-model-v1";
+
+bool UserOverrideModel::save(const std::filesystem::path& path) const {
+  std::ofstream ofs(path, std::ios::out | std::ios::trunc);
+  if (!ofs.is_open()) {
+    return false;
+  }
+
+  ofs << kFileHeader << "\n";
+
+  // Write entries in LRU order (front = most recently used).
+  for (const auto& [key, observation] : lruList_) {
+    // ENTRY line: key <TAB> observation_count
+    ofs << "E\t" << key << "\t" << observation.count << "\n";
+    // OVERRIDE lines: candidate <TAB> count <TAB> timestamp <TAB> forceHigh
+    for (const auto& [candidate, override_] : observation.overrides) {
+      ofs << "O\t" << candidate << "\t" << override_.count << "\t"
+          << std::fixed << override_.timestamp << "\t"
+          << (override_.forceHighScoreOverride ? 1 : 0) << "\n";
+    }
+  }
+
+  return ofs.good();
+}
+
+bool UserOverrideModel::load(const std::filesystem::path& path) {
+  std::ifstream ifs(path);
+  if (!ifs.is_open()) {
+    return false;
+  }
+
+  std::string header;
+  if (!std::getline(ifs, header) || header != kFileHeader) {
+    return false;
+  }
+
+  // Clear existing data.
+  lruList_.clear();
+  lruMap_.clear();
+
+  // We read entries in file order (front of file = most recently used in LRU).
+  // To reconstruct the LRU in the same order, we push_back (so the first entry
+  // read ends up at the front after we reverse, or we just push_back and accept
+  // that the LRU order is preserved as-is since we read front-to-back).
+  std::string line;
+  std::string currentKey;
+  Observation currentObservation;
+  bool hasEntry = false;
+
+  auto commitEntry = [&]() {
+    if (!hasEntry) {
+      return;
+    }
+    if (lruList_.size() >= capacity_) {
+      return;  // Respect capacity.
+    }
+    auto pair = KeyObservationPair(currentKey, currentObservation);
+    lruList_.push_back(pair);
+    auto it = lruList_.end();
+    --it;
+    lruMap_[currentKey] = it;
+    hasEntry = false;
+    currentObservation = Observation();
+  };
+
+  while (std::getline(ifs, line)) {
+    if (line.empty() || line[0] == '#') {
+      continue;
+    }
+
+    std::istringstream iss(line);
+    std::string type;
+    if (!std::getline(iss, type, '\t')) {
+      continue;
+    }
+
+    if (type == "E") {
+      // Commit previous entry if any.
+      commitEntry();
+
+      std::string obsCountStr;
+      if (!std::getline(iss, currentKey, '\t') ||
+          !std::getline(iss, obsCountStr, '\t')) {
+        continue;
+      }
+      currentObservation.count = std::stoull(obsCountStr);
+      hasEntry = true;
+    } else if (type == "O" && hasEntry) {
+      std::string candidate;
+      std::string countStr;
+      std::string tsStr;
+      std::string forceStr;
+      if (!std::getline(iss, candidate, '\t') ||
+          !std::getline(iss, countStr, '\t') ||
+          !std::getline(iss, tsStr, '\t') ||
+          !std::getline(iss, forceStr, '\t')) {
+        continue;
+      }
+      Override o;
+      o.count = std::stoull(countStr);
+      o.timestamp = std::stod(tsStr);
+      o.forceHighScoreOverride = (forceStr == "1");
+      currentObservation.overrides[candidate] = o;
+    }
+  }
+
+  // Commit the last entry.
+  commitEntry();
+
+  return true;
 }
 
 }  // namespace McBopomofo

--- a/src/Engine/UserOverrideModel.h
+++ b/src/Engine/UserOverrideModel.h
@@ -24,6 +24,7 @@
 #ifndef SRC_ENGINE_USEROVERRIDEMODEL_H_
 #define SRC_ENGINE_USEROVERRIDEMODEL_H_
 
+#include <filesystem>
 #include <list>
 #include <map>
 #include <string>
@@ -61,6 +62,10 @@ class UserOverrideModel {
                double timestamp, bool forceHighScoreOverride = false);
 
   Suggestion suggest(const std::string& key, double timestamp);
+
+  // Persistence: save/load the model to/from a file.
+  bool save(const std::filesystem::path& path) const;
+  bool load(const std::filesystem::path& path);
 
  private:
   struct Override {

--- a/src/KeyHandler.cpp
+++ b/src/KeyHandler.cpp
@@ -1698,6 +1698,7 @@ void KeyHandler::pinNodeWithAssociatedPhrase(
   if (!grid_.overrideCandidate(actualPrefixCursorIndex, prefixCandidate)) {
     return;
   }
+  Formosa::Gramambular2::ReadingGrid::WalkResult prevWalk = latestWalk_;
   walk();
 
   // Now we've set ourselves up. Because associated phrases require the strict
@@ -1740,9 +1741,23 @@ void KeyHandler::pinNodeWithAssociatedPhrase(
   }
 
   walk();
+
+  // Update the user override model for the prefix selection, mirroring the
+  // logic in pinNode().
+  userOverrideModel_.observe(prevWalk, latestWalk_, actualPrefixCursorIndex,
+                             GetEpochNowInSeconds());
+
   // Cursor is already at accumulatedCursor, so no more work here.
 }
 
 void KeyHandler::walk() { latestWalk_ = grid_.walk(); }
+
+bool KeyHandler::saveUserOverrideModel(const std::filesystem::path& path) {
+  return userOverrideModel_.save(path);
+}
+
+bool KeyHandler::loadUserOverrideModel(const std::filesystem::path& path) {
+  return userOverrideModel_.load(path);
+}
 
 }  // namespace McBopomofo

--- a/src/KeyHandler.h
+++ b/src/KeyHandler.h
@@ -24,6 +24,7 @@
 #ifndef SRC_KEYHANDLER_H_
 #define SRC_KEYHANDLER_H_
 
+#include <filesystem>
 #include <functional>
 #include <memory>
 #include <string>
@@ -166,6 +167,10 @@ class KeyHandler {
 
   // Sets whether to enable the Bopomofo variant annotator.
   void setBopomofoFontAnnotationSupportEnabled(bool enabled);
+
+  // Persistence for user override model.
+  bool saveUserOverrideModel(const std::filesystem::path& path);
+  bool loadUserOverrideModel(const std::filesystem::path& path);
 
   bool bopomofoFontAnnotationSupportEnabled() const {
     return bopomofoFontAnnotationSupportEnabled_;

--- a/src/McBopomofo.cpp
+++ b/src/McBopomofo.cpp
@@ -31,6 +31,7 @@
 #include <fmt/format.h>
 #include <notifications_public.h>  // from fcitx-module/notifications
 
+#include <filesystem>
 #include <memory>
 #include <sstream>
 #include <string>
@@ -46,6 +47,7 @@
 namespace McBopomofo {
 
 constexpr char kConfigPath[] = "conf/mcbopomofo.conf";
+constexpr char kUserOverrideModelFilename[] = "user-override-model.dat";
 
 // These two are used to determine whether Shift-[1-9] is pressed.
 constexpr int kFcitxRawKeycode_1 = 10;
@@ -581,6 +583,14 @@ McBopomofoEngine::McBopomofoEngine(fcitx::Instance* instance)
   // Required by convention of fcitx5 modules to load config on its own.
   // NOLINTNEXTLINE(clang-analyzer-optin.cplusplus.VirtualCall)
   reloadConfig();
+
+  // Load persisted user override model if available.
+  auto uomPath = languageModelLoader_->userDataPath() + "/" +
+                  kUserOverrideModelFilename;
+  if (std::filesystem::exists(uomPath)) {
+    keyHandler_->loadUserOverrideModel(uomPath);
+    FCITX_MCBOPOMOFO_INFO() << "Loaded user override model: " << uomPath;
+  }
 }
 
 const fcitx::Configuration* McBopomofoEngine::getConfig() const {
@@ -740,6 +750,11 @@ void McBopomofoEngine::reset(const fcitx::InputMethodEntry& /*unused*/,
   // our control, the approach here is likely the most sensible.
   if (event.type() == fcitx::EventType::InputContextFocusOut ||
       event.type() == fcitx::EventType::InputContextReset) {
+    // Persist user override model on focus-out / reset.
+    auto uomPath = languageModelLoader_->userDataPath() + "/" +
+                    kUserOverrideModelFilename;
+    keyHandler_->saveUserOverrideModel(uomPath);
+
     keyHandler_->reset();
 
     bool useClientPreedit =


### PR DESCRIPTION
## Summary

- **Persist UserOverrideModel to disk** so that learned candidate preferences survive across fcitx5 restarts. Previously, all UOM data was purely in-memory and lost on every restart.
- **Fix missing `observe()` call in `pinNodeWithAssociatedPhrase()`** — the UOM was never learning from associated phrase selections, unlike `pinNode()` which already had the call.

## Details

### Persistence
- Added `save()`/`load()` methods to `UserOverrideModel` using a simple tab-separated text format (`user-override-model.dat`)
- Data is saved to `~/.local/share/fcitx5/mcbopomofo/user-override-model.dat`
- **Load**: on engine startup (constructor)
- **Save**: on input context focus-out or reset events

### Bug fix
- `pinNodeWithAssociatedPhrase()` now calls `userOverrideModel_.observe()` after `walk()`, mirroring the existing pattern in `pinNode()` (line 1639)

### File format
```
mcbopomofo-user-override-model-v1
E	(anterior)-(prev)-(head)	5
O	候選字	3	1711234567.000000	0
O	另一個	2	1711234568.000000	1
```

## Test plan
- [x] Builds cleanly with `cmake --build build` (zero warnings)
- [ ] Manual test: type and select candidates, verify `user-override-model.dat` is created after focus-out
- [ ] Manual test: restart fcitx5, verify previously learned preferences are restored
- [ ] Manual test: select associated phrases, verify they are also learned

🤖 Generated with [Claude Code](https://claude.com/claude-code)