### PR TITLE
Ports the Hanin style punctuation list to FCITX

### DIFF
--- a/src/InputState.h
+++ b/src/InputState.h
@@ -137,15 +137,25 @@ inline bool operator==(const ChoosingCandidate::Candidate& a,
   return a.reading == b.reading && a.value == b.value;
 }
 
-// Represents the Marking state where the user uses Shift-Left/Shift-Right to
-// mark a phrase to be added to their custom phrases. A Marking state still has
-// a composingBuffer, and the invariant is that composingBuffer = head +
-// markedText + tail. Unlike cursorIndex, which is UTF-8 based,
+struct ChoosingPunctuationList : ChoosingCandidate {
+  ChoosingPunctuationList(const std::string& buf, const size_t index,
+                          const size_t originalIndex, std::vector<Candidate> cs)
+      : ChoosingCandidate(buf, index, originalIndex, std::move(cs)) {}
+
+  ChoosingPunctuationList(const ChoosingCandidate& state)
+      : ChoosingCandidate(state.composingBuffer, state.cursorIndex,
+                          state.originalCursor, state.candidates) {}
+};
+
+// Represents the Marking state where the user uses Shift-Left/Shift-Right
+// to mark a phrase to be added to their custom phrases. A Marking state
+// still has a composingBuffer, and the invariant is that composingBuffer
+// = head + markedText + tail. Unlike cursorIndex, which is UTF-8 based,
 // markStartGridCursorIndex is in the same unit that a Gramambular's grid
 // builder uses. In other words, markStartGridCursorIndex is the beginning
