### PR TITLE
Use ICU's text trasform to replace Iroha Kana input

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -50,6 +50,8 @@ set(MCBOPOMOFO_LIB_SOURCES
     TimestampedPath.cpp
     NumberInputHelper.h
     NumberInputHelper.cpp
+    IcuTransformInputHelper.h
+    IcuTransformInputHelper.cpp
 )
 
 # Setup some compiler option that is generally useful and compatible with Fcitx 5 (C++17)

--- a/src/IcuTransformInputHelper.cpp
+++ b/src/IcuTransformInputHelper.cpp
@@ -1,0 +1,79 @@
+// Copyright (c) 2022 and onwards The McBopomofo Authors.
+//
+// Permission is hereby granted, free of charge, to any person
+// obtaining a copy of this software and associated documentation
+// files (the "Software"), to deal in the Software without
+// restriction, including without limitation the rights to use,
+// copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following
+// conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+// OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+// HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+// OTHER DEALINGS IN THE SOFTWARE.
+
+#include "IcuTransformInputHelper.h"
+
+#include <unicode/translit.h>
+#include <unicode/unistr.h>
+
+#include <algorithm>
+#include <sstream>
+#include <string>
+#include <vector>
+// #include "Log.h"
+
+namespace McBopomofo {
+namespace IcuTransformInputHelper {
+
+static std::string transformString(const std::string& id,
+                                   const std::string& input) {
+  UErrorCode status = U_ZERO_ERROR;
+
+  std::unique_ptr<icu::Transliterator, void (*)(icu::Transliterator*)> tr(
+      icu::Transliterator::createInstance(icu::UnicodeString::fromUTF8(id),
+                                          UTRANS_FORWARD, status),
+      [](icu::Transliterator* t) { delete t; });
+
+  if (U_FAILURE(status)) {
+    return "";
+  }
+  icu::UnicodeString uInput = icu::UnicodeString::fromUTF8(input);
+  tr->transliterate(uInput);
+  std::string output;
+  uInput.toUTF8String(output);
+  return output;
+}
+
+std::vector<std::string> FillCandidatesWithString(std::string string) {
+    std::vector<std::string> candidates;
+    std::vector<std::string> transforms = {
+        "Latin-Hiragana",    // Hiragana script
+        "Latin-Katakana",    // Katakana script
+        "Latin-Hangul",      // Hangul script
+        "Latin-Thai",        // Thai script
+        "Latin-Greek",       // Greek script
+        "Latin-Cyrillic",    // Cyrillic script
+        "Latin-Arabic",      // Arabic script
+        "Latin-Hebrew",      // Hebrew script
+        "Latin-Devanagari",  // Devanagari script
+    };
+    for (const auto& transform : transforms) {
+        std::string transformed = transformString(transform, string);
+        if (!transformed.empty()) {
+            candidates.push_back(transformed);  
+        }
+    }
+    return candidates;
+}
+}  // namespace IcuTransformInputHelper
+}  // namespace McBopomofo

--- a/src/IcuTransformInputHelper.cpp
+++ b/src/IcuTransformInputHelper.cpp
@@ -29,24 +29,28 @@
 #include <algorithm>
 #include <sstream>
 #include <string>
+#include <unordered_map>
 #include <vector>
