### PR TITLE
Use C++20 (fixes #252)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.12)
 project(fcitx5-mcbopomofo VERSION 3.0)
 
 find_package(ECM REQUIRED 1.0.0)

--- a/src/Big5Utils/CMakeLists.txt
+++ b/src/Big5Utils/CMakeLists.txt
@@ -1,9 +1,9 @@
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.12)
 project(Big5UtilsLib)
 
 find_package(ICU COMPONENTS uc REQUIRED)
 
-set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD 20)
 set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC")
 
 add_library(Big5UtilsLib

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.12)
 project(mcbopomofo VERSION 3.0)
 
 find_package(PkgConfig REQUIRED)

--- a/src/ChineseNumbers/CMakeLists.txt
+++ b/src/ChineseNumbers/CMakeLists.txt
@@ -1,7 +1,7 @@
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.12)
 project(ChineseNumbersLib)
 
-set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD 20)
 set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC")
 
 add_library(ChineseNumbersLib

--- a/src/Engine/ByteBlockBackedDictionaryTest.cpp
+++ b/src/Engine/ByteBlockBackedDictionaryTest.cpp
@@ -47,10 +47,11 @@ TEST(ByteBlockBackedDictionaryTest, Simple2) {
 }
 
 TEST(ByteBlockBackedDictionaryTest, EncodingAgnostic1) {
-  constexpr char data[] = u8"smile 😊";
+  const auto *data = u8"smile 😊";
+  const char *charData = reinterpret_cast<const char*>(data);
   ByteBlockBackedDictionary dict;
-  ASSERT_TRUE(dict.parse(data, sizeof(data)));
-  ASSERT_EQ(dict.getValues("smile").at(0), u8"😊");
+  ASSERT_TRUE(dict.parse(charData, strlen(charData)));
+  ASSERT_EQ(dict.getValues("smile").at(0), reinterpret_cast<const char*>(u8"😊"));
 }
 
 TEST(ByteBlockBackedDictionaryTest, EncodingAgnostic2) {

--- a/src/Engine/CMakeLists.txt
+++ b/src/Engine/CMakeLists.txt
@@ -1,7 +1,7 @@
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.12)
 project(McBopomofoLMLib)
 
-set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC")
 
 add_subdirectory(gramambular2)

--- a/src/Engine/Mandarin/CMakeLists.txt
+++ b/src/Engine/Mandarin/CMakeLists.txt
@@ -1,7 +1,7 @@
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.12)
 project(Mandarin)
 
-set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD 20)
 set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC")
 
 add_library(MandarinLib Mandarin.h Mandarin.cpp)

--- a/src/Engine/Mandarin/Mandarin.cpp
+++ b/src/Engine/Mandarin/Mandarin.cpp
@@ -268,7 +268,8 @@ const BPMF BPMF::FromHanyuPinyin(const std::string& str) {
   } else if (PinyinParseHelper::ConsumePrefix(pinyin, "ue")) {
     secondComponent = BPMF::UE;
     thirdComponent = BPMF::E;
-  } else if (PinyinParseHelper::ConsumePrefix(pinyin, u8"ü")) {
+  } else if (PinyinParseHelper::ConsumePrefix(
+                 pinyin, reinterpret_cast<const char*>(u8"ü"))) {
     secondComponent = BPMF::UE;
   }
 
