### PR TITLE
Update CI matrix to include newer Ubuntu and Fedora versions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,12 +9,11 @@ jobs:
       matrix:
         os:
           [
-            "ubuntu:25.10",
-            "ubuntu:25.04",
+            "ubuntu:26.04",
             "ubuntu:24.04",
             "ubuntu:22.04",
-            "debian:12",
             "debian:13",
+            "debian:12",
             "linuxmintd/mint22-amd64",
             "linuxmintd/mint21-amd64",
           ]
@@ -75,7 +74,15 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ["fedora:42", "fedora:41", "fedora:40", "fedora:39"]
+        os:
+          [
+            "fedora:44",
+            "fedora:43",
+            "fedora:42",
+            "fedora:41",
+            "fedora:40",
+            "fedora:39",
+          ]
     runs-on: ubuntu-latest
     container: ${{ matrix.os }}
     steps:


### PR DESCRIPTION
The PR update the matrix since newer versions are out.