### PR TITLE
Sync engine source with McBopomofo

### DIFF
--- a/src/Engine/ByteBlockBackedDictionary.cpp
+++ b/src/Engine/ByteBlockBackedDictionary.cpp
@@ -31,6 +31,16 @@
 #endif
 #endif
 
+#ifdef ENABLE_EXPERIMENTAL_SIMD_SUPPORT_NEON
+#if defined(__ARM_NEON)
+#include <arm_neon.h>
+
+#include <cstdint>
+#else
+#error ARM NEON support required
+#endif
+#endif
+
 #include "ByteBlockBackedDictionary.h"
 
 namespace McBopomofo {
@@ -84,7 +94,8 @@ const char* AdvanceToNextNonContentCharacter(const char* ptr, const char* end) {
   return ptr;
 }
 
-#ifndef ENABLE_EXPERIMENTAL_SIMD_SUPPORT_AVX512
+#if !defined(ENABLE_EXPERIMENTAL_SIMD_SUPPORT_AVX512) && \
+    !defined(ENABLE_EXPERIMENTAL_SIMD_SUPPORT_NEON)
 const char* FindFirstNULL(const char* ptr, const char* end,
                           size_t* firstLineNumber = nullptr) {
   const char* i = ptr;
@@ -271,6 +282,188 @@ const char* AVX512_FindFirstNULL(const char* ptr, const char* end,
 
 #endif
 
+#ifdef ENABLE_EXPERIMENTAL_SIMD_SUPPORT_NEON
+
+// Returns the index of the first non-zero byte in v, or 16 if all zero
+static inline int FirstNonZeroLane16(uint8x16_t v) {
+  if (vmaxvq_u8(v) == 0) {
+    return 16;
+  }
+  // Scalar fallback for the position
+  alignas(16) uint8_t tmp[16];
+  vst1q_u8(tmp, v);
+  for (int i = 0; i < 16; ++i) {
+    if (tmp[i]) {
+      return i;
+    }
+  }
+  return 16;
+}
+
+const char* NEON_AdvanceToNextCRLF(const char* ptr, const char* unaligned16End,
+                                   const char* end) {
+  const uint8x16_t lfs = vdupq_n_u8(static_cast<uint8_t>('\n'));
+  const uint8x16_t crs = vdupq_n_u8(static_cast<uint8_t>('\r'));
+
+  while (ptr < unaligned16End) {
+    const uint8x16_t block = vld1q_u8(reinterpret_cast<const uint8_t*>(ptr));
+    const uint8x16_t matchLF = vceqq_u8(block, lfs);
+    const uint8x16_t matchCR = vceqq_u8(block, crs);
+    const uint8x16_t match = vorrq_u8(matchLF, matchCR);
+    const int pos = FirstNonZeroLane16(match);
+    if (pos < 16) {
+      return ptr + pos;
+    }
+    ptr += 16;
+  }
+
+  return AdvanceToNextCRLF(ptr, end);
+}
+
+// Four chars: 0x09 (Tab), 0x0a (LF), 0x0d (CR), 0x20 (Space)
+// Tab maps to 0x01
+// LF maps to 0x02
+// CR maps to 0x04
+// Tab|LF|CR = 0x07
+// Space maps to 0x08
+alignas(16) constexpr uint8_t NEON_LO_NIBBLES_LOOKUP[16] = {
+    0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    0x00, 0x01, 0x02, 0x00, 0x00, 0x04, 0x00, 0x00,
+};
+
+alignas(16) constexpr uint8_t NEON_HI_NIBBLES_LOOKUP[16] = {
+    0x07, 0x00, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+};
+
+const char* NEON_AdvanceToNextNonContentCharacter(const char* ptr,
+                                                  const char* unaligned16End,
+                                                  const char* end) {
+  const uint8x16_t loTbl =
+      vld1q_u8(reinterpret_cast<const uint8_t*>(NEON_LO_NIBBLES_LOOKUP));
+  const uint8x16_t hiTbl =
+      vld1q_u8(reinterpret_cast<const uint8_t*>(NEON_HI_NIBBLES_LOOKUP));
+  const uint8x16_t nibbleMask = vdupq_n_u8(0x0f);
+
+  while (ptr < unaligned16End) {
+    const uint8x16_t input = vld1q_u8(reinterpret_cast<const uint8_t*>(ptr));
+    const uint8x16_t loNibbles = vandq_u8(input, nibbleMask);
+    const uint8x16_t hiNibbles = vandq_u8(vshrq_n_u8(input, 4), nibbleMask);
+    const uint8x16_t lo = vqtbl1q_u8(loTbl, loNibbles);
+    const uint8x16_t hi = vqtbl1q_u8(hiTbl, hiNibbles);
+    const uint8x16_t intersection = vandq_u8(lo, hi);
+    // non-content characters have a non-zero intersection
+    const int pos = FirstNonZeroLane16(intersection);
+    if (pos < 16) {
+      return ptr + pos;
+    }
+    ptr += 16;
+  }
+
+  return AdvanceToNextNonContentCharacter(ptr, end);
+}
+
+constexpr uintptr_t NEON_ALIGN16 = 16;
+constexpr uintptr_t NEON_ALIGN16_MASK = NEON_ALIGN16 - 1;
+
+const char* NEON_FindFirstNULL(const char* ptr, const char* end,
+                               size_t* firstLineNumber = nullptr) {
+  const char* i = ptr;
+  bool found = false;
+
+  // Handle unaligned head
+  if ((reinterpret_cast<uintptr_t>(i) & NEON_ALIGN16_MASK) != 0) {
+    const char* headEnd = reinterpret_cast<const char*>(
+        (reinterpret_cast<uintptr_t>(i) + NEON_ALIGN16_MASK) &
+        ~NEON_ALIGN16_MASK);
+    headEnd = headEnd < end ? headEnd : end;
+    while (i != headEnd) {
+      if (*i == '\0') {
+        found = true;
+        break;
+      }
+      ++i;
+    }
+  }
+
+  if (!found && i != end) {
+    const char* middleEnd = reinterpret_cast<const char*>(
+        reinterpret_cast<uintptr_t>(end) & ~NEON_ALIGN16_MASK);
+    const uint8x16_t zeros = vdupq_n_u8(0);
+    while (i < middleEnd) {
+      const uint8x16_t block = vld1q_u8(reinterpret_cast<const uint8_t*>(i));
+      const uint8x16_t match = vceqq_u8(block, zeros);
+      const int pos = FirstNonZeroLane16(match);
+      if (pos < 16) {
+        i += pos;
+        found = true;
+        break;
+      }
+      i += NEON_ALIGN16;
+    }
+  }
+
+  // Handle tail
+  if (!found) {
+    while (i != end) {
+      if (*i == '\0') {
+        found = true;
+        break;
+      }
+      ++i;
+    }
+  }
+
+  if (!found || firstLineNumber == nullptr) {
+    return i;
+  }
+
+  // Count newlines from ptr to i
+  size_t lineCounter = 1;
+  const char* p = ptr;
+
+  // Scalar head
+  if ((reinterpret_cast<uintptr_t>(p) & NEON_ALIGN16_MASK) != 0) {
+    const char* headEnd = reinterpret_cast<const char*>(
+        (reinterpret_cast<uintptr_t>(p) + NEON_ALIGN16_MASK) &
+        ~NEON_ALIGN16_MASK);
+    headEnd = headEnd < i ? headEnd : i;
+    while (p != headEnd) {
+      if (*p == '\n') {
+        ++lineCounter;
+      }
+      ++p;
+    }
+  }
+
+  // NEON middle
+  if (p != i) {
+    const char* middleEnd = reinterpret_cast<const char*>(
+        reinterpret_cast<uintptr_t>(i) & ~NEON_ALIGN16_MASK);
+    const uint8x16_t linefeeds = vdupq_n_u8(static_cast<uint8_t>('\n'));
+    while (p < middleEnd) {
+      const uint8x16_t block = vld1q_u8(reinterpret_cast<const uint8_t*>(p));
+      const uint8x16_t match = vceqq_u8(block, linefeeds);
+      // Count set bytes
+      lineCounter += vaddvq_u8(vshrq_n_u8(match, 7));
+      p += NEON_ALIGN16;
+    }
+  }
+
+  // Scalar tail
+  while (p != i) {
+    if (*p == '\n') {
+      ++lineCounter;
+    }
+    ++p;
+  }
+
+  *firstLineNumber = lineCounter;
+  return i;
+}
+
+#endif
+
 }  // namespace
 
 void ByteBlockBackedDictionary::clear() {
@@ -305,12 +498,20 @@ bool ByteBlockBackedDictionary::parse(const char* block, size_t size,
   if (unaligned32End < ptr) {
     unaligned32End = ptr;
   }
+#elif defined(ENABLE_EXPERIMENTAL_SIMD_SUPPORT_NEON)
+  const char* unaligned16End =
+      reinterpret_cast<const char*>(reinterpret_cast<uintptr_t>(end) - 16);
+  if (unaligned16End < ptr) {
+    unaligned16End = ptr;
+  }
 #endif
 
   // Validate that no NULL characters are in the text.
   size_t errorAtLine = 0;
-#ifdef ENABLE_EXPERIMENTAL_SIMD_SUPPORT_AVX512
+#if defined(ENABLE_EXPERIMENTAL_SIMD_SUPPORT_AVX512)
   const char* ctrlCharPtr = AVX512_FindFirstNULL(ptr, end, &errorAtLine);
+#elif defined(ENABLE_EXPERIMENTAL_SIMD_SUPPORT_NEON)
+  const char* ctrlCharPtr = NEON_FindFirstNULL(ptr, end, &errorAtLine);
 #else
   const char* ctrlCharPtr = FindFirstNULL(ptr, end, &errorAtLine);
 #endif
@@ -330,8 +531,10 @@ bool ByteBlockBackedDictionary::parse(const char* block, size_t size,
       }
 
       if (*ptr == '#') {
-#ifdef ENABLE_EXPERIMENTAL_SIMD_SUPPORT_AVX512
+#if defined(ENABLE_EXPERIMENTAL_SIMD_SUPPORT_AVX512)
         ptr = AVX512_AdvanceToNextCRLF(ptr, unaligned32End, end);
+#elif defined(ENABLE_EXPERIMENTAL_SIMD_SUPPORT_NEON)
+        ptr = NEON_AdvanceToNextCRLF(ptr, unaligned16End, end);
 #else
         ptr = AdvanceToNextCRLF(ptr, end);
 #endif
@@ -339,8 +542,10 @@ bool ByteBlockBackedDictionary::parse(const char* block, size_t size,
       }
 
       const char* keyStart = ptr;
-#ifdef ENABLE_EXPERIMENTAL_SIMD_SUPPORT_AVX512
+#if defined(ENABLE_EXPERIMENTAL_SIMD_SUPPORT_AVX512)
       ptr = AVX512_AdvanceToNextNonContentCharacter(ptr, unaligned32End, end);
+#elif defined(ENABLE_EXPERIMENTAL_SIMD_SUPPORT_NEON)
+      ptr = NEON_AdvanceToNextNonContentCharacter(ptr, unaligned16End, end);
 #else
       ptr = AdvanceToNextNonContentCharacter(ptr, end);
 #endif
@@ -356,8 +561,10 @@ bool ByteBlockBackedDictionary::parse(const char* block, size_t size,
       }
 
       const char* valueStart = ptr;
-#ifdef ENABLE_EXPERIMENTAL_SIMD_SUPPORT_AVX512
+#if defined(ENABLE_EXPERIMENTAL_SIMD_SUPPORT_AVX512)
       ptr = AVX512_AdvanceToNextCRLF(ptr, unaligned32End, end);
+#elif defined(ENABLE_EXPERIMENTAL_SIMD_SUPPORT_NEON)
+      ptr = NEON_AdvanceToNextCRLF(ptr, unaligned16End, end);
 #else
       ptr = AdvanceToNextCRLF(ptr, end);
 #endif
@@ -405,8 +612,10 @@ bool ByteBlockBackedDictionary::parse(const char* block, size_t size,
       }
 
       if (*ptr == '#') {
-#ifdef ENABLE_EXPERIMENTAL_SIMD_SUPPORT_AVX512
+#if defined(ENABLE_EXPERIMENTAL_SIMD_SUPPORT_AVX512)
         ptr = AVX512_AdvanceToNextCRLF(ptr, unaligned32End, end);
+#elif defined(ENABLE_EXPERIMENTAL_SIMD_SUPPORT_NEON)
+        ptr = NEON_AdvanceToNextCRLF(ptr, unaligned16End, end);
 #else
         ptr = AdvanceToNextCRLF(ptr, end);
 #endif
@@ -414,8 +623,10 @@ bool ByteBlockBackedDictionary::parse(const char* block, size_t size,
       }
 
       const char* valueStart = ptr;
-#ifdef ENABLE_EXPERIMENTAL_SIMD_SUPPORT_AVX512
+#if defined(ENABLE_EXPERIMENTAL_SIMD_SUPPORT_AVX512)
       ptr = AVX512_AdvanceToNextNonContentCharacter(ptr, unaligned32End, end);
+#elif defined(ENABLE_EXPERIMENTAL_SIMD_SUPPORT_NEON)
+      ptr = NEON_AdvanceToNextNonContentCharacter(ptr, unaligned16End, end);
 #else
       ptr = AdvanceToNextNonContentCharacter(ptr, end);
 #endif
@@ -430,8 +641,10 @@ bool ByteBlockBackedDictionary::parse(const char* block, size_t size,
       }
 
       const char* maybeKeyStart = ptr;
-#ifdef ENABLE_EXPERIMENTAL_SIMD_SUPPORT_AVX512
+#if defined(ENABLE_EXPERIMENTAL_SIMD_SUPPORT_AVX512)
       ptr = AVX512_AdvanceToNextNonContentCharacter(ptr, unaligned32End, end);
+#elif defined(ENABLE_EXPERIMENTAL_SIMD_SUPPORT_NEON)
+      ptr = NEON_AdvanceToNextNonContentCharacter(ptr, unaligned16End, end);
 #else
       ptr = AdvanceToNextNonContentCharacter(ptr, end);
 #endif
@@ -457,8 +670,10 @@ bool ByteBlockBackedDictionary::parse(const char* block, size_t size,
         // More content incoming.
         valueEnd = maybeKeyEnd;
         maybeKeyStart = ptr;
-#ifdef ENABLE_EXPERIMENTAL_SIMD_SUPPORT_AVX512
+#if defined(ENABLE_EXPERIMENTAL_SIMD_SUPPORT_AVX512)
         ptr = AVX512_AdvanceToNextNonContentCharacter(ptr, unaligned32End, end);
+#elif defined(ENABLE_EXPERIMENTAL_SIMD_SUPPORT_NEON)
+        ptr = NEON_AdvanceToNextNonContentCharacter(ptr, unaligned16End, end);
 #else
         ptr = AdvanceToNextNonContentCharacter(ptr, end);
 #endif

--- a/src/Engine/CMakeLists.txt
+++ b/src/Engine/CMakeLists.txt
@@ -46,6 +46,19 @@ if (ENABLE_EXPERIMENTAL_SIMD_SUPPORT_AVX512)
     endif()
 endif ()
 
+# NEON is supported by default on AArch64 (ARM64), so we can enable it automatically
+# Users can disable it by setting ENABLE_EXPERIMENTAL_SIMD_SUPPORT_NEON to OFF
+# if (NOT DEFINED ENABLE_EXPERIMENTAL_SIMD_SUPPORT_NEON)
+#     if (CMAKE_SYSTEM_PROCESSOR MATCHES "aarch64|arm64|ARM64")
+#         message(STATUS "Detected architecture: ${CMAKE_SYSTEM_PROCESSOR}, enabling NEON support automatically")
+#         set(ENABLE_EXPERIMENTAL_SIMD_SUPPORT_NEON ON)
+#     endif ()
+# endif ()
+
+if (ENABLE_EXPERIMENTAL_SIMD_SUPPORT_NEON)
+    target_compile_definitions(McBopomofoLMLib PRIVATE ENABLE_EXPERIMENTAL_SIMD_SUPPORT_NEON=1)
+endif ()
+
 if (ENABLE_TEST)
         enable_testing()
         if (CMAKE_VERSION VERSION_GREATER_EQUAL "3.24.0")
@@ -75,17 +88,43 @@ if (ENABLE_TEST)
         )
         add_dependencies(runMcBopomofoLMLibTest McBopomofoLMLibTest)
 
-        # Benchmark for ByteBlockBackedDictionary; not enabled by default
-        #
-        # find_package(benchmark)
-        # add_executable(ByteBlockBackedDictionaryBenchmark
-        #         ByteBlockBackedDictionaryBenchmark.cpp)
-        # target_link_libraries(ByteBlockBackedDictionaryBenchmark McBopomofoLMLib benchmark::benchmark)
+        if (ENABLE_BENCHMARK)
+            set(BENCHMARK_ENABLE_TESTING OFF CACHE BOOL "" FORCE)
+            set(BENCHMARK_ENABLE_GTEST_TESTS OFF CACHE BOOL "" FORCE)
+            set(BENCHMARK_VERSION "v1.9.5")
+            MESSAGE(STATUS "Fetching Google Benchmark ${BENCHMARK_VERSION} from GitHub")
+            include(FetchContent)
+            FetchContent_Declare(
+                    benchmark
+                    URL "https://github.com/google/benchmark/archive/refs/tags/${BENCHMARK_VERSION}.zip"
+            )
+            FetchContent_MakeAvailable(benchmark)
 
-        # Stressed benchmark for ParselessLM; not enabled by default
-        #
-        # find_package(benchmark)
-        # add_executable(ParselessLMBenchmark
-        #         ParselessLMBenchmark.cpp)
-        # target_link_libraries(ParselessLMBenchmark McBopomofoLMLib benchmark::benchmark)
+            add_executable(ByteBlockBackedDictionaryBenchmark
+                    ByteBlockBackedDictionaryBenchmark.cpp)
+            target_link_libraries(ByteBlockBackedDictionaryBenchmark McBopomofoLMLib benchmark::benchmark)
+
+            if (ENABLE_EXPERIMENTAL_SIMD_SUPPORT_NEON)
+                target_compile_definitions(ByteBlockBackedDictionaryBenchmark PRIVATE ENABLE_EXPERIMENTAL_SIMD_SUPPORT_NEON=1)
+            endif ()
+            if (ENABLE_EXPERIMENTAL_SIMD_SUPPORT_AVX512)
+                target_compile_options(ByteBlockBackedDictionaryBenchmark PRIVATE -mavx512f -march=native -DENABLE_EXPERIMENTAL_SIMD_SUPPORT_AVX512=1)
+            endif ()
+
+            add_custom_target(
+                    runByteBlockBackedDictionaryBenchmark
+                    COMMAND ${CMAKE_CURRENT_BINARY_DIR}/ByteBlockBackedDictionaryBenchmark
+            )
+            add_dependencies(runByteBlockBackedDictionaryBenchmark ByteBlockBackedDictionaryBenchmark)
+
+            add_executable(ParselessLMBenchmark
+                    ParselessLMBenchmark.cpp)
+            target_link_libraries(ParselessLMBenchmark McBopomofoLMLib benchmark::benchmark)
+
+            add_custom_target(
+                    runParselessLMBenchmark
+                    COMMAND ${CMAKE_CURRENT_BINARY_DIR}/ParselessLMBenchmark
+            )
+            add_dependencies(runParselessLMBenchmark ParselessLMBenchmark)
+        endif ()
 endif ()

--- a/src/Engine/Mandarin/Mandarin.cpp
+++ b/src/Engine/Mandarin/Mandarin.cpp
@@ -688,10 +688,8 @@ BopomofoCharacterMap::BopomofoCharacterMap() {
   characterToComponent[u8"ˋ"] = BPMF::Tone4;
   characterToComponent[u8"˙"] = BPMF::Tone5;
 
-  for (std::map<std::string, BPMF::Component>::iterator iter =
-           characterToComponent.begin();
-       iter != characterToComponent.end(); ++iter) {
-    componentToCharacter[(*iter).second] = (*iter).first;
+  for (const auto& [character, component] : characterToComponent) {
+    componentToCharacter[component] = character;
   }
 }
 

--- a/src/Engine/Mandarin/Mandarin.h
+++ b/src/Engine/Mandarin/Mandarin.h
@@ -183,13 +183,11 @@ class BopomofoKeyboardLayout {
   BopomofoKeyboardLayout(const BopomofoKeyToComponentMap& ktcm,
                          const std::string& name)
       : name_(name), keyToComponent_(ktcm) {
-    for (BopomofoKeyToComponentMap::const_iterator miter =
-             keyToComponent_.begin();
-         miter != keyToComponent_.end(); ++miter)
-      for (std::vector<BPMF::Component>::const_iterator viter =
-               (*miter).second.begin();
-           viter != (*miter).second.end(); ++viter)
-        componentToKey_[*viter] = (*miter).first;
+    for (const auto& [key, components] : keyToComponent_) {
+      for (const auto& component : components) {
+        componentToKey_[component] = key;
+      }
+    }
   }
 
   const std::string name() const { return name_; }

--- a/src/Engine/ParselessLMBenchmark.cpp
+++ b/src/Engine/ParselessLMBenchmark.cpp
@@ -50,7 +50,7 @@ static void BM_ParselessLMFindUnigrams(benchmark::State& state) {
   ParselessLM lm;
   lm.open(kDataPath);
   for (auto _ : state) {
-    lm.unigramsForKey(kUnigramSearchKey);
+    lm.getUnigrams(kUnigramSearchKey);
   }
   lm.close();
 }

--- a/src/Engine/ParselessPhraseDB.cpp
+++ b/src/Engine/ParselessPhraseDB.cpp
@@ -39,7 +39,8 @@ bool ParselessPhraseDB::ValidatePragma(const char* buf, size_t length) {
   return header == SORTED_PRAGMA_HEADER;
 }
 
-std::unique_ptr<ParselessPhraseDB> ParselessPhraseDB::CreateValidatedDB(const char* buf, size_t length) {
+std::unique_ptr<ParselessPhraseDB> ParselessPhraseDB::CreateValidatedDB(
+    const char* buf, size_t length) {
   if (buf == nullptr || length == 0) {
     return nullptr;
   }
@@ -48,7 +49,8 @@ std::unique_ptr<ParselessPhraseDB> ParselessPhraseDB::CreateValidatedDB(const ch
     return nullptr;
   }
 
-  return std::make_unique<ParselessPhraseDB>(buf, length, /*validate_pragma=*/true);
+  return std::make_unique<ParselessPhraseDB>(buf, length,
+                                             /*validate_pragma=*/true);
 }
 
 ParselessPhraseDB::ParselessPhraseDB(const char* buf, size_t length,

--- a/src/Engine/ParselessPhraseDB.h
+++ b/src/Engine/ParselessPhraseDB.h
@@ -69,7 +69,8 @@ class ParselessPhraseDB {
 
   // Convenient function for validating and returning a DB instance. nullptr if
   // the block is empty or is not valid.
-  static std::unique_ptr<ParselessPhraseDB> CreateValidatedDB(const char* buf, size_t length);
+  static std::unique_ptr<ParselessPhraseDB> CreateValidatedDB(const char* buf,
+                                                              size_t length);
 
  private:
   const char* begin_;

--- a/src/Engine/VariantAnnotator.cpp
+++ b/src/Engine/VariantAnnotator.cpp
@@ -103,26 +103,23 @@ VariantAnnotator::Result VariantAnnotator::annotateSingleCharacter(
   if (!variant.empty()) {
     // If variant != value, a variant selector must have been used.
     bool selectorUsed = variant != value;
-    return Result{.annotatedString = variant,
-                  .hasVariantSelectors = selectorUsed};
+    return Result{variant, selectorUsed, false};
   }
 
   // Now try the fallback.
   variant = findUnannotatedVariant(value);
   if (variant.empty() || variant == reading) {
-    return Result{.annotatedString = value};
+    return Result{value, false, false};
   }
 
   std::string puaBlock = findCombinedPUABopomofoReading(reading);
   if (!puaBlock.empty()) {
     // The string is the value + Variant 0 selector + the Bopomofo block in PUA.
-    return Result{.annotatedString = variant + puaBlock,
-                  .hasVariantSelectors = true,
-                  .hasPUACodePoints = true};
+    return Result{variant + puaBlock, true, true};
   }
 
   // Only the unannotated Variant 0 is found.
-  return Result{.annotatedString = variant, .hasVariantSelectors = true};
+  return Result{variant, true, false};
 }
 
 VariantAnnotator::CombinedResult VariantAnnotator::annotate(

--- a/src/Engine/VariantAnnotatorTest.cpp
+++ b/src/Engine/VariantAnnotatorTest.cpp
@@ -137,9 +137,10 @@ TEST(VariantAnnotatorTest, AnnotateCharactersWithMismatchedArguments) {
   GTEST_SKIP();
 #endif
   auto annotator = CreateLoadedAnnotator();
-  EXPECT_DEATH((annotator->annotate({"個", "人", "一", "個", "人", "一", "個"},
-                                    {"ㄍㄜˋ", "ㄖㄣˊ"})),
-               "values.+readings");
+  EXPECT_DEATH(
+      (static_cast<void>(annotator->annotate(
+          {"個", "人", "一", "個", "人", "一", "個"}, {"ㄍㄜˋ", "ㄖㄣˊ"}))),
+      "values.+readings");
 }
 
 TEST(VariantAnnotatorTest, AnnotateCharactersWithAllDefaults) {

--- a/src/Engine/gramambular2/reading_grid.cpp
+++ b/src/Engine/gramambular2/reading_grid.cpp
@@ -414,7 +414,7 @@ std::vector<ReadingGrid::NodeInSpan> ReadingGrid::overlappingNodesAt(
   for (size_t i = 1, len = spans_[loc].maxLength(); i <= len; ++i) {
     NodePtr ptr = spans_[loc].nodeOf(i);
     if (ptr != nullptr) {
-      ReadingGrid::NodeInSpan element{.node = std::move(ptr), .spanIndex = loc};
+      ReadingGrid::NodeInSpan element{std::move(ptr), loc};
       results.emplace_back(std::move(element));
     }
   }
@@ -426,7 +426,7 @@ std::vector<ReadingGrid::NodeInSpan> ReadingGrid::overlappingNodesAt(
     for (size_t j = beginLen; j <= endLen; ++j) {
       NodePtr ptr = spans_[i].nodeOf(j);
       if (ptr != nullptr) {
-        ReadingGrid::NodeInSpan element{.node = std::move(ptr), .spanIndex = i};
+        ReadingGrid::NodeInSpan element{std::move(ptr), i};
         results.emplace_back(std::move(element));
       }
     }

--- a/src/Engine/gramambular2/reading_grid.h
+++ b/src/Engine/gramambular2/reading_grid.h
@@ -183,10 +183,8 @@ class ReadingGrid {
   WalkResult walk();
 
   struct Candidate {
-    Candidate(std::string r, std::string v, std::string rawValue)
-        : reading(std::move(r)),
-          value(std::move(v)),
-          rawValue(std::move(rawValue)) {}
+    Candidate(std::string r, std::string v, std::string rv = "")
+        : reading(std::move(r)), value(std::move(v)), rawValue(std::move(rv)) {}
     const std::string reading;
     const std::string value;
     const std::string rawValue;

--- a/src/Engine/gramambular2/reading_grid_test.cpp
+++ b/src/Engine/gramambular2/reading_grid_test.cpp
@@ -738,14 +738,14 @@ TEST(ReadingGridTest, DisambiguateCandidates) {
 
   constexpr size_t loc = 2;  // after 高熱
 
-  ASSERT_TRUE(grid.overrideCandidate(
-      loc, ReadingGrid::Candidate("ㄏㄨㄛˇ", "🔥", "🔥")));
+  ASSERT_TRUE(
+      grid.overrideCandidate(loc, ReadingGrid::Candidate("ㄏㄨㄛˇ", "🔥")));
   result = grid.walk();
   ASSERT_EQ(result.valuesAsStrings(),
             (std::vector<std::string>{"高熱", "🔥", "焰", "危險"}));
 
   ASSERT_TRUE(grid.overrideCandidate(
-      loc, ReadingGrid::Candidate("ㄏㄨㄛˇㄧㄢˋ", "🔥", "🔥")));
+      loc, ReadingGrid::Candidate("ㄏㄨㄛˇㄧㄢˋ", "🔥")));
   result = grid.walk();
   ASSERT_EQ(result.valuesAsStrings(),
             (std::vector<std::string>{"高熱", "🔥", "危險"}));


### PR DESCRIPTION
The two repos started to drift. This keeps them in sync. The NEON support in particular is now included.

This includes changes from:

- https://github.com/openvanilla/McBopomofo/pull/499
- https://github.com/openvanilla/McBopomofo/pull/794
- https://github.com/openvanilla/McBopomofo/pull/822

Also did a clang-format pass.