### PR TITLE
Improve how MemoryMappedFile handles mmap failures

### DIFF
--- a/src/Engine/MemoryMappedFile.cpp
+++ b/src/Engine/MemoryMappedFile.cpp
@@ -49,7 +49,7 @@ MemoryMappedFile& MemoryMappedFile::operator=(
 MemoryMappedFile::~MemoryMappedFile() { close(); }
 
 bool MemoryMappedFile::open(const char* path) {
-  if (data_) {
+  if (fd_ != -1) {
     return false;
   }
 
@@ -67,6 +67,7 @@ bool MemoryMappedFile::open(const char* path) {
 
   length_ = static_cast<size_t>(sb.st_size);
 
+  // No need to check if length_ is 0; mmmap fails on empty files.
   data_ = mmap(nullptr, length_, PROT_READ, MAP_SHARED, fd_, 0);
   if (data_ == MAP_FAILED) {
     ::close(fd_);
@@ -80,7 +81,7 @@ bool MemoryMappedFile::open(const char* path) {
 }
 
 void MemoryMappedFile::close() {
-  if (data_ == nullptr) {
+  if (fd_ == -1) {
     return;
   }
   munmap(data_, length_);

--- a/src/Engine/MemoryMappedFile.h
+++ b/src/Engine/MemoryMappedFile.h
@@ -48,6 +48,8 @@ class MemoryMappedFile {
   bool open(const char* path);
   void close();
 
+  bool isOpen() const { return fd_ != -1; }
+
   [[nodiscard]] const char* data() const {
     return static_cast<const char*>(data_);
   }

--- a/src/Engine/MemoryMappedFileTest.cpp
+++ b/src/Engine/MemoryMappedFileTest.cpp
@@ -21,6 +21,7 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 // OTHER DEALINGS IN THE SOFTWARE.
 
+#include <cassert>
 #include <cstdio>
 #include <filesystem>
 #include <fstream>
@@ -33,48 +34,89 @@
 
 namespace McBopomofo {
 
+class TempFile {
+ public:
+  TempFile(const char* initData, size_t length) {
+    std::filesystem::path p = std::filesystem::temp_directory_path() /
+                              "org.openvanilla.mcbopomofo.XXXXXX";
+    path_ = p.native();
+
+    int fd = mkstemp(path_.data());
+    assert(fd != -1);
+
+    ssize_t written = write(fd, initData, length);
+    assert(static_cast<size_t>(written) == length);
+    (void)written;
+
+    close(fd);
+  }
+
+  ~TempFile() {
+    std::error_code ec;
+    bool result = std::filesystem::remove(path_, ec);
+    assert(result);
+    (void)result;
+  }
+
+  const char* path() const { return path_.c_str(); }
+
+ protected:
+  std::string path_;
+};
+
+class TempDir {
+ public:
+  TempDir() {
+    std::filesystem::path p = std::filesystem::temp_directory_path() /
+                              "org.openvanilla.mcbopomofo.XXXXXX";
+    path_ = p.native();
+    char* result = mkdtemp(path_.data());
+    assert(result != nullptr);
+    fprintf(stderr, "TEMPDIR: %s\n", result);
+  }
+
+  ~TempDir() {
+    std::error_code ec;
+    bool result = std::filesystem::remove(path_, ec);
+    assert(result);
+    (void)result;
+  }
+
+  const char* path() const { return path_.c_str(); }
+
+ protected:
+  std::string path_;
+};
+
 TEST(MemoryMappedFileTest, UnopenedInstance) {
   MemoryMappedFile mf;
+  EXPECT_FALSE(mf.isOpen());
   EXPECT_EQ(mf.length(), 0);
   EXPECT_EQ(mf.data(), nullptr);
 }
 
 TEST(MemoryMappedFileTest, BasicFunctionalities) {
-  std::random_device rd;
-  std::default_random_engine re(rd());
-  std::uniform_int_distribution<unsigned int> suffix_gen(0);
-
-  std::string prefix("org.openvanilla.mcbopomofo.memorymappedfiletest-");
-  std::filesystem::path tmp_file_path;
-
-  constexpr int kMaxRetry = 10;
-  for (int i = 0; i < kMaxRetry; ++i) {
-    std::string filename = prefix + std::to_string(suffix_gen(re));
-    std::filesystem::path p = std::filesystem::temp_directory_path() / filename;
-    if (!std::filesystem::exists(p)) {
-      tmp_file_path = p;
-      break;
-    }
-  }
-  ASSERT_FALSE(tmp_file_path.empty()) << "Must form a temp filename";
-
   constexpr size_t kBufSize = 4 * 1024 * 1024;
   uint8_t* buf = new uint8_t[kBufSize];
+
+  std::random_device rd;
+  std::default_random_engine re(rd());
 
   std::uniform_int_distribution<unsigned int> randchar(0, 255);
   for (size_t i = 0; i < kBufSize; ++i) {
     buf[i] = static_cast<uint8_t>(randchar(re) & 0xff);
   }
 
-  std::ofstream out(tmp_file_path, std::ios::binary);
-  out.write(reinterpret_cast<char*>(buf), kBufSize);
-  out.close();
+  std::unique_ptr<TempFile> temp =
+      std::make_unique<TempFile>(reinterpret_cast<char*>(buf), kBufSize);
 
   MemoryMappedFile mf;
-  ASSERT_EQ(mf.length(), 0);
-  ASSERT_EQ(mf.data(), nullptr);
-  bool open_result = mf.open(tmp_file_path.c_str());
-  ASSERT_TRUE(open_result);
+  EXPECT_EQ(mf.length(), 0);
+  EXPECT_EQ(mf.data(), nullptr);
+  EXPECT_FALSE(mf.isOpen());
+  bool open_result = mf.open(temp->path());
+  EXPECT_TRUE(open_result);
+  EXPECT_TRUE(mf.isOpen());
 
   EXPECT_EQ(mf.length(), kBufSize);
   EXPECT_TRUE(mf.data() != nullptr);
@@ -83,25 +125,31 @@ TEST(MemoryMappedFileTest, BasicFunctionalities) {
   mf.close();
   EXPECT_EQ(mf.length(), 0);
   EXPECT_EQ(mf.data(), nullptr);
+  EXPECT_FALSE(mf.isOpen());
 
   // Should be a no-op.
   mf.close();
 
   MemoryMappedFile mf2;
-  open_result = mf2.open(tmp_file_path.c_str());
+  open_result = mf2.open(temp->path());
   EXPECT_TRUE(open_result);
   EXPECT_TRUE(mf2.data() != nullptr);
+  EXPECT_TRUE(mf2.isOpen());
 
   MemoryMappedFile mf3(std::move(mf2));
   EXPECT_TRUE(mf2.data() == nullptr);
   EXPECT_TRUE(mf3.data() != nullptr);
+  EXPECT_FALSE(mf2.isOpen());
+  EXPECT_TRUE(mf3.isOpen());
 
   MemoryMappedFile mf4 = std::move(mf3);
   EXPECT_TRUE(mf3.data() == nullptr);
   EXPECT_TRUE(mf4.data() != nullptr);
+  EXPECT_FALSE(mf3.isOpen());
+  EXPECT_TRUE(mf4.isOpen());
 
   // Flip a byte of the underlying file. The map should reflect that.
-  FILE* f = fopen(tmp_file_path.c_str(), "r+b");
+  FILE* f = fopen(temp->path(), "r+b");
   EXPECT_NE(f, nullptr);
   EXPECT_NE(fputc(~buf[0], f), EOF);
   EXPECT_EQ(fclose(f), 0);
@@ -112,19 +160,23 @@ TEST(MemoryMappedFileTest, BasicFunctionalities) {
 
   mf4.close();
   EXPECT_TRUE(mf4.data() == nullptr);
+  EXPECT_FALSE(mf4.isOpen());
 
-  std::filesystem::remove(tmp_file_path);
   delete[] buf;
+
+  std::string oldPath = temp->path();
+  temp = nullptr;
 
   // Opening a non-existence file.
   MemoryMappedFile mf5;
-  open_result = mf5.open(tmp_file_path.c_str());
+  open_result = mf5.open(oldPath.c_str());
   EXPECT_FALSE(open_result);
   EXPECT_EQ(mf5.length(), 0);
   EXPECT_EQ(mf5.data(), nullptr);
+  EXPECT_FALSE(mf5.isOpen());
 }
 
-TEST(MemoryMappedFileTest, EmptyFile) {
+TEST(MemoryMappedFileTest, OpenFailureOnEmptyFile) {
   std::filesystem::path tmp_file_path =
       std::filesystem::temp_directory_path() /
       "org.openvanilla.mcbopomofo.memorymappedfiletest-empty-file";
@@ -134,33 +186,30 @@ TEST(MemoryMappedFileTest, EmptyFile) {
 
   MemoryMappedFile mf;
   EXPECT_FALSE(mf.open(tmp_file_path.c_str()));
+  EXPECT_FALSE(mf.isOpen());
   EXPECT_EQ(mf.length(), 0);
   EXPECT_EQ(mf.data(), nullptr);
 
   mf.close();
   EXPECT_EQ(mf.length(), 0);
   EXPECT_EQ(mf.data(), nullptr);
+  EXPECT_FALSE(mf.isOpen());
 
   std::filesystem::remove(tmp_file_path);
 }
 
-TEST(MemoryMappedFileTest, MmapFailure) {
-  std::filesystem::path tmp_dir_path =
-      std::filesystem::temp_directory_path() /
-      "org.openvanilla.mcbopomofo.memorymappedfiletest-mmap-failure";
-  std::filesystem::remove_all(tmp_dir_path);
-  ASSERT_TRUE(std::filesystem::create_directory(tmp_dir_path));
-
+TEST(MemoryMappedFileTest, OpenFailureOnDirectory) {
+  TempDir dir;
   MemoryMappedFile mf;
-  EXPECT_FALSE(mf.open(tmp_dir_path.c_str()));
+  EXPECT_FALSE(mf.open(dir.path()));
+  EXPECT_FALSE(mf.isOpen());
   EXPECT_EQ(mf.length(), 0);
   EXPECT_EQ(mf.data(), nullptr);
 
   mf.close();
   EXPECT_EQ(mf.length(), 0);
   EXPECT_EQ(mf.data(), nullptr);
-
-  std::filesystem::remove_all(tmp_dir_path);
+  EXPECT_FALSE(mf.isOpen());
 }
 
 }  // namespace McBopomofo


### PR DESCRIPTION
Instead of relying on `data_` being non-nullptr, MemoryMappedFile now relies on `fd_ != -1` to reflect the fact that the file descriptor is the ground truth.

Also improves how the tests create temp filenames and directory names.

See also https://github.com/openvanilla/McBopomofo/pull/827