-// #include "Log.h"
 
 namespace McBopomofo {
 namespace IcuTransformInputHelper {
 
+static icu::Transliterator* getTransliterator(const std::string& id) {
+  static std::unordered_map<std::string, std::unique_ptr<icu::Transliterator>>
+      cache;
+  auto it = cache.find(id);
+  if (it == cache.end()) {
+    UErrorCode status = U_ZERO_ERROR;
+    auto* tr = icu::Transliterator::createInstance(
+        icu::UnicodeString::fromUTF8(id), UTRANS_FORWARD, status);
+    it = cache.emplace(id, std::unique_ptr<icu::Transliterator>(tr)).first;
+  }
+  return it->second.get();
+}
+
 static std::string transformString(const std::string& id,
                                    const std::string& input) {
-  UErrorCode status = U_ZERO_ERROR;
-
-  std::unique_ptr<icu::Transliterator, void (*)(icu::Transliterator*)> tr(
-      icu::Transliterator::createInstance(icu::UnicodeString::fromUTF8(id),
-                                          UTRANS_FORWARD, status),
-      [](icu::Transliterator* t) { delete t; });
-
-  if (U_FAILURE(status)) {
-    return "";
-  }
+  auto* tr = getTransliterator(id);
   icu::UnicodeString uInput = icu::UnicodeString::fromUTF8(input);
   tr->transliterate(uInput);
   std::string output;
@@ -54,26 +58,26 @@ static std::string transformString(const std::string& id,
   return output;
 }
 
-std::vector<std::string> FillCandidatesWithString(std::string string) {
-    std::vector<std::string> candidates;
-    std::vector<std::string> transforms = {
-        "Latin-Hiragana",    // Hiragana script
-        "Latin-Katakana",    // Katakana script
-        "Latin-Hangul",      // Hangul script
-        "Latin-Thai",        // Thai script
-        "Latin-Greek",       // Greek script
-        "Latin-Cyrillic",    // Cyrillic script
-        "Latin-Arabic",      // Arabic script
-        "Latin-Hebrew",      // Hebrew script
-        "Latin-Devanagari",  // Devanagari script
-    };
-    for (const auto& transform : transforms) {
-        std::string transformed = transformString(transform, string);
-        if (!transformed.empty()) {
-            candidates.push_back(transformed);  
-        }
+std::vector<std::string> FillCandidatesWithString(const std::string& string) {
+  std::vector<std::string> candidates;
+  static const std::vector<std::string> transforms = {
+      "Latin-Hiragana",    // Hiragana script
+      "Latin-Katakana",    // Katakana script
+      "Latin-Hangul",      // Hangul script
+      "Latin-Thai",        // Thai script
+      "Latin-Greek",       // Greek script
+      "Latin-Cyrillic",    // Cyrillic script
+      "Latin-Arabic",      // Arabic script
+      "Latin-Hebrew",      // Hebrew script
+      "Latin-Devanagari",  // Devanagari script
+  };
+  for (const auto& transform : transforms) {
+    std::string transformed = transformString(transform, string);
+    if (!transformed.empty()) {
+      candidates.emplace_back(transformed);
     }
-    return candidates;
+  }
+  return candidates;
 }
 }  // namespace IcuTransformInputHelper
 }  // namespace McBopomofo

--- a/src/IcuTransformInputHelper.h
+++ b/src/IcuTransformInputHelper.h
@@ -21,8 +21,8 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 // OTHER DEALINGS IN THE SOFTWARE.
 
-#ifndef MCBOPOMOFO_SRC_NUMBERINPUTHELPER_H_
-#define MCBOPOMOFO_SRC_NUMBERINPUTHELPER_H_
+#ifndef MCBOPOMOFO_SRC_ICUTRANSFORMINPUTHELPER_H_
+#define MCBOPOMOFO_SRC_ICUTRANSFORMINPUTHELPER_H_
 
 #include <memory>
 #include <string>
@@ -31,13 +31,12 @@
 #include "Engine/gramambular2/language_model.h"
 
 namespace McBopomofo {
-namespace NumberInputHelper {
+namespace IcuTransformInputHelper {
 
-std::vector<std::string> FillCandidatesWithNumber(
-    std::string number,
-    std::shared_ptr<Formosa::Gramambular2::LanguageModel> languageModel);
+std::vector<std::string> FillCandidatesWithString(
+    std::string string);
 
-}  // namespace NumberInputHelper
+}  // namespace IcuTransformInputHelper
 }  // namespace McBopomofo
 
-#endif /* MCBOPOMOFO_SRC_NUMBERINPUTHELPER_H_ */
+#endif /* MCBOPOMOFO_SRC_ICUTRANSFORMINPUTHELPER_H_ */

--- a/src/IcuTransformInputHelper.h
+++ b/src/IcuTransformInputHelper.h
@@ -33,8 +33,7 @@
 namespace McBopomofo {
 namespace IcuTransformInputHelper {
 
-std::vector<std::string> FillCandidatesWithString(
-    std::string string);
+std::vector<std::string> FillCandidatesWithString(const std::string& string);
 
 }  // namespace IcuTransformInputHelper
 }  // namespace McBopomofo

--- a/src/InputState.h
+++ b/src/InputState.h
@@ -303,24 +303,6 @@ struct Big5 : InputState {
   std::string hexCode;
 };
 
-struct Iroha : InputState {
-  explicit Iroha(std::string code = "") : code(std::move(code)) {}
-  Iroha(Iroha const& code) : code(code.code) {}
-  std::string composingBuffer() const { return "[伊呂波] " + code; }
-  std::string code;
-};
-
-struct IrohaCandidate : InputState {
-  explicit IrohaCandidate(std::string code = "",
-                          std::vector<std::string> candidates = {})
-      : code(std::move(code)), candidates(std::move(candidates)) {}
-  IrohaCandidate(IrohaCandidate const& other)
-      : code(other.code), candidates(other.candidates) {}
-  std::string composingBuffer() const { return "[伊呂波] " + code; }
-  std::string code;
-  std::vector<std::string> candidates;
-};
-
 struct SelectingDateMacro : InputState {
   explicit SelectingDateMacro(
       const std::function<std::string(std::string)>& converter);
@@ -350,8 +332,6 @@ struct SelectingFeature : InputState {
     features.emplace_back("日韓多語拼音轉換", []() {
       return std::make_unique<IcuTransformInput>("", std::vector<std::string>());
     });
-    // features.emplace_back("伊呂波假名輸入",
-    //                       []() { return std::make_unique<Iroha>(""); });
   }
 
   std::unique_ptr<InputState> nextState(size_t index) {

--- a/src/InputState.h
+++ b/src/InputState.h
@@ -281,6 +281,21 @@ struct NumberInput : NotEmpty {
   std::vector<std::string> candidates;
 };
 
+struct IcuTransformInput : NotEmpty {
+  explicit IcuTransformInput(const std::string& string,
+                             std::vector<std::string> cs)
+      : NotEmpty("[文字轉換] " + string, ("[文字轉換] " + string).length(), ""),
+        string(string),
+        candidates(std::move(cs)) {}
+  IcuTransformInput(const IcuTransformInput& other)
+      : NotEmpty("[文字轉換] " + other.string, ("[文字轉換] " + other.string).length(), ""),
+        string(other.string),
+        candidates(other.candidates) {}
+
+  std::string string;
+  std::vector<std::string> candidates;
+};
+
 struct Big5 : InputState {
   explicit Big5(std::string hexCode = "") : hexCode(std::move(hexCode)) {}
   Big5(Big5 const& code) : hexCode(code.hexCode) {}
@@ -332,8 +347,11 @@ struct SelectingFeature : InputState {
     features.emplace_back("數字輸入", []() {
       return std::make_unique<NumberInput>("", std::vector<std::string>());
     });
-    features.emplace_back("伊呂波假名輸入",
-                          []() { return std::make_unique<Iroha>(""); });
+    features.emplace_back("日韓多語拼音轉換", []() {
+      return std::make_unique<IcuTransformInput>("", std::vector<std::string>());
+    });
+    // features.emplace_back("伊呂波假名輸入",
+    //                       []() { return std::make_unique<Iroha>(""); });
   }
 
   std::unique_ptr<InputState> nextState(size_t index) {

--- a/src/KeyHandler.cpp
+++ b/src/KeyHandler.cpp
@@ -1270,7 +1270,6 @@ bool KeyHandler::handleIcuTransformInput(Key key,
     std::string newString = state->string + key.ascii;
     auto candidates =
         IcuTransformInputHelper::FillCandidatesWithString(newString);
-    // FCITX_MCBOPOMOFO_INFO() << "newString: " << newString << ", candidates: " << candidates.size();
     auto newState =
         std::make_unique<InputStates::IcuTransformInput>(newString, candidates);
     stateCallback(std::move(newState));
@@ -1278,10 +1277,6 @@ bool KeyHandler::handleIcuTransformInput(Key key,
   } else if (!state->candidates.empty()) {
     // If the candidate panel is visible, let it handle the key.
     return false;
-  } else if (std::isprint(key.ascii)) {
-    // Reject all other printable, non-numeric keys.
-    errorCallback();
-    return true;
   }
 
   // If the buffer is empty, all other keys (e.g. cursor keys) exit the state.

--- a/src/KeyHandler.cpp
+++ b/src/KeyHandler.cpp
@@ -33,6 +33,8 @@
 
 #include "Big5Utils/Big5Utils.h"
 #include "BopomofoBraille/Converter.h"
+#include "IcuTransformInputHelper.h"
+#include "Log.h"
 #include "NumberInputHelper.h"
 #include "UTF8Helper.h"
 
@@ -1233,6 +1235,66 @@ bool KeyHandler::handleNumberInput(Key key,
   stateCallback(std::make_unique<InputStates::EmptyIgnoringPrevious>());
   return true;
 }
+
+bool KeyHandler::handleIcuTransformInput(Key key,
+                                   McBopomofo::InputStates::IcuTransformInput* state,
+                                   StateCallback stateCallback,
+                                   KeyHandler::ErrorCallback errorCallback) {
+  if (key.ascii == Key::ESC) {
+    stateCallback(std::make_unique<InputStates::EmptyIgnoringPrevious>());
+    return true;
+  }
+  if (key.isDeleteKeys()) {
+    std::string string = state->string;
+    if (!string.empty()) {
+      string = string.substr(0, string.length() - 1);
+      auto candidates =
+          IcuTransformInputHelper::FillCandidatesWithString(string);
+      auto newState =
+          std::make_unique<InputStates::IcuTransformInput>(string, candidates);
+      stateCallback(std::move(newState));
+      return true;
+    } else {
+      errorCallback();
+      return true;
+    }
+  }
+
+  char selectionKeys[10] = {'!', '@', '#', '$', '%', '^', '&', '*', '(', ')'};
+  for (size_t i = 0; i < state->candidates.size() && i < 10; ++i) {
+    if (key.ascii == selectionKeys[i]) {
+      return false;  
+    }
+  }
+
+  if (isprint(key.ascii)) {
+    if (state->string.length() > 100) {
+      errorCallback();
+      return true;
+    }
+    std::string newString = state->string + key.ascii;
+    auto candidates =
+        IcuTransformInputHelper::FillCandidatesWithString(newString);
+    // FCITX_MCBOPOMOFO_INFO() << "newString: " << newString << ", candidates: " << candidates.size();
+    auto newState =
+        std::make_unique<InputStates::IcuTransformInput>(newString, candidates);
+    stateCallback(std::move(newState));
+    return true;
+  } else if (!state->candidates.empty()) {
+    // If the candidate panel is visible, let it handle the key.
+    return false;
+  } else if (std::isprint(key.ascii)) {
+    // Reject all other printable, non-numeric keys.
+    errorCallback();
+    return true;
+  }
+
+  // If the buffer is empty, all other keys (e.g. cursor keys) exit the state.
+  stateCallback(std::make_unique<InputStates::EmptyIgnoringPrevious>());
+  return true;
+}
+
+
 
 bool KeyHandler::handleBig5(Key key, McBopomofo::InputStates::Big5* state,
                             StateCallback stateCallback,

--- a/src/KeyHandler.cpp
+++ b/src/KeyHandler.cpp
@@ -139,11 +139,6 @@ bool KeyHandler::handle(Key key, McBopomofo::InputState* state,
     return handleBig5(key, big5, stateCallback, errorCallback);
   }
 
-  auto* iroha = dynamic_cast<InputStates::Iroha*>(state);
-  if (iroha != nullptr) {
-    return handleIroha(key, iroha, stateCallback, errorCallback);
-  }
-
   // From Key's definition, if shiftPressed is true, it can't be a simple key
   // that can be represented by ASCII.
   char simpleAscii =
@@ -1335,78 +1330,6 @@ bool KeyHandler::handleBig5(Key key, McBopomofo::InputStates::Big5* state,
 
     auto newState = std::make_unique<InputStates::Big5>(newHexCode);
     stateCallback(std::move(newState));
-  } else {
-    errorCallback();
-  }
-  return true;
-}
-
-bool KeyHandler::handleIroha(Key key, McBopomofo::InputStates::Iroha* state,
-                             StateCallback stateCallback,
-                             KeyHandler::ErrorCallback errorCallback) {
-  if (key.ascii == Key::ESC) {
-    stateCallback(std::make_unique<InputStates::EmptyIgnoringPrevious>());
-    return true;
-  }
-
-  if (key.ascii == Key::RETURN || key.ascii == Key::SPACE) {
-    std::string code = state->code;
-    if (code.empty()) {
-      stateCallback(std::make_unique<InputStates::EmptyIgnoringPrevious>());
-      return true;
-    }
-
-    std::string unigram = "_kana_" + code;
-    if (lm_->hasUnigrams(unigram)) {
-      auto unigrams = lm_->getUnigrams(unigram);
-      if (unigrams.size() == 1) {
-        std::string value = unigrams[0].value();
-        auto seq = std::make_unique<InputStates::StateSequence>();
-        seq->push_back(std::make_unique<InputStates::Committing>(value));
-        seq->push_back(std::make_unique<InputStates::Iroha>(""));
-        stateCallback(std::move(seq));
-      } else {
-        std::vector<std::string> candidates;
-        for (const auto& unigram : unigrams) {
-          candidates.emplace_back(unigram.value());
-        }
-        auto newState =
-            std::make_unique<InputStates::IrohaCandidate>(code, candidates);
-        stateCallback(std::move(newState));
-      }
-      return true;
-    } else {
-      errorCallback();
-      auto newState = std::make_unique<InputStates::Iroha>("");
-      stateCallback(std::move(newState));
-      return true;
-    }
-  }
-
-  if (key.isDeleteKeys()) {
-    std::string code = state->code;
-    if (!code.empty()) {
-      code = code.substr(0, code.length() - 1);
-      auto newState = std::make_unique<InputStates::Iroha>(code);
-      stateCallback(std::move(newState));
-    } else {
-      stateCallback(std::make_unique<InputStates::EmptyIgnoringPrevious>());
-    }
-    return true;
-  }
-
-  if ((key.ascii >= 'a' && key.ascii <= 'z') ||
-      (key.ascii >= 'A' && key.ascii <= 'Z')) {
-    std::string code = state->code;
-    if (code.length() <= 4)  // Iroha code is 4 hex digits.
-    {
-      std::string code =
-          state->code + static_cast<char>(std::tolower(key.ascii));
-      auto newState = std::make_unique<InputStates::Iroha>(code);
-      stateCallback(std::move(newState));
-    } else {
-      errorCallback();
-    }
   } else {
     errorCallback();
   }

--- a/src/KeyHandler.h
+++ b/src/KeyHandler.h
@@ -241,9 +241,6 @@ class KeyHandler {
   bool handleBig5(Key key, McBopomofo::InputStates::Big5* state,
                   StateCallback stateCallback,
                   KeyHandler::ErrorCallback errorCallback);
-  bool handleIroha(Key key, McBopomofo::InputStates::Iroha* state,
-                   StateCallback stateCallback,
-                   KeyHandler::ErrorCallback errorCallback);
 
   bool handleTabKey(bool isShiftPressed, McBopomofo::InputState* state,
                     const StateCallback& stateCallback,

--- a/src/KeyHandler.h
+++ b/src/KeyHandler.h
@@ -83,6 +83,11 @@ class KeyHandler {
   bool handleNumberInput(Key key, InputStates::NumberInput* state,
                          StateCallback stateCallback,
                          KeyHandler::ErrorCallback errorCallback);
+
+  bool handleIcuTransformInput(
+      Key key, McBopomofo::InputStates::IcuTransformInput* state,
+      StateCallback stateCallback, KeyHandler::ErrorCallback errorCallback);
+
   // Candidate selected. Can assume the context is in a candidate state.
   void candidateSelected(
       const InputStates::ChoosingCandidate::Candidate& candidate,

--- a/src/McBopomofo.cpp
+++ b/src/McBopomofo.cpp
@@ -337,24 +337,6 @@ class McBopomofoDirectInsertWord : public fcitx::CandidateWord {
   KeyHandler::StateCallback callback;
 };
 
-class McBopomofoIrohaWord : public fcitx::CandidateWord {
- public:
-  explicit McBopomofoIrohaWord(fcitx::Text displayText, std::string text,
-                               KeyHandler::StateCallback callback)
-      : fcitx::CandidateWord(std::move(displayText)),
-        text(std::move(text)),
-        callback(std::move(callback)) {}
-  void select(fcitx::InputContext* /*unused*/) const override {
-    auto seq = std::make_unique<InputStates::StateSequence>();
-    seq->push_back(std::make_unique<InputStates::Committing>(text));
-    seq->push_back(std::make_unique<InputStates::Iroha>(""));
-    callback(std::move(seq));
-  }
-
-  std::string text;
-  KeyHandler::StateCallback callback;
-};
-
 class McBopomofoTextOnlyCandidateWord : public fcitx::CandidateWord {
  public:
   explicit McBopomofoTextOnlyCandidateWord(fcitx::Text displayText)
@@ -852,8 +834,7 @@ void McBopomofoEngine::keyEvent(const fcitx::InputMethodEntry& /*unused*/,
       dynamic_cast<InputStates::SelectingDateMacro*>(state_.get()) != nullptr ||
       dynamic_cast<InputStates::CustomMenu*>(state_.get()) != nullptr ||
       dynamic_cast<InputStates::NumberInput*>(state_.get()) != nullptr ||
-      dynamic_cast<InputStates::IcuTransformInput*>(state_.get()) != nullptr ||
-      dynamic_cast<InputStates::IrohaCandidate*>(state_.get()) != nullptr) {
+      dynamic_cast<InputStates::IcuTransformInput*>(state_.get()) != nullptr) {
     // Absorb all keys when the candidate panel is on.
     keyEvent.filterAndAccept();
 
@@ -889,7 +870,6 @@ void McBopomofoEngine::keyEvent(const fcitx::InputMethodEntry& /*unused*/,
         dynamic_cast<InputStates::SelectingFeature*>(state_.get()) != nullptr ||
         dynamic_cast<InputStates::SelectingDateMacro*>(state_.get()) !=
             nullptr ||
-        dynamic_cast<InputStates::IrohaCandidate*>(state_.get()) != nullptr ||
         dynamic_cast<InputStates::CustomMenu*>(state_.get()) != nullptr) {
       context->updateUserInterface(fcitx::UserInterfaceComponent::InputPanel);
       context->updatePreedit();
@@ -1571,12 +1551,7 @@ void McBopomofoEngine::enterNewState(fcitx::InputContext* context,
                  dynamic_cast<InputStates::SelectingDateMacro*>(currentPtr)) {
     handleCandidatesState(context, prevPtr, selectingDateMacro);
   } else if (auto* big5 = dynamic_cast<InputStates::Big5*>(currentPtr)) {
-    handleStateWithCustomInput(context, big5->composingBuffer());
-  } else if (auto* iroha = dynamic_cast<InputStates::Iroha*>(currentPtr)) {
-    handleStateWithCustomInput(context, iroha->composingBuffer());
-  } else if (auto* irohaCandidates =
-                 dynamic_cast<InputStates::IrohaCandidate*>(currentPtr)) {
-    handleCandidatesState(context, prevPtr, irohaCandidates);
+    handleStateWithCustomInput(context, big5->composingBuffer());  
   } else if (auto* customMenu =
                  dynamic_cast<InputStates::CustomMenu*>(currentPtr)) {
     handleCandidatesState(context, prevPtr, customMenu);
@@ -1650,8 +1625,6 @@ void McBopomofoEngine::handleCandidatesState(fcitx::InputContext* context,
       dynamic_cast<InputStates::NumberInput*>(state_.get());
   InputStates::IcuTransformInput* icuTransformInput =
       dynamic_cast<InputStates::IcuTransformInput*>(state_.get());
-  InputStates::IrohaCandidate* irohaCandidates =
-      dynamic_cast<InputStates::IrohaCandidate*>(state_.get());
 
   bool useShiftKey = numberInput != nullptr || icuTransformInput != nullptr ||
                      associatedPhrasesPlain != nullptr;
@@ -1838,13 +1811,6 @@ void McBopomofoEngine::handleCandidatesState(fcitx::InputContext* context,
       std::unique_ptr<fcitx::CandidateWord> candidate =
           std::make_unique<McBopomofoDirectInsertWord>(fcitx::Text(displayText),
                                                        displayText, callback);
-      candidateList->append(std::move(candidate));
-    }
-  } else if (irohaCandidates != nullptr) {
-    for (const auto& displayText : irohaCandidates->candidates) {
-      std::unique_ptr<fcitx::CandidateWord> candidate =
-          std::make_unique<McBopomofoIrohaWord>(fcitx::Text(displayText),
-                                                displayText, callback);
       candidateList->append(std::move(candidate));
     }
   } else if (customMenu != nullptr) {

--- a/src/McBopomofo.cpp
+++ b/src/McBopomofo.cpp
@@ -824,6 +824,23 @@ void McBopomofoEngine::keyEvent(const fcitx::InputMethodEntry& /*unused*/,
     }
   }
 
+  InputStates::IcuTransformInput* maybeIcuTransformInput =
+      dynamic_cast<InputStates::IcuTransformInput*>(state_.get());
+  if (maybeIcuTransformInput != nullptr) {
+    bool handled = keyHandler_->handleIcuTransformInput(
+        MapFcitxKey(key, origKey), maybeIcuTransformInput,
+        [this, context](std::unique_ptr<InputState> next) {
+          enterNewState(context, std::move(next));
+        },
+        []() {
+          // TODO(unassigned): beep?
+        });
+    if (handled) {
+      keyEvent.filterAndAccept();
+      return;
+    }
+  }
+
   if (dynamic_cast<InputStates::ChoosingCandidate*>(state_.get()) != nullptr ||
       dynamic_cast<InputStates::SelectingDictionary*>(state_.get()) !=
           nullptr ||
@@ -835,6 +852,7 @@ void McBopomofoEngine::keyEvent(const fcitx::InputMethodEntry& /*unused*/,
       dynamic_cast<InputStates::SelectingDateMacro*>(state_.get()) != nullptr ||
       dynamic_cast<InputStates::CustomMenu*>(state_.get()) != nullptr ||
       dynamic_cast<InputStates::NumberInput*>(state_.get()) != nullptr ||
+      dynamic_cast<InputStates::IcuTransformInput*>(state_.get()) != nullptr ||
       dynamic_cast<InputStates::IrohaCandidate*>(state_.get()) != nullptr) {
     // Absorb all keys when the candidate panel is on.
     keyEvent.filterAndAccept();
@@ -907,6 +925,8 @@ bool McBopomofoEngine::handleCandidateKeyEvent(
       dynamic_cast<InputStates::AssociatedPhrasesPlain*>(state_.get());
   InputStates::NumberInput* numberInput =
       dynamic_cast<InputStates::NumberInput*>(state_.get());
+  InputStates::IcuTransformInput* icuTransformInput =
+      dynamic_cast<InputStates::IcuTransformInput*>(state_.get());
   InputStates::ChoosingPunctuationList* choosingPunctuationList =
       dynamic_cast<InputStates::ChoosingPunctuationList*>(state_.get());
 
@@ -937,7 +957,7 @@ bool McBopomofoEngine::handleCandidateKeyEvent(
   bool shouldUseShiftKey = associatedPhrasesPlain != nullptr;
 
   // Plain Bopomofo, Associated Phrases, and Number Input.
-  if (shouldUseShiftKey || numberInput != nullptr) {
+  if (shouldUseShiftKey || numberInput != nullptr || icuTransformInput != nullptr) {
     int code = origKey.code();
     // Shift-[1-9] keys can only be checked via raw key codes. The Key objects
     // in the selectionKeys_ do not carry such information.
@@ -1541,8 +1561,11 @@ void McBopomofoEngine::enterNewState(fcitx::InputContext* context,
   } else if (auto* numberInput =
                  dynamic_cast<InputStates::NumberInput*>(currentPtr)) {
     handleCandidatesState(context, prevPtr, numberInput);
+  } else if (auto* icuTransformInput =
+                 dynamic_cast<InputStates::IcuTransformInput*>(currentPtr)) {
+    handleCandidatesState(context, prevPtr, icuTransformInput);
   } else if (auto* selectingFeature =
-                 dynamic_cast<InputStates::SelectingFeature*>(currentPtr)) {
+               dynamic_cast<InputStates::SelectingFeature*>(currentPtr)) {
     handleCandidatesState(context, prevPtr, selectingFeature);
   } else if (auto* selectingDateMacro =
                  dynamic_cast<InputStates::SelectingDateMacro*>(currentPtr)) {
@@ -1625,11 +1648,13 @@ void McBopomofoEngine::handleCandidatesState(fcitx::InputContext* context,
       dynamic_cast<InputStates::AssociatedPhrasesPlain*>(state_.get());
   InputStates::NumberInput* numberInput =
       dynamic_cast<InputStates::NumberInput*>(state_.get());
+  InputStates::IcuTransformInput* icuTransformInput =
+      dynamic_cast<InputStates::IcuTransformInput*>(state_.get());
   InputStates::IrohaCandidate* irohaCandidates =
       dynamic_cast<InputStates::IrohaCandidate*>(state_.get());
 
-  bool useShiftKey =
-      numberInput != nullptr || associatedPhrasesPlain != nullptr;
+  bool useShiftKey = numberInput != nullptr || icuTransformInput != nullptr ||
+                     associatedPhrasesPlain != nullptr;
 
   if ((associatedPhrases != nullptr && associatedPhrases->autoTriggered)) {
     selectionKeys_ = fcitx::Key::keyListFromString("Shift+Return");
@@ -1808,6 +1833,13 @@ void McBopomofoEngine::handleCandidatesState(fcitx::InputContext* context,
                                                        displayText, callback);
       candidateList->append(std::move(candidate));
     }
+  } else if (icuTransformInput != nullptr) {
+    for (const auto& displayText : icuTransformInput->candidates) {
+      std::unique_ptr<fcitx::CandidateWord> candidate =
+          std::make_unique<McBopomofoDirectInsertWord>(fcitx::Text(displayText),
+                                                       displayText, callback);
+      candidateList->append(std::move(candidate));
+    }
   } else if (irohaCandidates != nullptr) {
     for (const auto& displayText : irohaCandidates->candidates) {
       std::unique_ptr<fcitx::CandidateWord> candidate =
@@ -1872,6 +1904,7 @@ fcitx::CandidateLayoutHint McBopomofoEngine::getCandidateLayoutHint() const {
   fcitx::CandidateLayoutHint layoutHint = fcitx::CandidateLayoutHint::NotSet;
 
   if (dynamic_cast<InputStates::NumberInput*>(state_.get()) != nullptr ||
+      dynamic_cast<InputStates::IcuTransformInput*>(state_.get()) != nullptr ||
       dynamic_cast<InputStates::SelectingDictionary*>(state_.get()) !=
           nullptr ||
       dynamic_cast<InputStates::ShowingCharInfo*>(state_.get()) != nullptr ||

--- a/src/NumberInputHelper.cpp
+++ b/src/NumberInputHelper.cpp
@@ -1,3 +1,26 @@
+// Copyright (c) 2022 and onwards The McBopomofo Authors.
+//
+// Permission is hereby granted, free of charge, to any person
+// obtaining a copy of this software and associated documentation
+// files (the "Software"), to deal in the Software without
+// restriction, including without limitation the rights to use,
+// copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following
+// conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+// OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+// HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+// OTHER DEALINGS IN THE SOFTWARE.
+
 #include "NumberInputHelper.h"
 
 #include <algorithm>


### PR DESCRIPTION
The PR adds a new ICU trasform state to let users to input ASCII string and convert to Japanese kana characters, Hangui and so on.

The PR also removes the existing Iroha input mode. The phrase entries for Iroha mode are still there since McBopomofo for other platforms are still using them.

See also https://github.com/openvanilla/McBopomofo/pull/879