### PR TITLE
Port Iroha Kana input to Linux

### DIFF
--- a/src/InputState.h
+++ b/src/InputState.h
@@ -355,6 +355,16 @@ struct CustomMenu : NotEmpty {
   std::vector<MenuEntry> entries;
 };
 
+// A sequence of states to be processed in order. This allows a single key
+// event to trigger multiple state transitions without calling the state
+// callback more than once.
+struct StateSequence : InputState {
+  explicit StateSequence(std::vector<std::unique_ptr<InputState>> states)
+      : states(std::move(states)) {}
+
+  std::vector<std::unique_ptr<InputState>> states;
+};
+
 }  // namespace InputStates
 
 }  // namespace McBopomofo

--- a/src/InputState.h
+++ b/src/InputState.h
@@ -278,6 +278,24 @@ struct Big5 : InputState {
   std::string hexCode;
 };
 
+struct Iroha : InputState {
+  explicit Iroha(std::string code = "") : code(std::move(code)) {}
+  Iroha(Iroha const& code) : code(code.code) {}
+  std::string composingBuffer() const { return "[伊呂波] " + code; }
+  std::string code;
+};
+
+struct IrohaCandidate : InputState {
+  explicit IrohaCandidate(std::string code = "",
+                          std::vector<std::string> candidates = {})
+      : code(std::move(code)), candidates(std::move(candidates)) {}
+  IrohaCandidate(IrohaCandidate const& other)
+      : code(other.code), candidates(other.candidates) {}
+  std::string composingBuffer() const { return "[伊呂波] " + code; }
+  std::string code;
+  std::vector<std::string> candidates;
+};
+
 struct SelectingDateMacro : InputState {
   explicit SelectingDateMacro(
       const std::function<std::string(std::string)>& converter);
@@ -304,6 +322,8 @@ struct SelectingFeature : InputState {
     features.emplace_back("數字輸入", []() {
       return std::make_unique<NumberInput>("", std::vector<std::string>());
     });
+    features.emplace_back("伊呂波假名輸入",
+                          []() { return std::make_unique<Iroha>(""); });
   }
 
   std::unique_ptr<InputState> nextState(size_t index) {

--- a/src/InputState.h
+++ b/src/InputState.h
@@ -357,10 +357,17 @@ struct CustomMenu : NotEmpty {
 
 // A sequence of states to be processed in order. This allows a single key
 // event to trigger multiple state transitions without calling the state
-// callback more than once.
+// callback more than once. StateSequence states are not allowed to be added
+// to prevent recursive sequences.
 struct StateSequence : InputState {
-  explicit StateSequence(std::vector<std::unique_ptr<InputState>> states)
-      : states(std::move(states)) {}
+  StateSequence() = default;
+
+  void push_back(std::unique_ptr<InputState> state) {
+    if (dynamic_cast<StateSequence*>(state.get()) != nullptr) {
+      return;
+    }
+    states.emplace_back(std::move(state));
+  }
 
   std::vector<std::unique_ptr<InputState>> states;
 };

--- a/src/KeyHandler.cpp
+++ b/src/KeyHandler.cpp
@@ -1215,11 +1215,10 @@ bool KeyHandler::handleIroha(Key key, McBopomofo::InputStates::Iroha* state,
       auto unigrams = lm_->getUnigrams(unigram);
       if (unigrams.size() == 1) {
         std::string value = unigrams[0].value();
-        std::vector<std::unique_ptr<InputState>> states;
-        states.emplace_back(std::make_unique<InputStates::Committing>(value));
-        states.emplace_back(std::make_unique<InputStates::Iroha>(""));
-        stateCallback(
-            std::make_unique<InputStates::StateSequence>(std::move(states)));
+        auto seq = std::make_unique<InputStates::StateSequence>();
+        seq->push_back(std::make_unique<InputStates::Committing>(value));
+        seq->push_back(std::make_unique<InputStates::Iroha>(""));
+        stateCallback(std::move(seq));
       } else {
         std::vector<std::string> candidates;
         for (const auto& unigram : unigrams) {

--- a/src/KeyHandler.cpp
+++ b/src/KeyHandler.cpp
@@ -1240,12 +1240,11 @@ bool KeyHandler::handleIroha(Key key, McBopomofo::InputStates::Iroha* state,
     std::string code = state->code;
     if (!code.empty()) {
       code = code.substr(0, code.length() - 1);
+      auto newState = std::make_unique<InputStates::Iroha>(code);
+      stateCallback(std::move(newState));
     } else {
-      errorCallback();
-      return true;
+      stateCallback(std::make_unique<InputStates::EmptyIgnoringPrevious>());
     }
-    auto newState = std::make_unique<InputStates::Iroha>(code);
-    stateCallback(std::move(newState));
     return true;
   }
 

--- a/src/KeyHandler.cpp
+++ b/src/KeyHandler.cpp
@@ -1228,6 +1228,7 @@ bool KeyHandler::handleIroha(Key key, McBopomofo::InputStates::Iroha* state,
             std::make_unique<InputStates::IrohaCandidate>(code, candidates);
         stateCallback(std::move(newState));
       }
+      return true;
     } else {
       errorCallback();
       auto newState = std::make_unique<InputStates::Iroha>("");
@@ -1251,7 +1252,7 @@ bool KeyHandler::handleIroha(Key key, McBopomofo::InputStates::Iroha* state,
   if ((key.ascii >= 'a' && key.ascii <= 'z') ||
       (key.ascii >= 'A' && key.ascii <= 'Z')) {
     std::string code = state->code;
-    if (code.length() <= 4)  // Big5 code is 4 hex digits.
+    if (code.length() <= 4)  // Iroha code is 4 hex digits.
     {
       std::string code =
           state->code + static_cast<char>(std::tolower(key.ascii));

--- a/src/KeyHandler.cpp
+++ b/src/KeyHandler.cpp
@@ -134,6 +134,11 @@ bool KeyHandler::handle(Key key, McBopomofo::InputState* state,
     return handleBig5(key, big5, stateCallback, errorCallback);
   }
 
+  auto* iroha = dynamic_cast<InputStates::Iroha*>(state);
+  if (iroha != nullptr) {
+    return handleIroha(key, iroha, stateCallback, errorCallback);
+  }
+
   // From Key's definition, if shiftPressed is true, it can't be a simple key
   // that can be represented by ASCII.
   char simpleAscii =
@@ -1184,6 +1189,78 @@ bool KeyHandler::handleBig5(Key key, McBopomofo::InputStates::Big5* state,
 
     auto newState = std::make_unique<InputStates::Big5>(newHexCode);
     stateCallback(std::move(newState));
+  } else {
+    errorCallback();
+  }
+  return true;
+}
+
+bool KeyHandler::handleIroha(Key key, McBopomofo::InputStates::Iroha* state,
+                             StateCallback stateCallback,
+                             KeyHandler::ErrorCallback errorCallback) {
+  if (key.ascii == Key::ESC) {
+    stateCallback(std::make_unique<InputStates::EmptyIgnoringPrevious>());
+    return true;
+  }
+
+  if (key.ascii == Key::RETURN || key.ascii == Key::SPACE) {
+    std::string code = state->code;
+    if (code.empty()) {
+      stateCallback(std::make_unique<InputStates::EmptyIgnoringPrevious>());
+      return true;
+    }
+
+    std::string unigram = "_kana_" + code;
+    if (lm_->hasUnigrams(unigram)) {
+      auto unigrams = lm_->getUnigrams(unigram);
+      if (unigrams.size() == 1) {
+        std::string value = unigrams[0].value();
+        auto committing = std::make_unique<InputStates::Committing>(value);
+        stateCallback(std::move(committing));
+        auto newState = std::make_unique<InputStates::Iroha>("");
+        stateCallback(std::move(newState));
+      } else {
+        std::vector<std::string> candidates;
+        for (const auto& unigram : unigrams) {
+          candidates.emplace_back(unigram.value());
+        }
+        auto newState =
+            std::make_unique<InputStates::IrohaCandidate>(code, candidates);
+        stateCallback(std::move(newState));
+      }
+    } else {
+      errorCallback();
+      auto newState = std::make_unique<InputStates::Iroha>("");
+      stateCallback(std::move(newState));
+      return true;
+    }
+  }
+
+  if (key.isDeleteKeys()) {
+    std::string code = state->code;
+    if (!code.empty()) {
+      code = code.substr(0, code.length() - 1);
+    } else {
+      errorCallback();
+      return true;
+    }
+    auto newState = std::make_unique<InputStates::Iroha>(code);
+    stateCallback(std::move(newState));
+    return true;
+  }
+
+  if ((key.ascii >= 'a' && key.ascii <= 'z') ||
+      (key.ascii >= 'A' && key.ascii <= 'Z')) {
+    std::string code = state->code;
+    if (code.length() <= 4)  // Big5 code is 4 hex digits.
+    {
+      std::string code =
+          state->code + static_cast<char>(std::tolower(key.ascii));
+      auto newState = std::make_unique<InputStates::Iroha>(code);
+      stateCallback(std::move(newState));
+    } else {
+      errorCallback();
+    }
   } else {
     errorCallback();
   }

--- a/src/KeyHandler.cpp
+++ b/src/KeyHandler.cpp
@@ -1215,10 +1215,11 @@ bool KeyHandler::handleIroha(Key key, McBopomofo::InputStates::Iroha* state,
       auto unigrams = lm_->getUnigrams(unigram);
       if (unigrams.size() == 1) {
         std::string value = unigrams[0].value();
-        auto committing = std::make_unique<InputStates::Committing>(value);
-        stateCallback(std::move(committing));
-        auto newState = std::make_unique<InputStates::Iroha>("");
-        stateCallback(std::move(newState));
+        std::vector<std::unique_ptr<InputState>> states;
+        states.push_back(std::make_unique<InputStates::Committing>(value));
+        states.push_back(std::make_unique<InputStates::Iroha>(""));
+        stateCallback(
+            std::make_unique<InputStates::StateSequence>(std::move(states)));
       } else {
         std::vector<std::string> candidates;
         for (const auto& unigram : unigrams) {

--- a/src/KeyHandler.cpp
+++ b/src/KeyHandler.cpp
@@ -1216,8 +1216,8 @@ bool KeyHandler::handleIroha(Key key, McBopomofo::InputStates::Iroha* state,
       if (unigrams.size() == 1) {
         std::string value = unigrams[0].value();
         std::vector<std::unique_ptr<InputState>> states;
-        states.push_back(std::make_unique<InputStates::Committing>(value));
-        states.push_back(std::make_unique<InputStates::Iroha>(""));
+        states.emplace_back(std::make_unique<InputStates::Committing>(value));
+        states.emplace_back(std::make_unique<InputStates::Iroha>(""));
         stateCallback(
             std::make_unique<InputStates::StateSequence>(std::move(states)));
       } else {

--- a/src/KeyHandler.h
+++ b/src/KeyHandler.h
@@ -222,6 +222,9 @@ class KeyHandler {
   bool handleBig5(Key key, McBopomofo::InputStates::Big5* state,
                   StateCallback stateCallback,
                   KeyHandler::ErrorCallback errorCallback);
+  bool handleIroha(Key key, McBopomofo::InputStates::Iroha* state,
+                   StateCallback stateCallback,
+                   KeyHandler::ErrorCallback errorCallback);
 
   bool handleTabKey(bool isShiftPressed, McBopomofo::InputState* state,
                     const StateCallback& stateCallback,

--- a/src/KeyHandlerTest.cpp
+++ b/src/KeyHandlerTest.cpp
@@ -144,12 +144,24 @@ class KeyHandlerTest : public ::testing::Test {
       handled = keyHandler_->handle(
           key, state.get(),
           [&state](std::unique_ptr<McBopomofo::InputState> newState) {
-            if (dynamic_cast<InputStates::EmptyIgnoringPrevious*>(
-                    newState.get()) != nullptr) {
-              // Transition required by the contract of EmptyIgnoringPrevious.
-              state = std::make_unique<InputStates::Empty>();
+            auto processState =
+                [&state](std::unique_ptr<McBopomofo::InputState> s) {
+                  if (dynamic_cast<InputStates::EmptyIgnoringPrevious*>(
+                          s.get()) != nullptr) {
+                    // Transition required by the contract of
+                    // EmptyIgnoringPrevious.
+                    state = std::make_unique<InputStates::Empty>();
+                  } else {
+                    state = std::move(s);
+                  }
+                };
+            if (auto* seq = dynamic_cast<InputStates::StateSequence*>(
+                    newState.get())) {
+              for (auto& s : seq->states) {
+                processState(std::move(s));
+              }
             } else {
-              state = std::move(newState);
+              processState(std::move(newState));
             }
           },
           [&errorCallbackInvoked]() { errorCallbackInvoked = true; });

--- a/src/McBopomofo.cpp
+++ b/src/McBopomofo.cpp
@@ -337,6 +337,24 @@ class McBopomofoDirectInsertWord : public fcitx::CandidateWord {
   KeyHandler::StateCallback callback;
 };
 
+class McBopomofoIrohaWord : public fcitx::CandidateWord {
+ public:
+  explicit McBopomofoIrohaWord(fcitx::Text displayText, std::string text,
+                               KeyHandler::StateCallback callback)
+      : fcitx::CandidateWord(std::move(displayText)),
+        text(std::move(text)),
+        callback(std::move(callback)) {}
+  void select(fcitx::InputContext* /*unused*/) const override {
+    std::vector<std::unique_ptr<InputState>> states;
+    states.emplace_back(std::make_unique<InputStates::Committing>(text));
+    states.emplace_back(std::make_unique<InputStates::Iroha>(""));
+    callback(std::make_unique<InputStates::StateSequence>(std::move(states)));
+  }
+
+  std::string text;
+  KeyHandler::StateCallback callback;
+};
+
 class McBopomofoTextOnlyCandidateWord : public fcitx::CandidateWord {
  public:
   explicit McBopomofoTextOnlyCandidateWord(fcitx::Text displayText)
@@ -1711,18 +1729,9 @@ void McBopomofoEngine::handleCandidatesState(fcitx::InputContext* context,
     }
   } else if (irohaCandidates != nullptr) {
     for (const auto& displayText : irohaCandidates->candidates) {
-      KeyHandler::StateCallback irohaCallback =
-          [callback](std::unique_ptr<InputState> next) {
-            std::vector<std::unique_ptr<InputState>> states;
-            states.emplace_back(std::move(next));
-            states.emplace_back(std::make_unique<InputStates::Iroha>(""));
-            callback(std::make_unique<InputStates::StateSequence>(
-                std::move(states)));
-          };
       std::unique_ptr<fcitx::CandidateWord> candidate =
-          std::make_unique<McBopomofoDirectInsertWord>(fcitx::Text(displayText),
-                                                       displayText,
-                                                       irohaCallback);
+          std::make_unique<McBopomofoIrohaWord>(fcitx::Text(displayText),
+                                               displayText, callback);
       candidateList->append(std::move(candidate));
     }
   } else if (customMenu != nullptr) {

--- a/src/McBopomofo.cpp
+++ b/src/McBopomofo.cpp
@@ -1714,8 +1714,8 @@ void McBopomofoEngine::handleCandidatesState(fcitx::InputContext* context,
       KeyHandler::StateCallback irohaCallback =
           [callback](std::unique_ptr<InputState> next) {
             std::vector<std::unique_ptr<InputState>> states;
-            states.push_back(std::move(next));
-            states.push_back(std::make_unique<InputStates::Iroha>(""));
+            states.emplace_back(std::move(next));
+            states.emplace_back(std::make_unique<InputStates::Iroha>(""));
             callback(std::make_unique<InputStates::StateSequence>(
                 std::move(states)));
           };

--- a/src/McBopomofo.cpp
+++ b/src/McBopomofo.cpp
@@ -337,6 +337,22 @@ class McBopomofoDirectInsertWord : public fcitx::CandidateWord {
   KeyHandler::StateCallback callback;
 };
 
+class McBopomofoIrohaWord : public fcitx::CandidateWord {
+ public:
+  explicit McBopomofoIrohaWord(fcitx::Text displayText, std::string text,
+                               KeyHandler::StateCallback callback)
+      : fcitx::CandidateWord(std::move(displayText)),
+        text(std::move(text)),
+        callback(std::move(callback)) {}
+  void select(fcitx::InputContext* /*unused*/) const override {
+    callback(std::make_unique<InputStates::Committing>(text));
+    callback(std::make_unique<InputStates::Iroha>());
+  }
+
+  std::string text;
+  KeyHandler::StateCallback callback;
+};
+
 class McBopomofoTextOnlyCandidateWord : public fcitx::CandidateWord {
  public:
   explicit McBopomofoTextOnlyCandidateWord(fcitx::Text displayText)
@@ -816,7 +832,8 @@ void McBopomofoEngine::keyEvent(const fcitx::InputMethodEntry& /*unused*/,
       dynamic_cast<InputStates::SelectingFeature*>(state_.get()) != nullptr ||
       dynamic_cast<InputStates::SelectingDateMacro*>(state_.get()) != nullptr ||
       dynamic_cast<InputStates::CustomMenu*>(state_.get()) != nullptr ||
-      dynamic_cast<InputStates::NumberInput*>(state_.get()) != nullptr) {
+      dynamic_cast<InputStates::NumberInput*>(state_.get()) != nullptr ||
+      dynamic_cast<InputStates::IrohaCandidate*>(state_.get()) != nullptr) {
     // Absorb all keys when the candidate panel is on.
     keyEvent.filterAndAccept();
 
@@ -851,6 +868,7 @@ void McBopomofoEngine::keyEvent(const fcitx::InputMethodEntry& /*unused*/,
         dynamic_cast<InputStates::SelectingFeature*>(state_.get()) != nullptr ||
         dynamic_cast<InputStates::SelectingDateMacro*>(state_.get()) !=
             nullptr ||
+        dynamic_cast<InputStates::IrohaCandidate*>(state_.get()) != nullptr ||
         dynamic_cast<InputStates::CustomMenu*>(state_.get()) != nullptr) {
       context->updateUserInterface(fcitx::UserInterfaceComponent::InputPanel);
       context->updatePreedit();
@@ -1466,6 +1484,11 @@ void McBopomofoEngine::enterNewState(fcitx::InputContext* context,
     handleCandidatesState(context, prevPtr, selectingDateMacro);
   } else if (auto* big5 = dynamic_cast<InputStates::Big5*>(currentPtr)) {
     handleStateWithCustomInput(context, big5->composingBuffer());
+  } else if (auto* iroha = dynamic_cast<InputStates::Iroha*>(currentPtr)) {
+    handleStateWithCustomInput(context, iroha->composingBuffer());
+  } else if (auto* irohaCandidates =
+                 dynamic_cast<InputStates::IrohaCandidate*>(currentPtr)) {
+    handleCandidatesState(context, prevPtr, irohaCandidates);
   } else if (auto* customMenu =
                  dynamic_cast<InputStates::CustomMenu*>(currentPtr)) {
     handleCandidatesState(context, prevPtr, customMenu);
@@ -1525,6 +1548,8 @@ void McBopomofoEngine::handleCandidatesState(fcitx::InputContext* context,
       dynamic_cast<InputStates::AssociatedPhrasesPlain*>(state_.get());
   InputStates::NumberInput* numberInput =
       dynamic_cast<InputStates::NumberInput*>(state_.get());
+  InputStates::IrohaCandidate* irohaCandidates =
+      dynamic_cast<InputStates::IrohaCandidate*>(state_.get());
 
   bool useShiftKey =
       numberInput != nullptr || associatedPhrasesPlain != nullptr ||
@@ -1686,6 +1711,13 @@ void McBopomofoEngine::handleCandidatesState(fcitx::InputContext* context,
       std::unique_ptr<fcitx::CandidateWord> candidate =
           std::make_unique<McBopomofoDirectInsertWord>(fcitx::Text(displayText),
                                                        displayText, callback);
+      candidateList->append(std::move(candidate));
+    }
+  } else if (irohaCandidates != nullptr) {
+    for (const auto& displayText : irohaCandidates->candidates) {
+      std::unique_ptr<fcitx::CandidateWord> candidate =
+          std::make_unique<McBopomofoIrohaWord>(fcitx::Text(displayText),
+                                                displayText, callback);
       candidateList->append(std::move(candidate));
     }
   } else if (customMenu != nullptr) {

--- a/src/McBopomofo.cpp
+++ b/src/McBopomofo.cpp
@@ -835,7 +835,7 @@ void McBopomofoEngine::keyEvent(const fcitx::InputMethodEntry& /*unused*/,
     bool handled = handleCandidateKeyEvent(
         context, key, origKey, maybeCandidateList,
         [this, context](std::unique_ptr<InputState> next) {
-          enterNewState(context, std::move(next));
+          handleStateOrSequence(context, std::move(next));
         },
         []() {
           // TODO(unassigned): beep?
@@ -865,7 +865,7 @@ void McBopomofoEngine::keyEvent(const fcitx::InputMethodEntry& /*unused*/,
   bool accepted = keyHandler_->handle(
       MapFcitxKey(key, origKey), state_.get(),
       [this, context](std::unique_ptr<InputState> next) {
-        enterNewState(context, std::move(next));
+        handleStateOrSequence(context, std::move(next));
       },
       []() {
         // TODO(unassigned): beep?
@@ -1479,6 +1479,18 @@ void McBopomofoEngine::enterNewState(fcitx::InputContext* context,
   }
 }
 
+void McBopomofoEngine::handleStateOrSequence(
+    fcitx::InputContext* context, std::unique_ptr<InputState> newState) {
+  if (auto* stateSeq =
+          dynamic_cast<InputStates::StateSequence*>(newState.get())) {
+    for (auto& s : stateSeq->states) {
+      enterNewState(context, std::move(s));
+    }
+  } else {
+    enterNewState(context, std::move(newState));
+  }
+}
+
 void McBopomofoEngine::handleEmptyState(fcitx::InputContext* context,
                                         InputState* prev,
                                         InputStates::Empty* /*unused*/) {
@@ -1499,7 +1511,7 @@ void McBopomofoEngine::handleEmptyIgnoringPreviousState(
 }
 
 void McBopomofoEngine::handleCommittingState(fcitx::InputContext* context,
-                                             InputState* prev,
+                                             InputState* /*prev*/,
                                              InputStates::Committing* current) {
   context->inputPanel().reset();
   context->updateUserInterface(fcitx::UserInterfaceComponent::InputPanel);
@@ -1507,12 +1519,6 @@ void McBopomofoEngine::handleCommittingState(fcitx::InputContext* context,
     context->commitString(current->text);
   }
   context->updatePreedit();
-
-  // If prev is an Iroha candidate state, transition to Iroha state.
-  if (auto* irohaCandidates =
-          dynamic_cast<InputStates::IrohaCandidate*>(prev)) {
-    enterNewState(context, std::make_unique<InputStates::Iroha>(""));
-  }
 }
 
 void McBopomofoEngine::handleInputtingState(fcitx::InputContext* context,
@@ -1586,7 +1592,7 @@ void McBopomofoEngine::handleCandidatesState(fcitx::InputContext* context,
 
   KeyHandler::StateCallback callback =
       [this, context](std::unique_ptr<InputState> next) {
-        enterNewState(context, std::move(next));
+        handleStateOrSequence(context, std::move(next));
       };
 
   auto* choosing = dynamic_cast<InputStates::ChoosingCandidate*>(current);
@@ -1705,9 +1711,18 @@ void McBopomofoEngine::handleCandidatesState(fcitx::InputContext* context,
     }
   } else if (irohaCandidates != nullptr) {
     for (const auto& displayText : irohaCandidates->candidates) {
+      KeyHandler::StateCallback irohaCallback =
+          [callback](std::unique_ptr<InputState> next) {
+            std::vector<std::unique_ptr<InputState>> states;
+            states.push_back(std::move(next));
+            states.push_back(std::make_unique<InputStates::Iroha>(""));
+            callback(std::make_unique<InputStates::StateSequence>(
+                std::move(states)));
+          };
       std::unique_ptr<fcitx::CandidateWord> candidate =
           std::make_unique<McBopomofoDirectInsertWord>(fcitx::Text(displayText),
-                                                       displayText, callback);
+                                                       displayText,
+                                                       irohaCallback);
       candidateList->append(std::move(candidate));
     }
   } else if (customMenu != nullptr) {

--- a/src/McBopomofo.cpp
+++ b/src/McBopomofo.cpp
@@ -337,22 +337,6 @@ class McBopomofoDirectInsertWord : public fcitx::CandidateWord {
   KeyHandler::StateCallback callback;
 };
 
-class McBopomofoIrohaWord : public fcitx::CandidateWord {
- public:
-  explicit McBopomofoIrohaWord(fcitx::Text displayText, std::string text,
-                               KeyHandler::StateCallback callback)
-      : fcitx::CandidateWord(std::move(displayText)),
-        text(std::move(text)),
-        callback(std::move(callback)) {}
-  void select(fcitx::InputContext* /*unused*/) const override {
-    callback(std::make_unique<InputStates::Committing>(text));
-    callback(std::make_unique<InputStates::Iroha>());
-  }
-
-  std::string text;
-  KeyHandler::StateCallback callback;
-};
-
 class McBopomofoTextOnlyCandidateWord : public fcitx::CandidateWord {
  public:
   explicit McBopomofoTextOnlyCandidateWord(fcitx::Text displayText)
@@ -1515,7 +1499,7 @@ void McBopomofoEngine::handleEmptyIgnoringPreviousState(
 }
 
 void McBopomofoEngine::handleCommittingState(fcitx::InputContext* context,
-                                             InputState* /*unused*/,
+                                             InputState* prev,
                                              InputStates::Committing* current) {
   context->inputPanel().reset();
   context->updateUserInterface(fcitx::UserInterfaceComponent::InputPanel);
@@ -1523,6 +1507,12 @@ void McBopomofoEngine::handleCommittingState(fcitx::InputContext* context,
     context->commitString(current->text);
   }
   context->updatePreedit();
+
+  // If prev is an Iroha candidate state, transition to Iroha state.
+  if (auto* irohaCandidates =
+          dynamic_cast<InputStates::IrohaCandidate*>(prev)) {
+    enterNewState(context, std::make_unique<InputStates::Iroha>(""));
+  }
 }
 
 void McBopomofoEngine::handleInputtingState(fcitx::InputContext* context,
@@ -1716,8 +1706,8 @@ void McBopomofoEngine::handleCandidatesState(fcitx::InputContext* context,
   } else if (irohaCandidates != nullptr) {
     for (const auto& displayText : irohaCandidates->candidates) {
       std::unique_ptr<fcitx::CandidateWord> candidate =
-          std::make_unique<McBopomofoIrohaWord>(fcitx::Text(displayText),
-                                                displayText, callback);
+          std::make_unique<McBopomofoDirectInsertWord>(fcitx::Text(displayText),
+                                                       displayText, callback);
       candidateList->append(std::move(candidate));
     }
   } else if (customMenu != nullptr) {

--- a/src/McBopomofo.cpp
+++ b/src/McBopomofo.cpp
@@ -345,10 +345,10 @@ class McBopomofoIrohaWord : public fcitx::CandidateWord {
         text(std::move(text)),
         callback(std::move(callback)) {}
   void select(fcitx::InputContext* /*unused*/) const override {
-    std::vector<std::unique_ptr<InputState>> states;
-    states.emplace_back(std::make_unique<InputStates::Committing>(text));
-    states.emplace_back(std::make_unique<InputStates::Iroha>(""));
-    callback(std::make_unique<InputStates::StateSequence>(std::move(states)));
+    auto seq = std::make_unique<InputStates::StateSequence>();
+    seq->push_back(std::make_unique<InputStates::Committing>(text));
+    seq->push_back(std::make_unique<InputStates::Iroha>(""));
+    callback(std::move(seq));
   }
 
   std::string text;

--- a/src/McBopomofo.h
+++ b/src/McBopomofo.h
@@ -260,6 +260,12 @@ class McBopomofoEngine : public fcitx::InputMethodEngine {
   void enterNewState(fcitx::InputContext* context,
                      std::unique_ptr<InputState> newState);
 
+  // Handles a single state or a StateSequence. If the incoming state is a
+  // StateSequence, each state in the sequence is processed via enterNewState
+  // in order.
+  void handleStateOrSequence(fcitx::InputContext* context,
+                              std::unique_ptr<InputState> newState);
+
   // Methods below enterNewState raw pointers as they don't affect ownership.
   void handleEmptyState(fcitx::InputContext* context, InputState* prev,
                         InputStates::Empty* current);


### PR DESCRIPTION
The PR ports Iroha Kana input from macOS to fcitx5.

The PR also introduces a new state - state sequence. It is a container for multiple input states that allows the input controller to go to a specific state after committing texts.

This pull request adds support for a new "Iroha" (伊呂波) kana input method to the input engine, allowing users to enter kana using a custom code system. It introduces new input states, updates the key handling logic, and integrates candidate selection for kana input. The changes also improve state management by introducing a mechanism to process sequences of states in order, ensuring smooth transitions and consistent behavior.

**Iroha Kana Input Support:**

* Added new input states `Iroha` and `IrohaCandidate` to represent the kana input process and candidate selection, respectively. (`src/InputState.h` [src/InputState.hR281-R298](diffhunk://#diff-34ded6fcb3ec7838054f1dc2ed9db76045ab5f1aeb0fb7c19633b3faa53d2b18R281-R298))
* Integrated the "伊呂波假名輸入" option into the feature selection menu, enabling users to select the new input mode. (`src/InputState.h` [src/InputState.hR325-R326](diffhunk://#diff-34ded6fcb3ec7838054f1dc2ed9db76045ab5f1aeb0fb7c19633b3faa53d2b18R325-R326))
* Implemented `handleIroha` in the key handler to process kana input, handle candidate lookup, input confirmation, and error handling. (`src/KeyHandler.cpp` [[1]](diffhunk://#diff-e5f1eb352fc719fc9e84cf7b08d562b0c304a5540f991eae67a49497a0e2829aR1198-R1269) `src/KeyHandler.h` [[2]](diffhunk://#diff-8bf6674fa0fe0feb53820efb7bee31fe087cf2c2ec05d11885b53b75416e759aR225-R227)
* Updated the engine to display and handle Iroha candidates, including candidate selection and committing the chosen kana. (`src/McBopomofo.cpp` [[1]](diffhunk://#diff-50f12d3ac0f96e0283c298fc1df417accd434c4eb82e45cb37220ffcca1e2258R1565-R1566) [[2]](diffhunk://#diff-50f12d3ac0f96e0283c298fc1df417accd434c4eb82e45cb37220ffcca1e2258R1730-R1736) [[3]](diffhunk://#diff-50f12d3ac0f96e0283c298fc1df417accd434c4eb82e45cb37220ffcca1e2258R1489-R1511) [[4]](diffhunk://#diff-50f12d3ac0f96e0283c298fc1df417accd434c4eb82e45cb37220ffcca1e2258L819-R838) [[5]](diffhunk://#diff-50f12d3ac0f96e0283c298fc1df417accd434c4eb82e45cb37220ffcca1e2258L837-R856) [[6]](diffhunk://#diff-50f12d3ac0f96e0283c298fc1df417accd434c4eb82e45cb37220ffcca1e2258R873) [[7]](diffhunk://#diff-50f12d3ac0f96e0283c298fc1df417accd434c4eb82e45cb37220ffcca1e2258L866-R886)
* Added `McBopomofoIrohaWord` to represent kana candidates in the candidate list. (`src/McBopomofo.cpp` [src/McBopomofo.cppR340-R357](diffhunk://#diff-50f12d3ac0f96e0283c298fc1df417accd434c4eb82e45cb37220ffcca1e2258R340-R357))

**State Management Improvements:**

* Introduced `StateSequence`, a new input state that allows processing a sequence of states in order, enabling complex transitions (such as committing a candidate and returning to input) to be handled atomically. (`src/InputState.h` [src/InputState.hR358-R367](diffhunk://#diff-34ded6fcb3ec7838054f1dc2ed9db76045ab5f1aeb0fb7c19633b3faa53d2b18R358-R367))
* Added `handleStateOrSequence` to the engine to process either a single state or a sequence of states, ensuring consistent state transitions. (`src/McBopomofo.cpp` [[1]](diffhunk://#diff-50f12d3ac0f96e0283c298fc1df417accd434c4eb82e45cb37220ffcca1e2258R1489-R1511) `src/McBopomofo.h` [[2]](diffhunk://#diff-feb76a1b06d90bb6c2d34b391a86582dab360ca6684c8bf3740606f5eb9bfbccR263-R268)
* Updated test and engine logic to support processing of `StateSequence` states. (`src/KeyHandlerTest.cpp` [src/KeyHandlerTest.cppR147-R164](diffhunk://#diff-ce5d84dda123bbaf5e5720c11cfca7d881145724fc09b4e27f7febb06aedcb33R147-R164))

**Integration and UI Updates:**

* Modified candidate panel logic to absorb keys and update the UI when in Iroha candidate state. (`src/McBopomofo.cpp` [[1]](diffhunk://#diff-50f12d3ac0f96e0283c298fc1df417accd434c4eb82e45cb37220ffcca1e2258L819-R838) [[2]](diffhunk://#diff-50f12d3ac0f96e0283c298fc1df417accd434c4eb82e45cb37220ffcca1e2258R873)
* Ensured the composing buffer is correctly displayed for Iroha input states. (`src/McBopomofo.cpp` [src/McBopomofo.cppR1489-R1511](diffhunk://#diff-50f12d3ac0f96e0283c298fc1df417accd434c4eb82e45cb37220ffcca1e2258R1489-R1511))

These changes collectively add a new kana input method, improve state transition handling, and ensure a smooth user experience for the new feature. 