@@ -646,47 +647,47 @@ const BopomofoCharacterMap& BopomofoCharacterMap::SharedInstance() {
 }
 
 BopomofoCharacterMap::BopomofoCharacterMap() {
-  characterToComponent[u8"ㄅ"] = BPMF::B;
-  characterToComponent[u8"ㄆ"] = BPMF::P;
-  characterToComponent[u8"ㄇ"] = BPMF::M;
-  characterToComponent[u8"ㄈ"] = BPMF::F;
-  characterToComponent[u8"ㄉ"] = BPMF::D;
-  characterToComponent[u8"ㄊ"] = BPMF::T;
-  characterToComponent[u8"ㄋ"] = BPMF::N;
-  characterToComponent[u8"ㄌ"] = BPMF::L;
-  characterToComponent[u8"ㄎ"] = BPMF::K;
-  characterToComponent[u8"ㄍ"] = BPMF::G;
-  characterToComponent[u8"ㄏ"] = BPMF::H;
-  characterToComponent[u8"ㄐ"] = BPMF::J;
-  characterToComponent[u8"ㄑ"] = BPMF::Q;
-  characterToComponent[u8"ㄒ"] = BPMF::X;
-  characterToComponent[u8"ㄓ"] = BPMF::ZH;
-  characterToComponent[u8"ㄔ"] = BPMF::CH;
-  characterToComponent[u8"ㄕ"] = BPMF::SH;
-  characterToComponent[u8"ㄖ"] = BPMF::R;
-  characterToComponent[u8"ㄗ"] = BPMF::Z;
-  characterToComponent[u8"ㄘ"] = BPMF::C;
-  characterToComponent[u8"ㄙ"] = BPMF::S;
-  characterToComponent[u8"ㄧ"] = BPMF::I;
-  characterToComponent[u8"ㄨ"] = BPMF::U;
-  characterToComponent[u8"ㄩ"] = BPMF::UE;
-  characterToComponent[u8"ㄚ"] = BPMF::A;
-  characterToComponent[u8"ㄛ"] = BPMF::O;
-  characterToComponent[u8"ㄜ"] = BPMF::ER;
-  characterToComponent[u8"ㄝ"] = BPMF::E;
-  characterToComponent[u8"ㄞ"] = BPMF::AI;
-  characterToComponent[u8"ㄟ"] = BPMF::EI;
-  characterToComponent[u8"ㄠ"] = BPMF::AO;
-  characterToComponent[u8"ㄡ"] = BPMF::OU;
-  characterToComponent[u8"ㄢ"] = BPMF::AN;
-  characterToComponent[u8"ㄣ"] = BPMF::EN;
-  characterToComponent[u8"ㄤ"] = BPMF::ANG;
-  characterToComponent[u8"ㄥ"] = BPMF::ENG;
-  characterToComponent[u8"ㄦ"] = BPMF::ERR;
-  characterToComponent[u8"ˊ"] = BPMF::Tone2;
-  characterToComponent[u8"ˇ"] = BPMF::Tone3;
-  characterToComponent[u8"ˋ"] = BPMF::Tone4;
-  characterToComponent[u8"˙"] = BPMF::Tone5;
+  characterToComponent[reinterpret_cast<const char*>(u8"ㄅ")] = BPMF::B;
+  characterToComponent[reinterpret_cast<const char*>(u8"ㄆ")] = BPMF::P;
+  characterToComponent[reinterpret_cast<const char*>(u8"ㄇ")] = BPMF::M;
+  characterToComponent[reinterpret_cast<const char*>(u8"ㄈ")] = BPMF::F;
+  characterToComponent[reinterpret_cast<const char*>(u8"ㄉ")] = BPMF::D;
+  characterToComponent[reinterpret_cast<const char*>(u8"ㄊ")] = BPMF::T;
+  characterToComponent[reinterpret_cast<const char*>(u8"ㄋ")] = BPMF::N;
+  characterToComponent[reinterpret_cast<const char*>(u8"ㄌ")] = BPMF::L;
+  characterToComponent[reinterpret_cast<const char*>(u8"ㄎ")] = BPMF::K;
+  characterToComponent[reinterpret_cast<const char*>(u8"ㄍ")] = BPMF::G;
+  characterToComponent[reinterpret_cast<const char*>(u8"ㄏ")] = BPMF::H;
+  characterToComponent[reinterpret_cast<const char*>(u8"ㄐ")] = BPMF::J;
+  characterToComponent[reinterpret_cast<const char*>(u8"ㄑ")] = BPMF::Q;
+  characterToComponent[reinterpret_cast<const char*>(u8"ㄒ")] = BPMF::X;
+  characterToComponent[reinterpret_cast<const char*>(u8"ㄓ")] = BPMF::ZH;
+  characterToComponent[reinterpret_cast<const char*>(u8"ㄔ")] = BPMF::CH;
+  characterToComponent[reinterpret_cast<const char*>(u8"ㄕ")] = BPMF::SH;
+  characterToComponent[reinterpret_cast<const char*>(u8"ㄖ")] = BPMF::R;
+  characterToComponent[reinterpret_cast<const char*>(u8"ㄗ")] = BPMF::Z;
+  characterToComponent[reinterpret_cast<const char*>(u8"ㄘ")] = BPMF::C;
+  characterToComponent[reinterpret_cast<const char*>(u8"ㄙ")] = BPMF::S;
+  characterToComponent[reinterpret_cast<const char*>(u8"ㄧ")] = BPMF::I;
+  characterToComponent[reinterpret_cast<const char*>(u8"ㄨ")] = BPMF::U;
+  characterToComponent[reinterpret_cast<const char*>(u8"ㄩ")] = BPMF::UE;
+  characterToComponent[reinterpret_cast<const char*>(u8"ㄚ")] = BPMF::A;
+  characterToComponent[reinterpret_cast<const char*>(u8"ㄛ")] = BPMF::O;
+  characterToComponent[reinterpret_cast<const char*>(u8"ㄜ")] = BPMF::ER;
+  characterToComponent[reinterpret_cast<const char*>(u8"ㄝ")] = BPMF::E;
+  characterToComponent[reinterpret_cast<const char*>(u8"ㄞ")] = BPMF::AI;
+  characterToComponent[reinterpret_cast<const char*>(u8"ㄟ")] = BPMF::EI;
+  characterToComponent[reinterpret_cast<const char*>(u8"ㄠ")] = BPMF::AO;
+  characterToComponent[reinterpret_cast<const char*>(u8"ㄡ")] = BPMF::OU;
+  characterToComponent[reinterpret_cast<const char*>(u8"ㄢ")] = BPMF::AN;
+  characterToComponent[reinterpret_cast<const char*>(u8"ㄣ")] = BPMF::EN;
+  characterToComponent[reinterpret_cast<const char*>(u8"ㄤ")] = BPMF::ANG;
+  characterToComponent[reinterpret_cast<const char*>(u8"ㄥ")] = BPMF::ENG;
+  characterToComponent[reinterpret_cast<const char*>(u8"ㄦ")] = BPMF::ERR;
+  characterToComponent[reinterpret_cast<const char*>(u8"ˊ")] = BPMF::Tone2;
+  characterToComponent[reinterpret_cast<const char*>(u8"ˇ")] = BPMF::Tone3;
+  characterToComponent[reinterpret_cast<const char*>(u8"ˋ")] = BPMF::Tone4;
+  characterToComponent[reinterpret_cast<const char*>(u8"˙")] = BPMF::Tone5;
 
   for (const auto& [character, component] : characterToComponent) {
     componentToCharacter[component] = character;

--- a/src/Engine/VariantAnnotatorTest.cpp
+++ b/src/Engine/VariantAnnotatorTest.cpp
@@ -26,7 +26,7 @@
 
 namespace McBopomofo {
 
-constexpr std::string_view kTestVariantsData =
+static const auto* kTestVariantsData =
     u8"# format org.openvanilla.mcbopomofo.sorted\n"
     u8"一-na 一\U000E01E0\n"
     u8"一-ㄧ 一\n"
@@ -37,17 +37,20 @@ constexpr std::string_view kTestVariantsData =
     u8"個-ㄍㄜˋ 個\n"
     u8"個-ㄍㄜ˙ 個\U000E01E1";
 
-constexpr std::string_view kTestPUAData =
+static const auto* kTestPUAData =
     u8"# format org.openvanilla.mcbopomofo.sorted\n"
     u8"ㄍㄚˋ \uF145\n"
     u8"ㄧㄚˊ \uF4BB";
 
 static std::unique_ptr<VariantAnnotator> CreateLoadedAnnotator() {
   auto annotator = std::make_unique<VariantAnnotator>();
-  annotator->loadVariantsMap(ParselessPhraseDB::CreateValidatedDB(
-      kTestVariantsData.data(), kTestVariantsData.length()));
-  annotator->loadPUAMap(ParselessPhraseDB::CreateValidatedDB(
-      kTestPUAData.data(), kTestPUAData.length()));
+
+  const char* variantsData = reinterpret_cast<const char*>(kTestVariantsData);
+  const char* puaData = reinterpret_cast<const char*>(kTestPUAData);
+  annotator->loadVariantsMap(
+      ParselessPhraseDB::CreateValidatedDB(variantsData, strlen(variantsData)));
+  annotator->loadPUAMap(
+      ParselessPhraseDB::CreateValidatedDB(puaData, strlen(puaData)));
   EXPECT_TRUE(annotator->loaded());
   return annotator;
 }
@@ -82,7 +85,8 @@ TEST(VariantAnnotatorTest, SingleCharacterAnnotationWithVariantSelector) {
   auto annotator = CreateLoadedAnnotator();
   VariantAnnotator::Result result =
       annotator->annotateSingleCharacter("個", "ㄍㄜ˙");
-  EXPECT_EQ(result.annotatedString, u8"個\U000E01E1");
+  EXPECT_EQ(result.annotatedString,
+            reinterpret_cast<const char*>(u8"個\U000E01E1"));
   EXPECT_TRUE(result.hasVariantSelectors);
   EXPECT_FALSE(result.hasPUACodePoints);
 }
@@ -91,7 +95,8 @@ TEST(VariantAnnotatorTest, SingleCharacterAnnotationWithVariant0AndPUA) {
   auto annotator = CreateLoadedAnnotator();
   VariantAnnotator::Result result =
       annotator->annotateSingleCharacter("個", "ㄍㄚˋ");
-  EXPECT_EQ(result.annotatedString, u8"個\U000E01E0\uF145");
+  EXPECT_EQ(result.annotatedString,
+            reinterpret_cast<const char*>(u8"個\U000E01E0\uF145"));
   EXPECT_TRUE(result.hasVariantSelectors);
   EXPECT_TRUE(result.hasPUACodePoints);
 }
@@ -100,7 +105,8 @@ TEST(VariantAnnotatorTest, SingleCharacterAnnotationWithVariant0AndNoPUA) {
   auto annotator = CreateLoadedAnnotator();
   VariantAnnotator::Result result =
       annotator->annotateSingleCharacter("個", "ㄍ");
-  EXPECT_EQ(result.annotatedString, u8"個\U000E01E0");
+  EXPECT_EQ(result.annotatedString,
+            reinterpret_cast<const char*>(u8"個\U000E01E0"));
   EXPECT_TRUE(result.hasVariantSelectors);
   EXPECT_FALSE(result.hasPUACodePoints);
 }
@@ -109,7 +115,7 @@ TEST(VariantAnnotatorTest, SingleCharacterAnnotationWithUnknownCharacter) {
   auto annotator = CreateLoadedAnnotator();
   VariantAnnotator::Result result =
       annotator->annotateSingleCharacter("人", "ㄖㄣˊ");
-  EXPECT_EQ(result.annotatedString, u8"人");
+  EXPECT_EQ(result.annotatedString, reinterpret_cast<const char*>(u8"人"));
   EXPECT_FALSE(result.hasVariantSelectors);
   EXPECT_FALSE(result.hasPUACodePoints);
 }
@@ -120,15 +126,19 @@ TEST(VariantAnnotatorTest, AnnotateCharacters) {
       {"個", "人", "一", "個", "人", "一", "個"},
       {"ㄍㄜˋ", "ㄖㄣˊ", "ㄧˊ", "ㄍㄜ˙", "ㄖㄣˊ", "ㄧ", "ㄍㄚˋ"});
   EXPECT_EQ(result.annotatedString,
-            u8"個人一\U000E01E1個\U000E01E1人一個\U000E01E0\uF145");
+            reinterpret_cast<const char*>(
+                u8"個人一\U000E01E1個\U000E01E1人一個\U000E01E0\uF145"));
   EXPECT_TRUE(result.hasVariantSelectors);
   EXPECT_TRUE(result.hasPUACodePoints);
   EXPECT_EQ(result.accumulatedStringLength.size(), 8);
   EXPECT_EQ(result.accumulatedStringLength[0], 0);
-  EXPECT_EQ(result.accumulatedStringLength[1], strlen(u8"個"));
-  EXPECT_EQ(result.accumulatedStringLength[3], strlen(u8"個人一\U000E01E1"));
+  EXPECT_EQ(result.accumulatedStringLength[1],
+            strlen(reinterpret_cast<const char*>(u8"個")));
+  EXPECT_EQ(result.accumulatedStringLength[3],
+            strlen(reinterpret_cast<const char*>(u8"個人一\U000E01E1")));
   EXPECT_EQ(result.accumulatedStringLength[6],
-            strlen(u8"個人一\U000E01E1個\U000E01E1人一"));
+            strlen(reinterpret_cast<const char*>(
+                u8"個人一\U000E01E1個\U000E01E1人一")));
   EXPECT_EQ(result.accumulatedStringLength[7], result.annotatedString.size());
 }
 