-// position of the reading cursor. This makes it easy for a key handler to know
-// where the marked range is when combined with the grid builder's (reading)
-// cursor index.
+// position of the reading cursor. This makes it easy for a key handler to
+// know where the marked range is when combined with the grid builder's
+// (reading) cursor index.
 struct Marking : NotEmpty {
   Marking(const std::string& buf, const size_t composingBufferCursorIndex,
           const std::string& tooltipText, const size_t startCursorIndexInGrid,

--- a/src/KeyHandler.cpp
+++ b/src/KeyHandler.cpp
@@ -586,8 +586,45 @@ void KeyHandler::dictionaryServiceSelected(std::string phrase, size_t index,
                               stateCallback);
 }
 
-/// Candidate panel for punctuation list canceled. Can assume the context is
-/// in a ChoosingPunctuationList state.
+bool KeyHandler::candidatePanelPunctuationMaybeEntered(
+    Key key, size_t originalCursor, StateCallback stateCallback) {
+  if (key.ascii == 0) {
+    return false;
+  }
+
+  std::string unigramKey =
+      std::string(kPunctuationListUnigramKey) + "_" + key.ascii;
+  if (!lm_->hasUnigrams(unigramKey)) {
+    return false;
+  }
+
+  if (selectPhraseAfterCursorAsCandidate_) {
+    grid_.deleteReadingAfterCursor();
+  } else {
+    grid_.deleteReadingBeforeCursor();
+  }
+
+  grid_.insertReading(unigramKey);
+  walk();
+
+  if (inputMode_ == InputMode::PlainBopomofo) {
+    auto inputtingState = buildInputtingState();
+    auto choosingCandidates =
+        buildChoosingCandidateState(inputtingState.get(), originalCursor);
+    if (choosingCandidates->candidates.size() == 1) {
+      reset();
+      std::string text = choosingCandidates->candidates[0].value;
+      auto committing = std::make_unique<InputStates::Committing>(text);
+      stateCallback(std::move(committing));
+    } else {
+      stateCallback(std::move(choosingCandidates));
+    }
+  } else {
+    stateCallback(buildInputtingState());
+  }
+  return true;
+}
+
 void KeyHandler::candidatePanelPunctuationListCancelled(
     size_t originalCursor, StateCallback stateCallback) {
   if (inputMode_ == InputMode::PlainBopomofo) {

--- a/src/KeyHandler.cpp
+++ b/src/KeyHandler.cpp
@@ -116,8 +116,9 @@ bool KeyHandler::handle(Key key, McBopomofo::InputState* state,
                         StateCallback stateCallback,
                         ErrorCallback errorCallback) {
   if (key.ascii == '\\' && key.ctrlPressed) {
-    stateCallback(std::make_unique<InputStates::Empty>());
-    stateCallback(std::make_unique<InputStates::SelectingFeature>(
+    auto seq = std::make_unique<InputStates::StateSequence>();
+    seq->push_back(std::make_unique<InputStates::Empty>());
+    seq->push_back(std::make_unique<InputStates::SelectingFeature>(
         [this](std::string input) {
           auto* lm = dynamic_cast<McBopomofoLM*>(this->lm_.get());
           if (lm != nullptr) {
@@ -125,6 +126,7 @@ bool KeyHandler::handle(Key key, McBopomofo::InputState* state,
           }
           return input;
         }));
+    stateCallback(std::move(seq));
     reset();
     return true;
   }
@@ -431,8 +433,10 @@ bool KeyHandler::handle(Key key, McBopomofo::InputState* state,
       auto inputtingState = buildInputtingState();
       auto choosingCandidateState =
           buildChoosingCandidateState(inputtingState.get(), originalCursor);
-      stateCallback(std::move(inputtingState));
-      stateCallback(std::move(choosingCandidateState));
+      auto choosingPunctuationList =
+          std::make_unique<InputStates::ChoosingPunctuationList>(
+              *choosingCandidateState);
+      stateCallback(std::move(choosingPunctuationList));
     } else {
       // Punctuation ignored if a bopomofo reading is active..
       errorCallback();
@@ -580,6 +584,33 @@ void KeyHandler::dictionaryServiceSelected(std::string phrase, size_t index,
                                            StateCallback stateCallback) {
   dictionaryServices_->lookup(std::move(phrase), index, currentState,
                               stateCallback);
+}
+
+/// Candidate panel for punctuation list canceled. Can assume the context is
+/// in a ChoosingPunctuationList state.
+void KeyHandler::candidatePanelPunctuationListCancelled(
+    size_t originalCursor, StateCallback stateCallback) {
+  if (inputMode_ == InputMode::PlainBopomofo) {
+    reset();
+    std::unique_ptr<InputStates::EmptyIgnoringPrevious>
+        emptyIgnorePreviousState =
+            std::make_unique<InputStates::EmptyIgnoringPrevious>();
+    stateCallback(std::move(emptyIgnorePreviousState));
+    return;
+  }
+  if (selectPhraseAfterCursorAsCandidate_) {
+    grid_.deleteReadingAfterCursor();
+  } else {
+    grid_.deleteReadingBeforeCursor();
+  }
+  walk();
+  grid_.setCursor(originalCursor > 0 ? originalCursor - 1 : 0);
+  if (grid_.length() == 0) {
+    reset();
+    stateCallback(std::make_unique<InputStates::EmptyIgnoringPrevious>());
+  } else {
+    stateCallback(buildInputtingState());
+  }
 }
 
 void KeyHandler::candidatePanelCancelled(size_t originalCursor,

--- a/src/KeyHandler.h
+++ b/src/KeyHandler.h
@@ -92,6 +92,9 @@ class KeyHandler {
                                  InputState* currentState,
                                  StateCallback stateCallback);
 
+  bool candidatePanelPunctuationMaybeEntered(Key key, size_t originalCursor,
+                                             StateCallback stateCallback);
+
   /// Candidate panel for punctuation list canceled. Can assume the context is
   /// in a ChoosingPunctuationList state.
   void candidatePanelPunctuationListCancelled(size_t originalCursor,
@@ -258,9 +261,9 @@ class KeyHandler {
   std::string getHTMLRubyText();
   std::string getHanyuPinyin();
 
-  // Build a Marking state, ranging from beginCursorIndex to the current builder
-  // cursor. It doesn't matter if the beginCursorIndex is behind or after the
-  // builder cursor.
+  // Build a Marking state, ranging from beginCursorIndex to the current
+  // builder cursor. It doesn't matter if the beginCursorIndex is behind or
+  // after the builder cursor.
   std::unique_ptr<InputStates::Marking> buildMarkingState(
       size_t beginCursorIndex);
 
@@ -278,7 +281,8 @@ class KeyHandler {
   //     case, the prefixReading is ㄉㄜˊ and prefixValue is 得, and the
   //     associated phrase's reading and value are ㄉㄜˊ-ㄉㄠˋ and 得到
   //     respectively.
-  // (2) the current walk is 得 but we want to pin the phrase 德性, coming from
+  // (2) the current walk is 得 but we want to pin the phrase 德性, coming
+  // from
   //     the choosing-candidate state; in this case, the prefix reading and
   //     value is now ㄉㄜˊ and 德, and the associated phrase is ㄉㄜˊ-ㄒㄧㄥˋ
   //     and 德性 respectively.
@@ -350,7 +354,8 @@ class KeyHandler {
     // - "Bopomofo annotation support on"
     virtual std::string bopomofoFontAnnotationModeTooltip(
         bool hasUnicodeVariantSelectors, bool hasPUABlocks) = 0;
-    // Reference string: "cannot add new phrases when Bopomofo annotation is on"
+    // Reference string: "cannot add new phrases when Bopomofo annotation is
+    // on"
     virtual std::string markingNotAvailableInFontAnnotationMode() = 0;
   };
 };

--- a/src/KeyHandler.h
+++ b/src/KeyHandler.h
@@ -92,7 +92,13 @@ class KeyHandler {
                                  InputState* currentState,
                                  StateCallback stateCallback);
 
-  // Candidate panel canceled. Can assume the context is in a candidate state.
+  /// Candidate panel for punctuation list canceled. Can assume the context is
+  /// in a ChoosingPunctuationList state.
+  void candidatePanelPunctuationListCancelled(size_t originalCursor,
+                                              StateCallback stateCallback);
+
+  // Candidate panel canceled. Can assume the context is in a candidate
+  // state.
   void candidatePanelCancelled(size_t originalCursor,
                                StateCallback stateCallback);
 

--- a/src/McBopomofo.cpp
+++ b/src/McBopomofo.cpp
@@ -1254,8 +1254,6 @@ bool McBopomofoEngine::handleCandidateKeyEvent(
 
     size_t originalCursor = 0;
     if (choosingPunctuationList != nullptr) {
-      // FCITX_MCBOPOMOFO_INFO()
-      //     << "candidatePanelPunctuationListCancelled called";
       originalCursor = choosingPunctuationList->originalCursor;
       keyHandler_->candidatePanelPunctuationListCancelled(
           originalCursor, [stateCallback](std::unique_ptr<InputState> next) {
@@ -1275,6 +1273,17 @@ bool McBopomofoEngine::handleCandidateKeyEvent(
           stateCallback(std::move(next));
         });
     return true;
+  }
+
+  if (choosingPunctuationList != nullptr) {
+    bool result = keyHandler_->candidatePanelPunctuationMaybeEntered(
+        MapFcitxKey(key, origKey), choosingPunctuationList->originalCursor,
+        [stateCallback](std::unique_ptr<InputState> newState) {
+          stateCallback(std::move(newState));
+        });
+    if (result) {
+      return true;
+    }
   }
 
   fcitx::CandidateLayoutHint layoutHint = getCandidateLayoutHint();

--- a/src/McBopomofo.cpp
+++ b/src/McBopomofo.cpp
@@ -906,6 +906,8 @@ bool McBopomofoEngine::handleCandidateKeyEvent(
       dynamic_cast<InputStates::AssociatedPhrasesPlain*>(state_.get());
   InputStates::NumberInput* numberInput =
       dynamic_cast<InputStates::NumberInput*>(state_.get());
+  InputStates::ChoosingPunctuationList* choosingPunctuationList =
+      dynamic_cast<InputStates::ChoosingPunctuationList*>(state_.get());
 
   bool shouldUseShiftKey =
       associatedPhrasesPlain != nullptr ||
@@ -941,39 +943,62 @@ bool McBopomofoEngine::handleCandidateKeyEvent(
   MovingCursorOption movingCursorOption =
       config_.allowMovingCursorWhenChoosingCandidates.value();
 
-  bool isCursorMovingLeft =
-      key.check(FcitxKey_Left, fcitx::KeyStates(fcitx::KeyState::Shift));
-  bool isCursorMovingRight =
-      key.check(FcitxKey_Right, fcitx::KeyStates(fcitx::KeyState::Shift));
+  bool isCursorMovingLeft = false;
+  bool isCursorMovingRight = false;
 
-  if (!isCursorMovingLeft && !isCursorMovingRight) {
-    if (movingCursorOption == MovingCursorOption::UseJK) {
-      isCursorMovingLeft = key.check(FcitxKey_j);
-      isCursorMovingRight = key.check(FcitxKey_k);
-    } else if (movingCursorOption == MovingCursorOption::UseHL) {
-      isCursorMovingLeft = key.check(FcitxKey_h);
-      isCursorMovingRight = key.check(FcitxKey_l);
+  if (choosingPunctuationList != nullptr) {
+    if (key.check(FcitxKey_grave)) {
+      keyHandler_->reset();
+      auto seq = std::make_unique<InputStates::StateSequence>();
+      seq->push_back(std::make_unique<InputStates::EmptyIgnoringPrevious>());
+      seq->push_back(std::make_unique<InputStates::SelectingFeature>(
+          [this](std::string input) {
+            auto lm = languageModelLoader_->getLM();
+            return lm->convertMacro(input);
+          }));
+      stateCallback(std::move(seq));
+      return true;
     }
-  }
-
-  if (keyHandler_->inputMode() == McBopomofo::InputMode::McBopomofo &&
-      dynamic_cast<InputStates::ChoosingCandidate*>(state_.get()) != nullptr &&
-      (isCursorMovingLeft || isCursorMovingRight)) {
-    size_t cursor = keyHandler_->candidateCursorIndex();
-
-    if (isCursorMovingLeft) {
-      if (cursor > 0) {
-        cursor--;
+  } else {
+    // Note:
+    // - We do not allow moving cursor in punctuation list.
+    // - Shift + Left/Right is the default keybinding for moving cursor in
+    //   candidate list. When movingCursorOption is enabled, we also allow using
+    //   H/J/K/L or Left/Right without modifiers
+    isCursorMovingLeft =
+        key.check(FcitxKey_Left, fcitx::KeyStates(fcitx::KeyState::Shift));
+    isCursorMovingRight =
+        key.check(FcitxKey_Right, fcitx::KeyStates(fcitx::KeyState::Shift));
+    if (!isCursorMovingLeft && !isCursorMovingRight) {
+      if (movingCursorOption == MovingCursorOption::UseJK) {
+        isCursorMovingLeft = key.check(FcitxKey_j);
+        isCursorMovingRight = key.check(FcitxKey_k);
+      } else if (movingCursorOption == MovingCursorOption::UseHL) {
+        isCursorMovingLeft = key.check(FcitxKey_h);
+        isCursorMovingRight = key.check(FcitxKey_l);
       }
-    } else if (isCursorMovingRight) {
-      cursor++;
     }
-    keyHandler_->setCandidateCursorIndex(cursor);
-    auto inputting = keyHandler_->buildInputtingState();
-    auto choosing = keyHandler_->buildChoosingCandidateState(
-        inputting.get(), keyHandler_->candidateCursorIndex());
-    stateCallback(std::move(choosing));
-    return true;
+
+    if (keyHandler_->inputMode() == McBopomofo::InputMode::McBopomofo &&
+        dynamic_cast<InputStates::ChoosingCandidate*>(state_.get()) !=
+            nullptr &&
+        (isCursorMovingLeft || isCursorMovingRight)) {
+      size_t cursor = keyHandler_->candidateCursorIndex();
+
+      if (isCursorMovingLeft) {
+        if (cursor > 0) {
+          cursor--;
+        }
+      } else if (isCursorMovingRight) {
+        cursor++;
+      }
+      keyHandler_->setCandidateCursorIndex(cursor);
+      auto inputting = keyHandler_->buildInputtingState();
+      auto choosing = keyHandler_->buildChoosingCandidateState(
+          inputting.get(), keyHandler_->candidateCursorIndex());
+      stateCallback(std::move(choosing));
+      return true;
+    }
   }
 
   bool keyIsCancel = false;
@@ -994,7 +1019,7 @@ bool McBopomofoEngine::handleCandidateKeyEvent(
     auto* showingCharInfo =
         dynamic_cast<InputStates::ShowingCharInfo*>(state_.get());
 
-    if (choosingCandidate != nullptr) {
+    if (choosingCandidate != nullptr && choosingPunctuationList == nullptr) {
       // Enter selecting dictionary service state.
       if (keyHandler_->hasDictionaryServices()) {
         int page = candidateList->currentPage();
@@ -1035,7 +1060,8 @@ bool McBopomofoEngine::handleCandidateKeyEvent(
     bool isPlusKey = key.check(FcitxKey_plus) || key.check(FcitxKey_equal);
     bool isMinusKey =
         key.check(FcitxKey_minus) || key.check(FcitxKey_underscore);
-    if (choosingCandidate != nullptr && (isPlusKey || isMinusKey)) {
+    if (choosingCandidate != nullptr && choosingPunctuationList == nullptr &&
+        (isPlusKey || isMinusKey)) {
       int page = candidateList->currentPage();
       int pageSize = candidateList->size();
       int index = candidateList->cursorIndex();
@@ -1227,6 +1253,17 @@ bool McBopomofoEngine::handleCandidateKeyEvent(
     }
 
     size_t originalCursor = 0;
+    if (choosingPunctuationList != nullptr) {
+      // FCITX_MCBOPOMOFO_INFO()
+      //     << "candidatePanelPunctuationListCancelled called";
+      originalCursor = choosingPunctuationList->originalCursor;
+      keyHandler_->candidatePanelPunctuationListCancelled(
+          originalCursor, [stateCallback](std::unique_ptr<InputState> next) {
+            stateCallback(std::move(next));
+          });
+      return true;
+    }
+
     auto* choosing =
         dynamic_cast<InputStates::ChoosingCandidate*>(state_.get());
     if (choosing != nullptr) {
@@ -1731,7 +1768,7 @@ void McBopomofoEngine::handleCandidatesState(fcitx::InputContext* context,
     for (const auto& displayText : irohaCandidates->candidates) {
       std::unique_ptr<fcitx::CandidateWord> candidate =
           std::make_unique<McBopomofoIrohaWord>(fcitx::Text(displayText),
-                                               displayText, callback);
+                                                displayText, callback);
       candidateList->append(std::move(candidate));
     }
   } else if (customMenu != nullptr) {


### PR DESCRIPTION
The PR ports the Hanin style puncutation list. When a usaer press the backtick/grave key to show the punctuation list, he or she can then press any punctuation key to input the full-width punctuation directly.

The PR add a new state for showing the punctuation list and modiified the key handler.

Also updated data.txt.

--

This pull request makes a series of updates to the `data/data.txt` file, primarily expanding the dataset with new entries and improving coverage of various word forms, punctuation mappings, and emoji representations. The changes include the addition of many new punctuation variants, alternative word forms (including those with different characters or readings), and several mappings to emojis for certain words or phrases. These updates enhance the comprehensiveness and versatility of the dataset.

The most important changes are:

**Punctuation and Symbol Coverage:**
* Added a large set of new punctuation and symbol variants to the `_punctuation_list`, mapping various symbols (including full-width, circled, and emoji-like forms) to their corresponding ASCII or semantic representations. This significantly improves the handling of diverse punctuation in text processing.

**Alternative Word Forms and Readings:**
* Added alternative forms and readings for many words and phrases, including those with different characters, readings, or orthographies (e.g., both traditional and simplified, or different phonetic spellings). This includes entries like `ㄇㄟˇ-ㄩˇ-ㄐㄧㄠˋ-ㄒㄩㄝˊ` (美語教學) and similar variants for other terms. [[1]](diffhunk://#diff-29d7e4cc17367ef4ab645fb17ea15f2ed64135ea5d4d42eeaaba4c6044302ba9R15389) [[2]](diffhunk://#diff-29d7e4cc17367ef4ab645fb17ea15f2ed64135ea5d4d42eeaaba4c6044302ba9R31651) [[3]](diffhunk://#diff-29d7e4cc17367ef4ab645fb17ea15f2ed64135ea5d4d42eeaaba4c6044302ba9R31768) [[4]](diffhunk://#diff-29d7e4cc17367ef4ab645fb17ea15f2ed64135ea5d4d42eeaaba4c6044302ba9R53454-R53455) [[5]](diffhunk://#diff-29d7e4cc17367ef4ab645fb17ea15f2ed64135ea5d4d42eeaaba4c6044302ba9R54094) [[6]](diffhunk://#diff-29d7e4cc17367ef4ab645fb17ea15f2ed64135ea5d4d42eeaaba4c6044302ba9R70180)

**Emoji and Symbol Mappings:**
* Introduced mappings from certain words and phrases to relevant emojis, such as `ㄏㄠˇ` mapping to 🆗, 👍, 👌, 🙆‍♀️, and `ㄎㄢˋ-ㄎㄢˋ` mapping to 👀, providing richer semantic representations for these expressions. [[1]](diffhunk://#diff-29d7e4cc17367ef4ab645fb17ea15f2ed64135ea5d4d42eeaaba4c6044302ba9R67420) [[2]](diffhunk://#diff-29d7e4cc17367ef4ab645fb17ea15f2ed64135ea5d4d42eeaaba4c6044302ba9R67437) [[3]](diffhunk://#diff-29d7e4cc17367ef4ab645fb17ea15f2ed64135ea5d4d42eeaaba4c6044302ba9R63903) [[4]](diffhunk://#diff-29d7e4cc17367ef4ab645fb17ea15f2ed64135ea5d4d42eeaaba4c6044302ba9R35739) [[5]](diffhunk://#diff-29d7e4cc17367ef4ab645fb17ea15f2ed64135ea5d4d42eeaaba4c6044302ba9R31638)

**Expanded Vocabulary and Phrases:**
* Added new vocabulary entries and multi-character phrases, including technical terms, colloquial expressions, and specialized vocabulary (e.g., `電影分級制度`, `通識教育`, `年度預算`). [[1]](diffhunk://#diff-29d7e4cc17367ef4ab645fb17ea15f2ed64135ea5d4d42eeaaba4c6044302ba9R32023) [[2]](diffhunk://#diff-29d7e4cc17367ef4ab645fb17ea15f2ed64135ea5d4d42eeaaba4c6044302ba9R41237) [[3]](diffhunk://#diff-29d7e4cc17367ef4ab645fb17ea15f2ed64135ea5d4d42eeaaba4c6044302ba9R44265) [[4]](diffhunk://#diff-29d7e4cc17367ef4ab645fb17ea15f2ed64135ea5d4d42eeaaba4c6044302ba9R25641) [[5]](diffhunk://#diff-29d7e4cc17367ef4ab645fb17ea15f2ed64135ea5d4d42eeaaba4c6044302ba9R4246) [[6]](diffhunk://#diff-29d7e4cc17367ef4ab645fb17ea15f2ed64135ea5d4d42eeaaba4c6044302ba9R21755) [[7]](diffhunk://#diff-29d7e4cc17367ef4ab645fb17ea15f2ed64135ea5d4d42eeaaba4c6044302ba9R26088) [[8]](diffhunk://#diff-29d7e4cc17367ef4ab645fb17ea15f2ed64135ea5d4d42eeaaba4c6044302ba9R26723) [[9]](diffhunk://#diff-29d7e4cc17367ef4ab645fb17ea15f2ed64135ea5d4d42eeaaba4c6044302ba9R31496) [[10]](diffhunk://#diff-29d7e4cc17367ef4ab645fb17ea15f2ed64135ea5d4d42eeaaba4c6044302ba9R32932) [[11]](diffhunk://#diff-29d7e4cc17367ef4ab645fb17ea15f2ed64135ea5d4d42eeaaba4c6044302ba9R32976) [[12]](diffhunk://#diff-29d7e4cc17367ef4ab645fb17ea15f2ed64135ea5d4d42eeaaba4c6044302ba9R33391) [[13]](diffhunk://#diff-29d7e4cc17367ef4ab645fb17ea15f2ed64135ea5d4d42eeaaba4c6044302ba9R33542-R33543) [[14]](diffhunk://#diff-29d7e4cc17367ef4ab645fb17ea15f2ed64135ea5d4d42eeaaba4c6044302ba9R35136) [[15]](diffhunk://#diff-29d7e4cc17367ef4ab645fb17ea15f2ed64135ea5d4d42eeaaba4c6044302ba9R39222) [[16]](diffhunk://#diff-29d7e4cc17367ef4ab645fb17ea15f2ed64135ea5d4d42eeaaba4c6044302ba9R51649) [[17]](diffhunk://#diff-29d7e4cc17367ef4ab645fb17ea15f2ed64135ea5d4d42eeaaba4c6044302ba9R48778) [[18]](diffhunk://#diff-29d7e4cc17367ef4ab645fb17ea15f2ed64135ea5d4d42eeaaba4c6044302ba9R61319) [[19]](diffhunk://#diff-29d7e4cc17367ef4ab645fb17ea15f2ed64135ea5d4d42eeaaba4c6044302ba9R66660) [[20]](diffhunk://#diff-29d7e4cc17367ef4ab645fb17ea15f2ed64135ea5d4d42eeaaba4c6044302ba9R70346)

**Minor Corrections and Additions:**
* Made minor corrections such as adding missing kana variants (e.g., `_kana_vya ヴャ 0.0`) to improve the dataset's accuracy and completeness.