### PR TITLE
Include g++ in build dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@
 
 ```bash
 sudo apt install \
-    pkg-config fcitx5 libfcitx5core-dev libfcitx5config-dev libfcitx5utils-dev fcitx5-modules-dev \
+    g++ pkg-config fcitx5 libfcitx5core-dev libfcitx5config-dev libfcitx5utils-dev fcitx5-modules-dev \
     cmake extra-cmake-modules gettext libfmt-dev libicu-dev libjson-c-dev
 ```
 


### PR DESCRIPTION
This commit fixes #267. Tested on `docker.io/library/ubuntu:26.04` and `docker.io/library/ubuntu:24.04` container images.