@@ -158,7 +168,8 @@ TEST(VariantAnnotatorTest, AnnotateCharactersWithVariant0AndPUA) {
   VariantAnnotator::CombinedResult result = annotator->annotate(
       {"個", "人", "一", "個", "人", "一", "個"},
       {"ㄍㄜˋ", "ㄖㄣˊ", "ㄧ", "ㄍㄜˋ", "ㄖㄣˊ", "ㄧ", "ㄍㄚˋ"});
-  EXPECT_EQ(result.annotatedString, u8"個人一個人一個\U000E01E0\uF145");
+  EXPECT_EQ(result.annotatedString,
+            reinterpret_cast<const char*>(u8"個人一個人一個\U000E01E0\uF145"));
   EXPECT_TRUE(result.hasVariantSelectors);
   EXPECT_TRUE(result.hasPUACodePoints);
 }
@@ -168,7 +179,8 @@ TEST(VariantAnnotatorTest, AnnotateCharactersWithVariant0ButNoPUA) {
   VariantAnnotator::CombinedResult result = annotator->annotate(
       {"個", "人", "一", "個", "人", "一", "個"},
       {"ㄍㄜˋ", "ㄖㄣˊ", "ㄧ", "ㄍㄜˋ", "ㄖㄣˊ", "ㄧ", "ㄍ"});
-  EXPECT_EQ(result.annotatedString, u8"個人一個人一個\U000E01E0");
+  EXPECT_EQ(result.annotatedString,
+            reinterpret_cast<const char*>(u8"個人一個人一個\U000E01E0"));
   EXPECT_TRUE(result.hasVariantSelectors);
   EXPECT_FALSE(result.hasPUACodePoints);
 }

--- a/src/Engine/gramambular2/CMakeLists.txt
+++ b/src/Engine/gramambular2/CMakeLists.txt
@@ -1,7 +1,7 @@
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.12)
 project(gramambular2)
 
-set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD 20)
 set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC")
 
 add_library(gramambular2_lib language_model.h reading_grid.h reading_grid.cpp)

--- a/src/RomanNumbers/CMakeLists.txt
+++ b/src/RomanNumbers/CMakeLists.txt
@@ -1,7 +1,7 @@
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.12)
 project(RomanNumbersLib)
 
-set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD 20)
 set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC")
 
 add_library(RomanNumbersLib


### PR DESCRIPTION
This updates all UTF-8 string literal uses since u8 strings are now represented by char8_t which is a distinct type.