### PR TITLE
Reduces the amount of the candidates in the smart associated mode

### DIFF
--- a/src/InputState.h
+++ b/src/InputState.h
@@ -241,7 +241,7 @@ struct AssociatedPhrases : NotEmpty {
                     std::string pfxReading, std::string pfxValue,
                     size_t selIndex,
                     std::vector<ChoosingCandidate::Candidate> cs,
-                    bool useShiftKey = false)
+                    bool autoTriggered = false)
       : NotEmpty(prevState->composingBuffer, prevState->cursorIndex,
                  prevState->tooltip),
         previousState(std::move(prevState)),
@@ -250,14 +250,27 @@ struct AssociatedPhrases : NotEmpty {
         prefixValue(std::move(pfxValue)),
         selectedCandidateIndex(selIndex),
         candidates(std::move(cs)),
-        useShiftKey(useShiftKey) {}
+        autoTriggered(autoTriggered) {}
+
+  AssociatedPhrases(const AssociatedPhrases& other, bool autoTriggered = false)
+      : NotEmpty(other.previousState->composingBuffer,
+                 other.previousState->cursorIndex,
+                 other.previousState->tooltip),
+        previousState(std::make_unique<NotEmpty>(*other.previousState)),
+        prefixCursorIndex(other.prefixCursorIndex),
+        prefixReading(other.prefixReading),
+        prefixValue(other.prefixValue),
+        selectedCandidateIndex(other.selectedCandidateIndex),
+        candidates(other.candidates),
+        autoTriggered(autoTriggered) {}
+
   std::unique_ptr<NotEmpty> previousState;
   size_t prefixCursorIndex;
   std::string prefixReading;
   std::string prefixValue;
   size_t selectedCandidateIndex;
   const std::vector<ChoosingCandidate::Candidate> candidates;
-  bool useShiftKey;
+  bool autoTriggered;
 };
 
 struct AssociatedPhrasesPlain : InputState {

--- a/src/InputState.h
+++ b/src/InputState.h
@@ -252,11 +252,11 @@ struct AssociatedPhrases : NotEmpty {
         candidates(std::move(cs)),
         autoTriggered(autoTriggered) {}
 
-  AssociatedPhrases(const AssociatedPhrases& other, bool autoTriggered = false)
+  AssociatedPhrases(AssociatedPhrases& other, bool autoTriggered = false)
       : NotEmpty(other.previousState->composingBuffer,
                  other.previousState->cursorIndex,
                  other.previousState->tooltip),
-        previousState(std::make_unique<NotEmpty>(*other.previousState)),
+        previousState(std::move(other.previousState)),
         prefixCursorIndex(other.prefixCursorIndex),
         prefixReading(other.prefixReading),
         prefixValue(other.prefixValue),

--- a/src/InputState.h
+++ b/src/InputState.h
@@ -251,19 +251,6 @@ struct AssociatedPhrases : NotEmpty {
         selectedCandidateIndex(selIndex),
         candidates(std::move(cs)),
         autoTriggered(autoTriggered) {}
-
-  AssociatedPhrases(AssociatedPhrases& other, bool autoTriggered = false)
-      : NotEmpty(other.previousState->composingBuffer,
-                 other.previousState->cursorIndex,
-                 other.previousState->tooltip),
-        previousState(std::move(other.previousState)),
-        prefixCursorIndex(other.prefixCursorIndex),
-        prefixReading(other.prefixReading),
-        prefixValue(other.prefixValue),
-        selectedCandidateIndex(other.selectedCandidateIndex),
-        candidates(other.candidates),
-        autoTriggered(autoTriggered) {}
-
   std::unique_ptr<NotEmpty> previousState;
   size_t prefixCursorIndex;
   std::string prefixReading;

--- a/src/McBopomofo.cpp
+++ b/src/McBopomofo.cpp
@@ -859,12 +859,6 @@ void McBopomofoEngine::keyEvent(const fcitx::InputMethodEntry& /*unused*/,
           // TODO(unassigned): beep?
         });
 
-    InputStates::AssociatedPhrases* assocatedPheases =
-        dynamic_cast<InputStates::AssociatedPhrases*>(state_.get());
-    if (!handled && assocatedPheases != nullptr &&
-        assocatedPheases->autoTriggered) {
-      state_ = keyHandler_->buildInputtingState();
-    }
     if (dynamic_cast<InputStates::ChoosingCandidate*>(state_.get()) !=
             nullptr ||
         dynamic_cast<InputStates::SelectingDictionary*>(state_.get()) !=
@@ -918,8 +912,8 @@ bool McBopomofoEngine::handleCandidateKeyEvent(
 
   if (associatedPhrases != nullptr && associatedPhrases->autoTriggered) {
     if (key.check(FcitxKey_Tab)) {
-      auto expanded =
-          std::make_unique<InputStates::AssociatedPhrases>(*associatedPhrases);
+      auto expanded = std::make_unique<InputStates::AssociatedPhrases>(
+          *associatedPhrases, false);
       stateCallback(std::move(expanded));
       return true;
     }
@@ -932,6 +926,7 @@ bool McBopomofoEngine::handleCandidateKeyEvent(
       }
       return true;
     }
+    stateCallback(keyHandler_->buildInputtingState());
     return false;
   }
 
@@ -1251,9 +1246,6 @@ bool McBopomofoEngine::handleCandidateKeyEvent(
     }
 
     if (associatedPhrases != nullptr) {
-      if (associatedPhrases->autoTriggered) {
-        return false;
-      }
       auto* previous = associatedPhrases->previousState.get();
       auto* choosing = dynamic_cast<InputStates::ChoosingCandidate*>(previous);
       auto* inputting = dynamic_cast<InputStates::Inputting*>(previous);
@@ -1272,6 +1264,9 @@ bool McBopomofoEngine::handleCandidateKeyEvent(
       } else if (inputting != nullptr) {
         auto copy = std::make_unique<InputStates::Inputting>(*inputting);
         stateCallback(std::move(copy));
+      } else {
+        auto inputting = keyHandler_->buildInputtingState();
+        stateCallback(std::move(inputting));
       }
       return true;
     }
@@ -1315,12 +1310,6 @@ bool McBopomofoEngine::handleCandidateKeyEvent(
 
   // Space goes to next page or wraps to the first if at the end.
   if (key.check(FcitxKey_space)) {
-    // if (associatedPhrases != nullptr) {
-    //   if (associatedPhrases->autoTriggered) {
-    //     return false;
-    //   }
-    // }
-
     if (candidateList->hasNext()) {
       candidateList->next();
       candidateList->toCursorMovable()->nextCandidate();

--- a/src/McBopomofo.cpp
+++ b/src/McBopomofo.cpp
@@ -858,6 +858,13 @@ void McBopomofoEngine::keyEvent(const fcitx::InputMethodEntry& /*unused*/,
         []() {
           // TODO(unassigned): beep?
         });
+
+    InputStates::AssociatedPhrases* assocatedPheases =
+        dynamic_cast<InputStates::AssociatedPhrases*>(state_.get());
+    if (!handled && assocatedPheases != nullptr &&
+        assocatedPheases->autoTriggered) {
+      state_ = keyHandler_->buildInputtingState();
+    }
     if (dynamic_cast<InputStates::ChoosingCandidate*>(state_.get()) !=
             nullptr ||
         dynamic_cast<InputStates::SelectingDictionary*>(state_.get()) !=
@@ -909,9 +916,26 @@ bool McBopomofoEngine::handleCandidateKeyEvent(
   InputStates::ChoosingPunctuationList* choosingPunctuationList =
       dynamic_cast<InputStates::ChoosingPunctuationList*>(state_.get());
 
-  bool shouldUseShiftKey =
-      associatedPhrasesPlain != nullptr ||
-      (associatedPhrases != nullptr && associatedPhrases->useShiftKey);
+  if (associatedPhrases != nullptr && associatedPhrases->autoTriggered) {
+    if (key.check(FcitxKey_Tab)) {
+      auto expanded =
+          std::make_unique<InputStates::AssociatedPhrases>(*associatedPhrases);
+      stateCallback(std::move(expanded));
+      return true;
+    }
+    if (key.check(FcitxKey_Return, fcitx::KeyStates(fcitx::KeyState::Shift)) ||
+        key.check(FcitxKey_KP_Enter,
+                  fcitx::KeyStates(fcitx::KeyState::Shift))) {
+      int idx = candidateList->cursorIndex();
+      if (idx < candidateList->size()) {
+        candidateList->candidate(idx).select(context);
+      }
+      return true;
+    }
+    return false;
+  }
+
+  bool shouldUseShiftKey = associatedPhrasesPlain != nullptr;
 
   // Plain Bopomofo, Associated Phrases, and Number Input.
   if (shouldUseShiftKey || numberInput != nullptr) {
@@ -1227,7 +1251,7 @@ bool McBopomofoEngine::handleCandidateKeyEvent(
     }
 
     if (associatedPhrases != nullptr) {
-      if (associatedPhrases->useShiftKey) {
+      if (associatedPhrases->autoTriggered) {
         return false;
       }
       auto* previous = associatedPhrases->previousState.get();
@@ -1291,11 +1315,11 @@ bool McBopomofoEngine::handleCandidateKeyEvent(
 
   // Space goes to next page or wraps to the first if at the end.
   if (key.check(FcitxKey_space)) {
-    if (associatedPhrases != nullptr) {
-      if (associatedPhrases->useShiftKey) {
-        return false;
-      }
-    }
+    // if (associatedPhrases != nullptr) {
+    //   if (associatedPhrases->autoTriggered) {
+    //     return false;
+    //   }
+    // }
 
     if (candidateList->hasNext()) {
       candidateList->next();
@@ -1612,10 +1636,14 @@ void McBopomofoEngine::handleCandidatesState(fcitx::InputContext* context,
       dynamic_cast<InputStates::IrohaCandidate*>(state_.get());
 
   bool useShiftKey =
-      numberInput != nullptr || associatedPhrasesPlain != nullptr ||
-      (associatedPhrases != nullptr && associatedPhrases->useShiftKey);
+      numberInput != nullptr || associatedPhrasesPlain != nullptr;
 
-  if (useShiftKey) {
+  if ((associatedPhrases != nullptr && associatedPhrases->autoTriggered)) {
+    selectionKeys_ = fcitx::Key::keyListFromString("Shift+Return");
+    std::vector<std::string> labels = {"⇧⏎ "};
+    candidateList->setLabels(labels);
+    candidateList->setPageSize(1);
+  } else if (useShiftKey) {
     // This is for label appearance only. Shift+[1-9] keys can only be checked
     // via a raw key's key code, but Keys constructed with "Shift-" names does
     // not carry proper key codes.
@@ -1730,13 +1758,27 @@ void McBopomofoEngine::handleCandidatesState(fcitx::InputContext* context,
     std::vector<InputStates::ChoosingCandidate::Candidate> candidates =
         associatedPhrases->candidates;
 
-    for (const auto& c : candidates) {
-      std::unique_ptr<fcitx::CandidateWord> candidate =
-          std::make_unique<McBopomofoAssociatedPhraseCandidateWord>(
-              fcitx::Text(c.value), c, associatedPhrases->prefixReading,
-              associatedPhrases->prefixValue,
-              associatedPhrases->prefixCursorIndex, keyHandler_, callback);
-      candidateList->append(std::move(candidate));
+    if (associatedPhrases->autoTriggered) {
+      // If autoTriggered, show only the first candidate, and select it
+      // immediately when user press Enter/Return.
+      if (!candidates.empty()) {
+        const auto& c = candidates.front();
+        std::unique_ptr<fcitx::CandidateWord> candidate =
+            std::make_unique<McBopomofoAssociatedPhraseCandidateWord>(
+                fcitx::Text(c.value), c, associatedPhrases->prefixReading,
+                associatedPhrases->prefixValue,
+                associatedPhrases->prefixCursorIndex, keyHandler_, callback);
+        candidateList->append(std::move(candidate));
+      }
+    } else {
+      for (const auto& c : candidates) {
+        std::unique_ptr<fcitx::CandidateWord> candidate =
+            std::make_unique<McBopomofoAssociatedPhraseCandidateWord>(
+                fcitx::Text(c.value), c, associatedPhrases->prefixReading,
+                associatedPhrases->prefixValue,
+                associatedPhrases->prefixCursorIndex, keyHandler_, callback);
+        candidateList->append(std::move(candidate));
+      }
     }
   } else if (associatedPhrasesPlain != nullptr) {
     std::vector<InputStates::ChoosingCandidate::Candidate> candidates =

--- a/src/McBopomofo.cpp
+++ b/src/McBopomofo.cpp
@@ -913,7 +913,11 @@ bool McBopomofoEngine::handleCandidateKeyEvent(
   if (associatedPhrases != nullptr && associatedPhrases->autoTriggered) {
     if (key.check(FcitxKey_Tab)) {
       auto expanded = std::make_unique<InputStates::AssociatedPhrases>(
-          *associatedPhrases, false);
+          std::move(associatedPhrases->previousState),
+          associatedPhrases->prefixCursorIndex,
+          associatedPhrases->prefixReading, associatedPhrases->prefixValue,
+          associatedPhrases->selectedCandidateIndex,
+          associatedPhrases->candidates, false);
       stateCallback(std::move(expanded));
       return true;
     }


### PR DESCRIPTION
The PR ports https://github.com/openvanilla/McBopomofo/pull/824 to the fcitx5 version.

In the current implementation, there are too many candidates in the associated phrases in McBpomofo mode. The PR reduces the amount of the candidates to only one and a user can use shit+enter to use the associated phrases, or tab key to expand to all canidates.